### PR TITLE
removed cordova global-121-indy plugin

### DIFF
--- a/interfaces/PA-App/package-lock.json
+++ b/interfaces/PA-App/package-lock.json
@@ -3929,10 +3929,6 @@
       "integrity": "sha512-Jb3V72btxf3XHpkPQsGdyc8N6tVBYn1vsxSFj43fIz9vonJDUThYPCJJHqk6PX6N4dJw6I4FjxkpfCR4LDYMlw==",
       "dev": true
     },
-    "cordova-plugin-global-121-indy": {
-      "version": "github:global-121/121-indy-wrapper-ios#86b2afb4c56b02db449c8a716c6a275750b571d5",
-      "from": "github:global-121/121-indy-wrapper-ios#enable-121-pool"
-    },
     "cordova-plugin-ionic-keyboard": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cordova-plugin-ionic-keyboard/-/cordova-plugin-ionic-keyboard-2.2.0.tgz",

--- a/interfaces/PA-App/package.json
+++ b/interfaces/PA-App/package.json
@@ -4,10 +4,6 @@
   "author": "121.global",
   "homepage": "https://www.121.global/",
   "scripts": {
-    "dev:plugin-add-local": "npm run cordova -- plugin add --link ../../../121-indy-wrapper-ios",
-    "dev:plugin-add": "npm run ionic -- cordova plugin add github:global-121/121-indy-wrapper-ios#enable-121-pool",
-    "dev:plugin-remove": "npm run ionic -- cordova plugin remove cordova-plugin-global-121-indy",
-    "dev:plugin-refresh": "npm run dev:plugin-remove && npm run dev:plugin-add && npm run cordova plugins save",
     "dev:on-device": "npm run ionic -- cordova run android --device --consolelogs --livereload",
     "dev:local-android": "npm run ionic -- cordova run android --emulator --consolelogs --livereload",
     "dev:local-ios": "npm run ionic -- cordova run ios --consolelogs --livereload",
@@ -47,7 +43,6 @@
     "cordova-browser": "^6.0.0",
     "cordova-ios": "^5.0.1",
     "cordova-plugin-add-swift-support": "^2.0.2",
-    "cordova-plugin-global-121-indy": "github:global-121/121-indy-wrapper-ios#enable-121-pool",
     "core-js": "2.6.8",
     "rxjs": "~6.5.1",
     "tslib": "^1.10.0",
@@ -97,8 +92,7 @@
       "cordova-plugin-splashscreen": {},
       "cordova-plugin-ionic-webview": {},
       "cordova-plugin-ionic-keyboard": {},
-      "cordova-plugin-device": {},
-      "cordova-plugin-global-121-indy": {}
+      "cordova-plugin-device": {}
     },
     "platforms": [
       "browser",


### PR DESCRIPTION
@elwinschmitz I removed this - now unused (right?) - plugin, because it gave trouble in the 'npm ci' step in the webhook on the server. If I shouldn't have taken this out, or should have done so differently, we can always change it back.