### PR TITLE
Task 2926

### DIFF
--- a/interfaces/AW-App/package.json
+++ b/interfaces/AW-App/package.json
@@ -65,6 +65,7 @@
     "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-jasmine": "~3.3.1",
     "karma-jasmine-html-reporter": "^1.5.4",
+    "karma-phantomjs-launcher": "^1.0.4",
     "prettier": "2.0.5",
     "prettier-plugin-organize-imports": "^1.1.1",
     "protractor": "^7.0.0",

--- a/interfaces/AW-App/src/app/account/account.page.spec.ts
+++ b/interfaces/AW-App/src/app/account/account.page.spec.ts
@@ -8,6 +8,7 @@ import { AccountPage } from './account.page';
 fdescribe('AccountPage', () => {
   let component: AccountPage;
   let fixture: ComponentFixture<AccountPage>;
+  let event;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -19,6 +20,14 @@ fdescribe('AccountPage', () => {
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
+
+    event = {
+      preventDefault: function () {},
+      target: { elements: {
+        create: { value: ""},
+        confirm: { value: ""}
+      }}
+    }
   }));
 
   beforeEach(() => {
@@ -29,7 +38,28 @@ fdescribe('AccountPage', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-    console.log("We Start here");
-    console.log(component.changePasswordForm);
+  });
+
+  it('ngOnInit: should set up variables', () => {
+    expect(component.isLoggedIn).toBeDefined();
+  });
+
+  it('doLogin: should call login of authService', () => {
+    expect(component.isLoggedIn).toBeDefined();
+    spyOn(event, "preventDefault");
+    component.doLogin(event);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('logout: should create toastController', () => {
+    spyOn(component, "createToast");
+    component.logout();
+    expect(component.createToast).toHaveBeenCalled();
+  });
+
+  it('doChangePassword: should call if create != confirm', () => {
+    spyOn(component, "createToast");
+    component.logout();
+    expect(component.createToast).toHaveBeenCalled();
   });
 });

--- a/interfaces/AW-App/src/app/account/account.page.spec.ts
+++ b/interfaces/AW-App/src/app/account/account.page.spec.ts
@@ -57,9 +57,29 @@ fdescribe('AccountPage', () => {
     expect(component.createToast).toHaveBeenCalled();
   });
 
-  it('doChangePassword: should call if create != confirm', () => {
+ // async methods
+  fit('doChangePassword: should call changePassword if create == confirm', (done) => {
     spyOn(component, "createToast");
-    component.logout();
+    let spy = spyOn(component.programsService, "changePassword").and.returnValue(Promise.resolve(true));
+
+    component.doChangePassword(event);
+
+    spy.calls.mostRecent().returnValue.then(() => {
+        expect(component.createToast).toHaveBeenCalledWith(component.changedPassword);
+        expect(component.createToast).toHaveBeenCalled();
+        done();
+    });
+  });
+
+
+  fit('doChangePassword: should not call changePassword if create != confirm', () => {
+    spyOn(component, "createToast");
+    spyOn(component.programsService, "changePassword");
+    event.target.elements.create = "none";
+
+    component.doChangePassword(event);
+    expect(component.programsService.changePassword).not.toHaveBeenCalled();
     expect(component.createToast).toHaveBeenCalled();
   });
+
 });

--- a/interfaces/AW-App/src/app/account/account.page.spec.ts
+++ b/interfaces/AW-App/src/app/account/account.page.spec.ts
@@ -5,7 +5,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { AccountPage } from './account.page';
 
-describe('AccountPage', () => {
+fdescribe('AccountPage', () => {
   let component: AccountPage;
   let fixture: ComponentFixture<AccountPage>;
 
@@ -29,5 +29,7 @@ describe('AccountPage', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+    console.log("We Start here");
+    console.log(component.changePasswordForm);
   });
 });

--- a/interfaces/AW-App/src/karma.conf.js
+++ b/interfaces/AW-App/src/karma.conf.js
@@ -7,6 +7,7 @@ module.exports = function (config) {
     frameworks: ['jasmine', '@angular-devkit/build-angular'],
     plugins: [
       require('karma-jasmine'),
+      require('karma-phantomjs-launcher'),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),


### PR DESCRIPTION
Adding sample tests for Unit Tests.

In order to specifically run the tests, within the framework of Jasmin and Angular, we can only target by using the focus(?) prefix. So while we make changes we should prefix the describe with fdescribe (As shown within this change of account-page test spec).

Additionally, we can write tests for following scenarios which include:

- declarations of class wide variables
- calling of methods within the class / non-private objects
- checking the if and else statements