### PR TITLE
AB#4378 don't show vnumber in kenya

### DIFF
--- a/interfaces/HO-Portal/src/app/program/program-people-affected/program-people-affected.component.html
+++ b/interfaces/HO-Portal/src/app/program/program-people-affected/program-people-affected.component.html
@@ -102,6 +102,17 @@
   ></ngx-datatable-column>
 
   <ngx-datatable-column 
+    *ngIf="allPeopleAffected[0]?.vnumber && [phaseEnum.reviewInclusion, phaseEnum.payment].includes(thisPhase) && userRole === userEnum.ProgramManager"
+    prop="vnumber"
+    name="V-number"
+    minWidth="100"    
+    draggable="false"
+    resizeable="false"
+    sortable="true"
+  >
+  </ngx-datatable-column>
+
+  <ngx-datatable-column 
     *ngFor="let column of paymentColumns" 
     [prop]="column.prop"
     [name]="column.name"

--- a/interfaces/HO-Portal/src/app/program/program-people-affected/program-people-affected.component.html
+++ b/interfaces/HO-Portal/src/app/program/program-people-affected/program-people-affected.component.html
@@ -104,7 +104,7 @@
   <ngx-datatable-column 
     *ngIf="allPeopleAffected[0]?.vnumber && [phaseEnum.reviewInclusion, phaseEnum.payment].includes(thisPhase) && userRole === userEnum.ProgramManager"
     prop="vnumber"
-    name="V-number"
+    [name]="'page.program.program-people-affected.column.vnumber'|translate"
     minWidth="100"    
     draggable="false"
     resizeable="false"

--- a/interfaces/HO-Portal/src/app/program/program-people-affected/program-people-affected.component.ts
+++ b/interfaces/HO-Portal/src/app/program/program-people-affected/program-people-affected.component.ts
@@ -27,6 +27,9 @@ export class ProgramPeopleAffectedComponent implements OnInit {
   @Output()
   isCompleted: EventEmitter<boolean> = new EventEmitter<boolean>();
 
+  public phaseEnum = ProgramPhase;
+  public userEnum = UserRole;
+
   public program: Program;
   public activePhase: ProgramPhase;
 
@@ -175,16 +178,6 @@ export class ProgramPeopleAffectedComponent implements OnInit {
         prop: 'phoneNumber',
         name: this.translate.instant(
           'page.program.program-people-affected.column.phone-number',
-        ),
-        ...columnDefaults,
-        phases: [ProgramPhase.reviewInclusion, ProgramPhase.payment],
-        roles: [UserRole.ProgramManager],
-        minWidth: columnPhoneNumberWidth,
-      },
-      {
-        prop: 'vnumber',
-        name: this.translate.instant(
-          'page.program.program-people-affected.column.vnumber',
         ),
         ...columnDefaults,
         phases: [ProgramPhase.reviewInclusion, ProgramPhase.payment],


### PR DESCRIPTION
@elwinschmitz see this unmerged PR which solves this
- I realize it's super-ugly (filtering on whether the 1st PA has a vnumber)
- but will work in practice (in kenya no-one has a vnumber, in nld it's a mandatory field)
- I tried cleaner solutions, by putting loadData before loadColumns, and then being able to loadColumns based on data, but this didn't seem possible.
- another downside is that we have less control of in what position the columns comes exactly
- anyway: if you think it's not full-proof and/or too ugly, feel free to not merge (and either improve or decide it's not worth it)