### PR TITLE
Fix: Use icon-name that exists in Ionicons v5+

### DIFF
--- a/interfaces/PA-App/_check-icons-in-use.js
+++ b/interfaces/PA-App/_check-icons-in-use.js
@@ -59,7 +59,6 @@ fromDir('www', /\.(js|css|html)$/, checkIfUsed);
 const iconsUsed = iconList.filter((icon) => icon.used === true);
 
 // Always include some icons that are not picked up by the search:
-iconsUsed.push({ iconName: 'share-alt' }); // Used in 'toast'/'notification'-component
 iconsUsed.push({ iconName: 'log-out' }); // Used in 'list-item-detail'-component/detail-icon-property
 
 console.log(`\nFound ${iconsUsed.length} icons in use.\n`);

--- a/interfaces/PA-App/angular.json
+++ b/interfaces/PA-App/angular.json
@@ -64,7 +64,7 @@
                   "output": "assets"
                 },
                 {
-                  "glob": "**/{alert,arrow-back-sharp,arrow-down-circle-outline,arrow-undo,camera-reverse,caret-back-sharp,chatbubbles,chevron-back,close,cloud-download,color-fill,construct,create,download,eye,eye-off,flash,flash-off,hourglass,log-out,nuclear,people,person,qr-code,refresh,resize,share-alt,trash}.svg",
+                  "glob": "**/{alert,arrow-back-sharp,arrow-down-circle-outline,arrow-redo,arrow-undo,camera-reverse,caret-back-sharp,chatbubbles,chevron-back,close,cloud-download,color-fill,construct,create,download,eye,eye-off,flash,flash-off,hourglass,log-out,nuclear,people,person,qr-code,refresh,resize,trash}.svg",
                   "input": "node_modules/ionicons/dist/ionicons/svg",
                   "output": "./svg"
                 },

--- a/interfaces/PA-App/src/app/services/update.service.ts
+++ b/interfaces/PA-App/src/app/services/update.service.ts
@@ -69,7 +69,7 @@ export class UpdateService {
           buttons: [
             {
               side: 'start',
-              icon: 'share-alt',
+              icon: 'arrow-redo',
               handler: () => {
                 this.router.navigate([pageNav]);
               },


### PR DESCRIPTION
Related [AB#13731](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/13731)