### PR TITLE
Speed up CI-test pipeline

### DIFF
--- a/interfaces/HO-Portal/azure-pipelines.yml
+++ b/interfaces/HO-Portal/azure-pipelines.yml
@@ -23,7 +23,7 @@ steps:
   inputs:
     versionSpec: $(node_version)
 
-- script: npm install
+- script: npm ci
   displayName: Install
   workingDirectory: interfaces/HO-Portal/
 
@@ -33,10 +33,6 @@ steps:
 
 - script: npm run test:ci
   displayName: Tests
-  workingDirectory: interfaces/HO-Portal/
-
-- script: npm run build -- --prod
-  displayName: Build
   workingDirectory: interfaces/HO-Portal/
 
 - task: PublishCodeCoverageResults@1

--- a/services/programs-service/azure-pipelines.yml
+++ b/services/programs-service/azure-pipelines.yml
@@ -23,7 +23,7 @@ steps:
   inputs:
     versionSpec: $(node_version)
 
-- script: npm install
+- script: npm ci
   displayName: Install
   workingDirectory: services/programs-service/
 


### PR DESCRIPTION
By using `npm ci` and removing the `build` step (for now)
Building+deploying will require a new pipeline