### PR TITLE
Fix issues with HO login

### DIFF
--- a/interfaces/HO-Portal/src/app/auth/auth.guard.ts
+++ b/interfaces/HO-Portal/src/app/auth/auth.guard.ts
@@ -16,23 +16,25 @@ export class AuthGuard implements CanActivate {
 
   canActivate(
     next: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
+    state: RouterStateSnapshot
+  ): Observable<boolean> | Promise<boolean> | boolean {
     const url: string = state.url;
-    const currentUserRole = this.authService.getUserRole();
-    console.log('currentUserRole: ', currentUserRole);
 
-    return this.checkLogin(url, currentUserRole, next);
+    return this.checkLogin(url, next);
   }
 
-  checkLogin(url: string, currentUserRole: string, route: ActivatedRouteSnapshot): boolean {
-    if (this.authService.isLoggedIn()) {
-      if (!route.data.roles) {
-        return true;
-      }
-      if (route.data.roles.includes(currentUserRole)) {
-        return true;
-      }
+  checkLogin(url: string, route: ActivatedRouteSnapshot): boolean {
+    // If no specific role is required, only require a valid login
+    if (!route.data.roles && this.authService.isLoggedIn()) {
+      return true;
     }
+
+    // UserRole will only be a valid value, when login is valid
+    const currentUserRole = this.authService.getUserRole();
+    if (route.data.roles && route.data.roles.includes(currentUserRole)) {
+      return true;
+    }
+
     // Store the attempted URL for redirecting
     this.authService.redirectUrl = url;
     this.router.navigate(['/login']);

--- a/interfaces/HO-Portal/src/app/auth/auth.service.ts
+++ b/interfaces/HO-Portal/src/app/auth/auth.service.ts
@@ -22,22 +22,53 @@ export class AuthService {
     public programsService: ProgramsServiceApiService,
     private jwtService: JwtService,
     private router: Router
-  ) { }
+  ) {
+    this.checkLoggedInState();
+  }
+
+  checkLoggedInState() {
+    const user = this.getUserFromToken();
+
+    this.authenticationState.next(user);
+  }
 
   public isLoggedIn(): boolean {
-    if (this.jwtService.getToken()) {
-      this.loggedIn = true;
-    }
+    this.loggedIn = (this.getUserFromToken() !== null);
 
     return this.loggedIn;
   }
 
   public getUserRole(): string {
-    return (!this.userRole) ? this.jwtService.getTokenRole() : this.userRole;
+    if (!this.userRole) {
+      const user = this.getUserFromToken();
+
+      this.userRole = (user) ? user.role : '';
+    }
+
+    return this.userRole;
+  }
+
+  private getUserFromToken() {
+    const rawToken = this.jwtService.getToken();
+
+    if (!rawToken) {
+      return null;
+    }
+
+    const decodedToken = this.jwtService.decodeToken(rawToken);
+    const user: User = {
+      token: rawToken,
+      email: decodedToken.email,
+      role: decodedToken.role,
+    };
+
+    this.userRole = user.role;
+
+    return user;
   }
 
   public async login(email: string, password: string) {
-    this.programsService.login(
+    return this.programsService.login(
       email,
       password
     ).subscribe(

--- a/interfaces/HO-Portal/src/app/login/login.page.html
+++ b/interfaces/HO-Portal/src/app/login/login.page.html
@@ -10,11 +10,10 @@
       <ion-col size="4" class="">
 
           <form method="POST"
+                #loginForm
                 (ngSubmit)="doLogin()"
+                (keyup.enter)="doLogin()"
           >
-            <!-- Workaround to make the ENTER-key submit the form -->
-            <button type="submit" hidden>{{ 'page.login.form.submit.label'|translate }}</button>
-
             <ion-item>
               <ion-label position="stacked">{{ 'page.login.form.email.label'|translate }}</ion-label>
               <ion-input type="email"
@@ -43,6 +42,7 @@
 
             <ion-button type="submit"
                         expand="block"
+                        [disabled]="!loginForm?.form?.valid"
             >
               {{ 'page.login.form.submit.label'|translate }}
             </ion-button>

--- a/interfaces/HO-Portal/src/app/login/login.page.spec.ts
+++ b/interfaces/HO-Portal/src/app/login/login.page.spec.ts
@@ -4,10 +4,15 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { LoginPage } from './login.page';
 import { TranslateModule } from '@ngx-translate/core';
 import { AuthService } from '../auth/auth.service';
+import { of } from 'rxjs';
 
 describe('LoginPage', () => {
   let component: LoginPage;
   let fixture: ComponentFixture<LoginPage>;
+
+  const authServiceMock = {
+    authenticationState$: of(null),
+  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -19,6 +24,7 @@ describe('LoginPage', () => {
       providers: [
         {
           provide: AuthService,
+          useValue: authServiceMock,
         },
       ]
     })

--- a/interfaces/HO-Portal/src/app/login/login.page.ts
+++ b/interfaces/HO-Portal/src/app/login/login.page.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { AuthService } from '../auth/auth.service';
 
 @Component({
@@ -7,6 +7,8 @@ import { AuthService } from '../auth/auth.service';
   styleUrls: ['./login.page.scss'],
 })
 export class LoginPage {
+  @ViewChild('loginForm')
+  public loginForm;
 
   public email: any;
   public password: any;
@@ -15,13 +17,23 @@ export class LoginPage {
     private authService: AuthService,
   ) { }
 
-  public doLogin() {
+  public async doLogin() {
     console.log('doLogin()');
 
-    this.authService.login(
+    if (!this.loginForm.form.valid) {
+      return;
+    }
+
+    const result = await this.authService.login(
       this.email,
       this.password
     );
+
+    if (result.closed) {
+      // Remove credentials from interface-state to prevent re-use after log-out:
+      this.email = '';
+      this.password = '';
+    }
 
   }
 }

--- a/interfaces/HO-Portal/src/app/services/jwt.service.ts
+++ b/interfaces/HO-Portal/src/app/services/jwt.service.ts
@@ -26,13 +26,7 @@ export class JwtService {
     window.sessionStorage.removeItem(this.tokenKey);
   }
 
-  getTokenRole(): string|undefined {
-    console.log('JWT Service: getTokenRole');
-    const rawToken = window.sessionStorage[this.tokenKey];
-    if (rawToken) {
-      const decodedToken = this.jwtHelper.decodeToken(rawToken);
-      console.log('decodedToken: ', decodedToken);
-      return decodedToken.role;
-    }
+  decodeToken(rawToken: string): any {
+    return this.jwtHelper.decodeToken(rawToken);
   }
 }


### PR DESCRIPTION
- simplify JWT Service
- move all User-related logic into Auth.Service
- make isLoggedIn()-check REALLY check for a valid token
- check logged-in state on page-(re)load
- remove "ENTER to submit"-workaround
- fix bug where after log-out, credentials could be reused immediately