### PR TITLE
Install dependencies before starting, to have the latest code/state

### DIFF
--- a/interfaces/AW-App/package.json
+++ b/interfaces/AW-App/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "ionic": "ionic",
     "ng": "ng",
+    "prestart": "npm install --no-optional --no-audit --no-fund",
     "start": "ng serve --port 0",
     "set-env-variables": "node ./_set-env-variabes.js",
     "prebuild": "npm run set-env-variables",

--- a/interfaces/HO-Portal/package.json
+++ b/interfaces/HO-Portal/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "ionic": "ionic",
     "ng": "ng",
+    "prestart": "npm install --no-optional --no-audit --no-fund",
     "start": "ng serve --port 0",
     "set-env-variables": "node ./_set-env-variabes.js",
     "prebuild": "npm run set-env-variables",

--- a/interfaces/PA-App/package.json
+++ b/interfaces/PA-App/package.json
@@ -6,6 +6,7 @@
     "ng": "ng",
     "ionic": "ionic",
     "cordova": "cordova",
+    "prestart": "npm install --no-optional --no-audit --no-fund",
     "start": "ng serve --port 0",
     "dev:on-device": "npm run ionic -- cordova run android --device --consolelogs --livereload",
     "dev:local-android": "npm run ionic -- cordova run android --emulator --consolelogs --livereload",


### PR DESCRIPTION
This will add a small delay of approx. 10 seconds to every time you run `npm start`, but it prevents build-failures of missing dependencies (and you don't have to check/decide manually if you need to update your environment).

(Only enabled for the interfaces now, but might be equally useful for the services.)

CC: @jannisvisser 