### PR TITLE
AB#1518 review phonenumber validation

### DIFF
--- a/interfaces/AW-App/src/app/models/program.model.ts
+++ b/interfaces/AW-App/src/app/models/program.model.ts
@@ -19,6 +19,7 @@ export class ProgramCriterium {
   criterium: string;
   answerType: AnswerType;
   label: TranslatableString;
+  placeholder?: TranslatableString;
   options: null | ProgramCriteriumOption[];
 }
 

--- a/interfaces/AW-App/src/app/models/q-and-a.models.ts
+++ b/interfaces/AW-App/src/app/models/q-and-a.models.ts
@@ -12,6 +12,7 @@ export class Question {
   code: string;
   answerType: AnswerType;
   label: string;
+  placeholder?: string;
   options: QuestionOption[] | null;
 }
 

--- a/interfaces/AW-App/src/app/shared/phone-number-input/phone-number-input.component.html
+++ b/interfaces/AW-App/src/app/shared/phone-number-input/phone-number-input.component.html
@@ -4,7 +4,7 @@
   inputmode="tel"
   autocomplete="tel"
   pattern="^\+?[0-9 \-\(\)]+"
-  placeholder="+0 000 000 000"
+  [placeholder]="placeholder ? placeholder : '+0 000 000 000'"
   minlength="8"
   maxlength="17"
   [name]="name"

