### PR TITLE
AB#7204 Make "export-voucher"-endpoint always return the most-recent image

### DIFF
--- a/services/121-service/src/programs/fsp/intersolve.service.ts
+++ b/services/121-service/src/programs/fsp/intersolve.service.ts
@@ -375,7 +375,7 @@ export class IntersolveService {
       );
     }
 
-    const voucher = connection.images.find(
+    const voucher = connection.images.reverse().find(
       image => image.barcode.installment === installment,
     );
     if (!voucher) {


### PR DESCRIPTION
For "installment #17" PA will have multiple images, in `getVoucher` an array-method `find` is used;
This will return at the _first_ successful match (and thus the 'old/initial' voucher image of the correct installment-17).

By reversing the array, the most-recent image of the INcorrect-installment-17(should be 23) will be returned.