### PR TITLE
Add documentation of third-party dependencies + links

### DIFF
--- a/interfaces/HO-Portal/README.md
+++ b/interfaces/HO-Portal/README.md
@@ -14,3 +14,11 @@ The front-end for the *Humanitarian Organization* web portal, where 121-programs
 Some specific information need to be configured before use:
 
 - Set the API-endpoint(s) in the [`environment.ts`](./src/environments/environment.ts)-file.
+
+
+## Dependencies in use
+Next to the 'generic' dependencies/libraries/components used by all interfaces, the HO-portal also uses:
+
+- `ngx-datatable`
+  A component to render rows and columns of generic data and add basic functionalities like sorting, selecting, filtering, etc.
+  - API Documentation: <https://swimlane.gitbook.io/ngx-datatable/api>

--- a/interfaces/PA-App/README.md
+++ b/interfaces/PA-App/README.md
@@ -26,6 +26,14 @@ Some specific information need to be configured before use:
 - Set the API-endpoint(s) in the [`environment.ts`](./src/environments/environment.ts)-file.
 
 
+## Dependencies in use
+Next to the 'generic' dependencies/libraries/components [used by all interfaces](../README.md#Dependencies-in-use), the PA-app also uses:
+
+- [`angularx-qrcode`](https://github.com/cordobo/angularx-qrcode)
+  A component to render QR-codes with custom data.
+  - Documentation: <https://github.com/cordobo/angularx-qrcode#basic-usage>
+
+
 ## Deployment / Building
 To deploy a native build of this app, see the generic instructions in [/interfaces/README](../README.md#Deployment).
 

--- a/interfaces/README.md
+++ b/interfaces/README.md
@@ -62,6 +62,27 @@ Every interface or app will refer to the specific services or APIs they require.
 
 See the [/services/](../services/)-directory in this repository.
 
+
+### Dependencies in use
+All interfaces use a common set of dependencies/frameworks/libraries.
+
+- [Ionic v4](https://ionicframework.com/docs/v4/)  
+  This UI-kit or library gives us a foundation to quickly build interfaces cross-platform and cross-device-type(mobile/desktop).  
+  We use the (default) framework of Angular with(in) Ionic.
+  - Available components: <https://ionicframework.com/docs/v4/components>
+  - CSS Utilities: <https://ionicframework.com/docs/v4/layout/css-utilities>
+  - Icons: <https://ionicons.com/v4/>
+
+- [Angular v7](https://v7.angular.io/docs)  
+  This front-end framework gives us a structure to create components that can be connected, combined, share data and can be delivered as a web-app.
+  - API Documentation: <https://v7.angular.io/api>
+  - Used by Angular, RxJS: <https://rxjs-dev.firebaseapp.com/api>
+
+- [`ngx-translate`](http://www.ngx-translate.com/)  
+  An Angular-service to handle internationalization(i18n) or translations.
+  - API Documentation: <https://github.com/ngx-translate/core#api>
+  
+
 ### Continuous Integration (CI)
 Every interface has their own Azure Pipeline set up to run tests and generate 'builds'.  
 See their status on the [main README](../README.md#status).


### PR DESCRIPTION
@jannisvisser @RubenGeo :

I've added some links to documentation-sites that I use frequently, so maybe there are also useful links you can add for back-end dependencies/tools.
To get as much knowledge out of our heads and into something potential new developers can pick up and run with.