### PR TITLE
Respond less often to Release-webhook events

### DIFF
--- a/tools/webhook.js
+++ b/tools/webhook.js
@@ -61,6 +61,8 @@ http
       }
       if (
         process.env.NODE_ENV === "production" &&
+        payload.action === "released" &&
+        payload.release.draft === false &&
         payload.release.target_commitish &&
         payload.release.target_commitish.includes(process.env.VERSION)
       ) {


### PR DESCRIPTION
As it is fired multiple times per release/edit/publish and the production-VM isn't the fastest...