### PR TITLE
AB#6829 Fix time-format on generated voucher-image

### DIFF
--- a/services/121-service/src/notifications/imagecode/image-code.service.ts
+++ b/services/121-service/src/notifications/imagecode/image-code.service.ts
@@ -102,8 +102,9 @@ export class ImageCodeService {
     ];
     const day = String(date.getDate()).padStart(2, '0');
     const month = monthNames[date.getMonth()];
+    const time = date.toTimeString().substring(0, 5);
 
-    return `${day} ${month} ${date.getFullYear()} ${date.getHours()}:${date.getMinutes()}`;
+    return `${day} ${month} ${date.getFullYear()} ${time}`;
   }
 
   public async generateVoucherImage(voucherData: {


### PR DESCRIPTION
This changes: "8:5" into "08:05" for timestamps before 12-noon/before-10-minutes-past