### PR TITLE
Use text input-type, to prevent input-quirks in some browsers

### DIFF
--- a/interfaces/AW-App/src/app/validation-components/validate-program/validate-program.component.html
+++ b/interfaces/AW-App/src/app/validation-components/validate-program/validate-program.component.html
@@ -28,7 +28,7 @@
         </ion-radio-group>
       </div>
       <div *ngSwitchCase="answerTypes.Number">
-        <ion-input type="number"
+        <ion-input type="text"
                    inputmode="numeric"
                    pattern="[0-9]*"
                    [name]="question.code"
@@ -114,7 +114,7 @@
       </ion-button>
     </p>
   </dialogue-turn>
-  <dialogue-turn actor="self" 
+  <dialogue-turn actor="self"
                  *ngIf="programCredentialIssued"
                  [isSpoken]="programCredentialIssued"
   >

--- a/interfaces/PA-App/src/app/shared/q-and-a-set/q-and-a-set.component.html
+++ b/interfaces/PA-App/src/app/shared/q-and-a-set/q-and-a-set.component.html
@@ -26,7 +26,7 @@
         </ion-radio-group>
       </div>
       <div *ngSwitchCase="answerType.Number">
-        <ion-input type="number"
+        <ion-input type="text"
                    inputmode="numeric"
                    pattern="[0-9]*"
                    [name]="question.code"


### PR DESCRIPTION
See: https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/