--- a/interfaces/AW-App/src/app/shared/phone-number-input/phone-number-input.component.ts
+++ b/interfaces/AW-App/src/app/shared/phone-number-input/phone-number-input.component.ts
@@ -27,6 +27,9 @@ export class PhoneNumberInputComponent {
   public value: string;
 
   @Input()
+  public placeholder: string;
+
+  @Input()
   public disabled: boolean;
 
   @Input()

--- a/interfaces/AW-App/src/app/shared/q-and-a-set/q-and-a-set.component.html
+++ b/interfaces/AW-App/src/app/shared/q-and-a-set/q-and-a-set.component.html
@@ -10,7 +10,7 @@
       [isSpoken]="isFirst || isSubmitted || isEditing"
     >
       <p>
-        <ion-label>{{ question.label }}</ion-label>
+        <ion-label [innerHTML]="question.label"></ion-label>
       </p>
       <div [ngSwitch]="question.answerType">
         <div *ngSwitchCase="answerType.Enum">

--- a/interfaces/AW-App/src/app/shared/q-and-a-set/q-and-a-set.component.html
+++ b/interfaces/AW-App/src/app/shared/q-and-a-set/q-and-a-set.component.html
@@ -65,6 +65,7 @@
             ngDefaultControl
             [(ngModel)]="theFormModels[question.code]"
             required
+            [placeholder]="question.placeholder"
             [name]="question.code"
             [disabled]="isSubmitted"
             (isValidChange)="onChangeWithValidation(question.code, phoneNumberInput.value, phoneNumberInput.isValid)"

--- a/interfaces/AW-App/src/app/validation-components/validate-program/validate-program.component.html
+++ b/interfaces/AW-App/src/app/validation-components/validate-program/validate-program.component.html
@@ -26,7 +26,7 @@
   >
     <ul>
       <li *ngFor="let question of questions">
-        {{ question.label }}<br>
+        <span [innerHTML]="question.label"></span><br>
         <strong>{{ answers[question.code]?.label }}</strong>
       </li>
     </ul>

--- a/interfaces/AW-App/src/app/validation-components/validate-program/validate-program.component.ts
+++ b/interfaces/AW-App/src/app/validation-components/validate-program/validate-program.component.ts
@@ -102,6 +102,7 @@ export class ValidateProgramComponent implements ValidationComponent {
           code: criterium.criterium,
           answerType: criterium.answerType,
           label: this.translatableString.get(criterium.label),
+          placeholder: this.translatableString.get(criterium.placeholder),
           options: !criterium.options
             ? null
             : this.buildOptions(criterium.options),

--- a/interfaces/PA-App/src/app/mocks/api.program.mock.ts
+++ b/interfaces/PA-App/src/app/mocks/api.program.mock.ts
@@ -12,5 +12,6 @@ export const mockProgram: Program = {
   customCriteria: [],
   financialServiceProviders: [],
   credDefId: '',
+  phoneNumberPlaceholder: '+000 000 00 00',
   validation: true,
 };

--- a/interfaces/PA-App/src/app/models/program.model.ts
+++ b/interfaces/PA-App/src/app/models/program.model.ts
@@ -16,6 +16,7 @@ export class Program {
   financialServiceProviders: Fsp[];
   credDefId: string;
   validation: boolean;
+  phoneNumberPlaceholder: string;
 }
 
 export class ProgramCriterium {

--- a/interfaces/PA-App/src/app/personal-components/enroll-in-program/enroll-in-program.component.html
+++ b/interfaces/PA-App/src/app/personal-components/enroll-in-program/enroll-in-program.component.html
@@ -56,7 +56,7 @@
   >
     <ul>
       <li *ngFor="let question of questions">
-        {{ question.label }}<br>
+        <span [innerHTML]="question.label"></span><br>
         <strong>{{ answers[question.code]?.label }}</strong>
       </li>
     </ul>

--- a/interfaces/PA-App/src/app/personal-components/set-notification-number/set-notification-number.component.ts
+++ b/interfaces/PA-App/src/app/personal-components/set-notification-number/set-notification-number.component.ts
@@ -85,7 +85,11 @@ export class SetNotificationNumberComponent extends PersonalComponent {
 
   async getPlaceholder() {
     const currentProgram = await this.paData.getCurrentProgram();
-    return currentProgram.phoneNumberPlaceholder;
+    const phoneNumberPlaceholder = currentProgram.phoneNumberPlaceholder;
+    if (!phoneNumberPlaceholder) {
+      return '';
+    }
+    return phoneNumberPlaceholder;
   }
 
   private async checkExistingPhoneNumber() {

--- a/interfaces/PA-App/src/app/personal-components/set-notification-number/set-notification-number.component.ts
+++ b/interfaces/PA-App/src/app/personal-components/set-notification-number/set-notification-number.component.ts
@@ -1,10 +1,8 @@
 import { Component, Input } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { AnswerType } from 'src/app/models/q-and-a.models';
 import { ConversationService } from 'src/app/services/conversation.service';
 import { PaDataService } from 'src/app/services/padata.service';
 import { ProgramsServiceApiService } from 'src/app/services/programs-service-api.service';
-import { TranslatableStringService } from 'src/app/services/translatable-string.service';
 import { environment } from 'src/environments/environment';
 import { PersonalComponent } from '../personal-component.class';
 import { PersonalComponents } from '../personal-components.enum';
@@ -38,7 +36,6 @@ export class SetNotificationNumberComponent extends PersonalComponent {
     public translate: TranslateService,
     public paData: PaDataService,
     public programService: ProgramsServiceApiService,
-    private translatableString: TranslatableStringService,
   ) {
     super();
     this.useLocalStorage = environment.localStorage;
@@ -88,14 +85,7 @@ export class SetNotificationNumberComponent extends PersonalComponent {
 
   async getPlaceholder() {
     const currentProgram = await this.paData.getCurrentProgram();
-    // Use the first phone-number question as data-store:
-    const phoneNumberQuestion = currentProgram.customCriteria.find(
-      (question) => question.answerType === AnswerType.phoneNumber,
-    );
-    if (!phoneNumberQuestion) {
-      return '';
-    }
-    return this.translatableString.get(phoneNumberQuestion.placeholder);
+    return currentProgram.phoneNumberPlaceholder;
   }
 
   private async checkExistingPhoneNumber() {

--- a/interfaces/PA-App/src/app/shared/q-and-a-set/q-and-a-set.component.html
+++ b/interfaces/PA-App/src/app/shared/q-and-a-set/q-and-a-set.component.html
@@ -10,7 +10,7 @@
       [isSpoken]="isFirst || isSubmitted || isEditing"
     >
       <p>
-        <ion-label>{{ question.label }}</ion-label>
+        <ion-label [innerHTML]="question.label"></ion-label>
       </p>
       <div [ngSwitch]="question.answerType">
         <div *ngSwitchCase="answerType.Enum">

--- a/services/121-service/seed-data/fsp/fsp-mixed-attributes.json
+++ b/services/121-service/seed-data/fsp/fsp-mixed-attributes.json
@@ -4,7 +4,7 @@
     {
       "name": "phoneNumber",
       "label": {
-        "en": "Phone number with country-code. It should look like: +000 000 00 00"
+        "en": "Phone number with country-code. It should look like: <strong>+000 000 00 00</strong>"
       },
       "placeholder": {
         "en": "+000 000 00 00"

--- a/services/121-service/seed-data/fsp/fsp-mixed-attributes.json
+++ b/services/121-service/seed-data/fsp/fsp-mixed-attributes.json
@@ -4,7 +4,7 @@
     {
       "name": "phoneNumber",
       "label": {
-        "en": "Your phonenumber (including country-code, +000 000 00 00)"
+        "en": "Phone number with country-code. It should look like: +000 000 00 00"
       },
       "placeholder": {
         "en": "+000 000 00 00"

--- a/services/121-service/seed-data/fsp/fsp-mobile-money.json
+++ b/services/121-service/seed-data/fsp/fsp-mobile-money.json
@@ -4,7 +4,7 @@
     {
       "name": "phoneNumber",
       "label": {
-        "en": "What is your phonenumber, so we can send you mobile money (including country-code, +000 000 00 00)"
+        "en": "What is your phonenumber, so we can send you mobile money (With country-code. It should look like: +000 000 00 00)"
       },
       "placeholder": {
         "en": "+000 000 00 00"

--- a/services/121-service/seed-data/fsp/fsp-mobile-money.json
+++ b/services/121-service/seed-data/fsp/fsp-mobile-money.json
@@ -4,7 +4,7 @@
     {
       "name": "phoneNumber",
       "label": {
-        "en": "What is your phonenumber, so we can send you mobile money (With country-code. It should look like: +000 000 00 00)"
+        "en": "What is your phonenumber, so we can send you mobile money (With country-code. It should look like: <strong>+000 000 00 00</strong>)"
       },
       "placeholder": {
         "en": "+000 000 00 00"

--- a/services/121-service/seed-data/fsp/fsp-mpesa.json
+++ b/services/121-service/seed-data/fsp/fsp-mpesa.json
@@ -4,10 +4,10 @@
     {
       "name": "phoneNumber",
       "label": {
-        "en": "Which phone number do you want to receive your M-Pesa code on? (With country-code. It should look like: <strong>+000 000 00 00</strong>)"
+        "en": "Which phone number do you want to receive your M-Pesa code on? (With country-code. It should look like: <strong>+254 000 000 000</strong>)"
       },
       "placeholder": {
-        "en": "+000 000 00 00"
+        "en": "+254 000 000 000"
       },
       "answerType": "tel",
       "options": null

--- a/services/121-service/seed-data/fsp/fsp-mpesa.json
+++ b/services/121-service/seed-data/fsp/fsp-mpesa.json
@@ -4,7 +4,7 @@
     {
       "name": "phoneNumber",
       "label": {
-        "en": "Which phone number do you want to receive your M-Pesa code on? (Including country-code, +000 000 00 00)"
+        "en": "Which phone number do you want to receive your M-Pesa code on? (With country-code. It should look like: +000 000 00 00)"
       },
       "placeholder": {
         "en": "+000 000 00 00"

--- a/services/121-service/seed-data/fsp/fsp-mpesa.json
+++ b/services/121-service/seed-data/fsp/fsp-mpesa.json
@@ -4,7 +4,7 @@
     {
       "name": "phoneNumber",
       "label": {
-        "en": "Which phone number do you want to receive your M-Pesa code on? (With country-code. It should look like: +000 000 00 00)"
+        "en": "Which phone number do you want to receive your M-Pesa code on? (With country-code. It should look like: <strong>+000 000 00 00</strong>)"
       },
       "placeholder": {
         "en": "+000 000 00 00"

--- a/services/121-service/seed-data/program/program-anonymous1.json
+++ b/services/121-service/seed-data/program/program-anonymous1.json
@@ -70,6 +70,7 @@
       "rejected": "Je zit niet in het programma"
     }
   },
+  "phoneNumberPlaceholder": "+000 000 00 00",
   "customCriteria": [
     {
       "criterium": "name",

--- a/services/121-service/seed-data/program/program-anonymous2.json
+++ b/services/121-service/seed-data/program/program-anonymous2.json
@@ -70,6 +70,7 @@
       "rejected": "Je zit niet in het programma"
     }
   },
+  "phoneNumberPlaceholder": "+000 000 00 00",
   "customCriteria": [
     {
       "criterium": "name",

--- a/services/121-service/seed-data/program/program-demo.json
+++ b/services/121-service/seed-data/program/program-demo.json
@@ -58,6 +58,7 @@
       "rejected": "Unfortunately we have to inform you that you will not receive any (more) payments for this program. If you have questions, please contact us."
     }
   },
+  "phoneNumberPlaceholder": "+000 000 00 00",
   "customCriteria": [
     {
       "criterium": "name",

--- a/services/121-service/seed-data/program/program-pilot-ken.json
+++ b/services/121-service/seed-data/program/program-pilot-ken.json
@@ -43,6 +43,7 @@
       "rejected": "Unfortunately we have to inform you that you will not receive any (more) payments for this program. If you have questions, please contact us."
     }
   },
+  "phoneNumberPlaceholder": "+000 000 00 00",
   "customCriteria": [
     {
       "criterium": "multiple_choice",

--- a/services/121-service/seed-data/program/program-pilot-ken.json
+++ b/services/121-service/seed-data/program/program-pilot-ken.json
@@ -43,7 +43,7 @@
       "rejected": "Unfortunately we have to inform you that you will not receive any (more) payments for this program. If you have questions, please contact us."
     }
   },
-  "phoneNumberPlaceholder": "+000 000 00 00",
+  "phoneNumberPlaceholder": "+254 000 000 000",
   "customCriteria": [
     {
       "criterium": "multiple_choice",

--- a/services/121-service/seed-data/program/program-pilot-nl.json
+++ b/services/121-service/seed-data/program/program-pilot-nl.json
@@ -46,6 +46,7 @@
       "rejected": "Unfortunately we have to inform you that you will not receive any (more) payments for this program. If you have questions, please contact us."
     }
   },
+  "phoneNumberPlaceholder": "+31 6 00 00 00 00",
   "customCriteria": [
     {
       "criterium": "name",

--- a/services/121-service/seed-data/program/program-pilot-nl.json
+++ b/services/121-service/seed-data/program/program-pilot-nl.json
@@ -72,7 +72,7 @@
     {
       "criterium": "phoneNumberWhatsApp",
       "label": {
-        "en": "Number to reach me via WhatsApp: (It should look like: +00 0 00 00 00 00)"
+        "en": "Number to reach me via WhatsApp: (It should look like: +000 000 00 00)"
       },
       "placeholder": {
         "en": "+000 000 00 00"
@@ -89,7 +89,7 @@
         "en": "Number to reach me via SMS: (It should look like: +31 6 00 00 00 00)"
       },
       "placeholder": {
-        "en": "+000 000 00 00"
+        "en": "+31 6 00 00 00 00"
       },
       "answerType": "tel",
       "criteriumType": "standard",

--- a/services/121-service/seed-data/program/program-pilot-nl.json
+++ b/services/121-service/seed-data/program/program-pilot-nl.json
@@ -73,7 +73,7 @@
     {
       "criterium": "phoneNumberWhatsApp",
       "label": {
-        "en": "Number to reach me via WhatsApp: (It should look like: +000 000 00 00)"
+        "en": "Number to reach me via WhatsApp: (It should look like: <strong>+000 000 00 00</strong>)"
       },
       "placeholder": {
         "en": "+000 000 00 00"
@@ -87,7 +87,7 @@
     {
       "criterium": "phoneNumberSMS",
       "label": {
-        "en": "Number to reach me via SMS: (It should look like: +31 6 00 00 00 00)"
+        "en": "Number to reach me via SMS: (It should look like: <strong>+31 6 00 00 00 00</strong>)"
       },
       "placeholder": {
         "en": "+31 6 00 00 00 00"

--- a/services/121-service/src/programs/fsp/africas-talking.service.ts
+++ b/services/121-service/src/programs/fsp/africas-talking.service.ts
@@ -22,7 +22,6 @@ export class AfricasTalkingService {
     programId,
     installment,
   ): Promise<StatusMessageDto> {
-    console.log('paymentList: ', paymentList);
     const payload = this.createAfricasTalkingDetails(
       paymentList,
       programId,

--- a/services/121-service/src/programs/program/dto/create-program.dto.ts
+++ b/services/121-service/src/programs/program/dto/create-program.dto.ts
@@ -134,6 +134,10 @@ export class CreateProgramDto {
   })
   public readonly notifications: JSON;
 
+  @ApiModelProperty({ example: '+000 000 00 00' })
+  @IsString()
+  public readonly phoneNumberPlaceholder: string;
+
   @ApiModelProperty({
     example: [
       {

--- a/services/121-service/src/programs/program/program.controller.spec.ts
+++ b/services/121-service/src/programs/program/program.controller.spec.ts
@@ -34,6 +34,7 @@ const newProgramParameters = {
   meetingDocuments: JSON.parse('{"en": "documents"}'),
   customCriteria: [],
   notifications: JSON.parse('{}'),
+  phoneNumberPlaceholder: '+000 000 00 00',
   validation: true,
 };
 

--- a/services/121-service/src/programs/program/program.entity.ts
+++ b/services/121-service/src/programs/program/program.entity.ts
@@ -85,6 +85,9 @@ export class ProgramEntity {
   @Column('json')
   public notifications: JSON;
 
+  @Column({ nullable: true })
+  public phoneNumberPlaceholder: string;
+
   @Column('json')
   public description: JSON;
 

--- a/services/121-service/src/programs/program/program.service.ts
+++ b/services/121-service/src/programs/program/program.service.ts
@@ -155,6 +155,7 @@ export class ProgramService {
     program.highestScoresX = programData.highestScoresX;
     program.meetingDocuments = programData.meetingDocuments;
     program.notifications = programData.notifications;
+    program.phoneNumberPlaceholder = programData.phoneNumberPlaceholder;
     program.description = programData.description;
     program.descLocation = programData.descLocation;
     program.descHumanitarianObjective = programData.descHumanitarianObjective;


### PR DESCRIPTION
@elwinschmitz the problem was that the {{phoneNumberExample}} in set-notification-number was retrieved by looping over program-questions only. But if the program has no program phone number question, then the result was empty. I assessed (and discussed with Diderik) that given the theoretical possibility of phone number not being a program nor an FSP-question, it was logical to make it a program-attribute. Which is what I did.

Additionally I made the copy + (bold) styling of the phone number question label (more) aligned across the 3 different places it can occur now (program/fsp/notification). Where I took (your) 'set-notification-number' copy/styling as leading.