### PR TITLE
AB#3480 Handle empty-string as a valid value for a translatable string

### DIFF
--- a/interfaces/AW-App/src/app/services/translatable-string.service.ts
+++ b/interfaces/AW-App/src/app/services/translatable-string.service.ts
@@ -23,11 +23,11 @@ export class TranslatableStringService {
 
     let label: any = property[this.translate.currentLang];
 
-    if (!label) {
+    if (typeof label === 'undefined') {
       label = property[this.fallbackLanguageCode];
     }
 
-    if (!label) {
+    if (typeof label === 'undefined') {
       label = property;
     }
 

--- a/interfaces/HO-Portal/src/app/services/translatable-string.service.ts
+++ b/interfaces/HO-Portal/src/app/services/translatable-string.service.ts
@@ -7,11 +7,9 @@ import { TranslatableString } from '../models/translatable-string.model';
 })
 export class TranslatableStringService {
   private fallbackLanguageCode: string;
-  private languageCode: string;
 
   constructor(private translate: TranslateService) {
     this.fallbackLanguageCode = this.translate.getDefaultLang();
-    this.languageCode = this.translate.currentLang;
   }
 
   public get(property: TranslatableString | string): string {
@@ -23,13 +21,13 @@ export class TranslatableStringService {
       return property;
     }
 
-    let label: any = property[this.languageCode];
+    let label: any = property[this.translate.currentLang];
 
-    if (!label) {
+    if (typeof label === 'undefined') {
       label = property[this.fallbackLanguageCode];
     }
 
-    if (!label) {
+    if (typeof label === 'undefined') {
       label = property;
     }
 

--- a/interfaces/PA-App/src/app/services/translatable-string.service.ts
+++ b/interfaces/PA-App/src/app/services/translatable-string.service.ts
@@ -23,11 +23,11 @@ export class TranslatableStringService {
 
     let label: any = property[this.translate.currentLang];
 
-    if (!label) {
+    if (typeof label === 'undefined') {
       label = property[this.fallbackLanguageCode];
     }
 
-    if (!label) {
+    if (typeof label === 'undefined') {
       label = property;
     }
 


### PR DESCRIPTION
+ align all versions.