### PR TITLE
Upgrade Prettier to v2.7+ for HO-Portal

### DIFF
--- a/interfaces/HO-Portal/.prettierignore
+++ b/interfaces/HO-Portal/.prettierignore
@@ -15,8 +15,9 @@ resources/
 package*.json
 
 
-# Don't format HTML, waiting for https://github.com/prettier/prettier/pull/6644 to be possible
-*.html
-
 # Don't reorder imports for polyfills:
 src/polyfills.ts
+
+
+# Exception for inline code/styles
+src/index.html

--- a/interfaces/HO-Portal/.prettierrc.yml
+++ b/interfaces/HO-Portal/.prettierrc.yml
@@ -2,3 +2,4 @@
 #
 singleQuote: true
 trailingComma: all
+singleAttributePerLine: true

--- a/interfaces/HO-Portal/.vscode/settings.json
+++ b/interfaces/HO-Portal/.vscode/settings.json
@@ -1,17 +1,8 @@
 {
   "i18n-ally.keystyle": "nested",
   "i18n-ally.dirStructure": "file",
-  "i18n-ally.localesPaths": [
-    "src/assets/i18n/",
-  ],
-  "i18n-ally.enabledFrameworks": [
-    "ngx-translate"
-  ],
-  "[html]": {
-    "editor.formatOnSave": false,
-    "editor.formatOnPaste": false,
-    "editor.formatOnType": false,
-    "editor.defaultFormatter": "vscode.html-language-features"
-  },
+  "i18n-ally.localesPaths": ["src/assets/i18n/"],
+  "i18n-ally.enabledFrameworks": ["ngx-translate"],
   "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/interfaces/HO-Portal/angular.json
+++ b/interfaces/HO-Portal/angular.json
@@ -60,7 +60,6 @@
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
-              "extractCss": true,
               "extractLicenses": true,
               "vendorChunk": false,
               "buildOptimizer": true,

--- a/interfaces/HO-Portal/azure-pipelines.yml
+++ b/interfaces/HO-Portal/azure-pipelines.yml
@@ -49,6 +49,6 @@ steps:
     displayName: Tests
     workingDirectory: $(workingDir)
 
-  - script: npm run build -- --configuration production
+  - script: npm run build:prod
     displayName: Build Production-mode
     workingDirectory: $(workingDir)

--- a/interfaces/HO-Portal/package-lock.json
+++ b/interfaces/HO-Portal/package-lock.json
@@ -10638,9 +10638,9 @@
       "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
     },
     "prettier": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
-      "integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "prettier-plugin-organize-imports": {

--- a/interfaces/HO-Portal/package.json
+++ b/interfaces/HO-Portal/package.json
@@ -85,7 +85,7 @@
     "karma-coverage-istanbul-reporter": "~3.0.2",
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "^1.5.0",
-    "prettier": "2.5.0",
+    "prettier": "2.7.1",
     "prettier-plugin-organize-imports": "^3.0.3",
     "shx": "^0.3.3",
     "tslint": "~6.1.0",

--- a/interfaces/HO-Portal/package.json
+++ b/interfaces/HO-Portal/package.json
@@ -25,7 +25,7 @@
     "start:debug-production": "npm run build:debug && npm run serve:static",
     "test": "ng test --no-watch --browsers=ChromeHeadless",
     "test:dev": "ng test",
-    "lint:syntax": "prettier --check \"**/*.{md,js,ts,scss}\"",
+    "lint:syntax": "prettier --check \"**/*.{md,js,ts,scss,html}\"",
     "lint": "npm run lint:syntax && ng lint",
     "fix:syntax": "npm run lint:syntax -- --write"
   },

--- a/interfaces/HO-Portal/src/app/app.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/app.component.spec.ts
@@ -6,16 +6,14 @@ import { AppComponent } from './app.component';
 import { LoggingService } from './services/logging.service';
 
 describe('AppComponent', () => {
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [AppComponent],
-        providers: [LoggingService],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        imports: [TranslateModule.forRoot(), RouterTestingModule],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [AppComponent],
+      providers: [LoggingService],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      imports: [TranslateModule.forRoot(), RouterTestingModule],
+    }).compileComponents();
+  }));
 
   it('should create the app', async () => {
     const fixture = TestBed.createComponent(AppComponent);

--- a/interfaces/HO-Portal/src/app/components/header/header.component.html
+++ b/interfaces/HO-Portal/src/app/components/header/header.component.html
@@ -3,29 +3,33 @@
     <ion-row>
       <ion-col size="1">
         <ion-button
-          [title]="'header.help'|translate"
-          [attr.aria-label]="'header.help'|translate"
+          [title]="'header.help' | translate"
+          [attr.aria-label]="'header.help' | translate"
           routerLink="/help"
           fill="clear"
           size="small"
           color="medium"
           *ngIf="showHelp"
         >
-          <ion-icon name="help" slot="icon-only"></ion-icon>
+          <ion-icon
+            name="help"
+            slot="icon-only"
+          ></ion-icon>
         </ion-button>
         <ion-button
-          [title]="'header.home'|translate"
-          [attr.aria-label]="'header.home'|translate"
+          [title]="'header.home' | translate"
+          [attr.aria-label]="'header.home' | translate"
           routerLink="/home"
           fill="clear"
           size="small"
           color="medium"
           *ngIf="showHome"
         >
-          <ion-icon name="home" slot="icon-only"></ion-icon>
+          <ion-icon
+            name="home"
+            slot="icon-only"
+          ></ion-icon>
         </ion-button>
-
-
       </ion-col>
       <ion-col size="4">
         <h1 class="ion-no-margin">
@@ -39,11 +43,17 @@
       <ion-col size="2">
         <ion-row class="ion-justify-content-center">
           <div id="logo-container">
-            <img src="./assets/img/121-logo.png" alt="121">
+            <img
+              src="./assets/img/121-logo.png"
+              alt="121"
+            />
           </div>
         </ion-row>
       </ion-col>
-      <ion-col size="5" class="ion-text-end">
+      <ion-col
+        size="5"
+        class="ion-text-end"
+      >
         <app-user-state></app-user-state>
       </ion-col>
     </ion-row>

--- a/interfaces/HO-Portal/src/app/components/header/header.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/components/header/header.component.spec.ts
@@ -18,39 +18,37 @@ describe('HeaderComponent', () => {
 
   const mockProgramId = 1;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [HeaderComponent],
-        imports: [TranslateModule.forRoot(), RouterTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          {
-            provide: ActivatedRoute,
-            useValue: {
-              snapshot: {
-                params: {
-                  id: mockProgramId,
-                },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [HeaderComponent],
+      imports: [TranslateModule.forRoot(), RouterTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              params: {
+                id: mockProgramId,
               },
             },
           },
-          provideMagicalMock(AuthService),
-          provideMagicalMock(ProgramsServiceApiService),
-          provideMagicalMock(TranslatableStringService),
-        ],
-      }).compileComponents();
+        },
+        provideMagicalMock(AuthService),
+        provideMagicalMock(ProgramsServiceApiService),
+        provideMagicalMock(TranslatableStringService),
+      ],
+    }).compileComponents();
 
-      mockProgramsApi = TestBed.inject(ProgramsServiceApiService);
-      mockProgramsApi.getProgramById.and.returnValue(
-        new Promise((r) => r(apiProgramsMock.programs[mockProgramId])),
-      );
+    mockProgramsApi = TestBed.inject(ProgramsServiceApiService);
+    mockProgramsApi.getProgramById.and.returnValue(
+      new Promise((r) => r(apiProgramsMock.programs[mockProgramId])),
+    );
 
-      fixture = TestBed.createComponent(HeaderComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
-    }),
-  );
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
 
   it('should create', async () => {
     expect(component).toBeTruthy();

--- a/interfaces/HO-Portal/src/app/components/program-navigation/program-navigation.component.html
+++ b/interfaces/HO-Portal/src/app/components/program-navigation/program-navigation.component.html
@@ -10,14 +10,17 @@
           fill="clear"
           size="small"
         >
-          {{ 'header.dashboard'|translate }}
+          {{ 'header.dashboard' | translate }}
         </ion-button>
         <span
           *ngIf="rlaDashboard.isActive"
           class="navigation-button--indicator"
         ></span>
       </span>
-      <span *ngIf="showManageAidworkers" class="navigation-button">
+      <span
+        *ngIf="showManageAidworkers"
+        class="navigation-button"
+      >
         <ion-button
           [disabled]="!canManageAidWorkers()"
           [routerLink]="['/program', programId, 'aid-workers']"
@@ -27,7 +30,7 @@
           fill="clear"
           size="small"
         >
-          {{ 'header.aid-workers'|translate }}
+          {{ 'header.aid-workers' | translate }}
         </ion-button>
         <span
           *ngIf="rlaAidWorkers.isActive"
@@ -39,9 +42,7 @@
   <ion-row>
     <ion-col class="horizontal-scroll-container">
       <div class="ion-text-nowrap">
-        <app-phase-navigation
-          [programId]="programId"
-        ></app-phase-navigation>
+        <app-phase-navigation [programId]="programId"></app-phase-navigation>
       </div>
     </ion-col>
   </ion-row>

--- a/interfaces/HO-Portal/src/app/components/program-navigation/program-navigation.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/components/program-navigation/program-navigation.component.spec.ts
@@ -18,39 +18,37 @@ describe('HeaderComponent', () => {
 
   const mockProgramId = 1;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ProgramNavigationComponent],
-        imports: [TranslateModule.forRoot(), RouterTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          {
-            provide: ActivatedRoute,
-            useValue: {
-              snapshot: {
-                params: {
-                  id: mockProgramId,
-                },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProgramNavigationComponent],
+      imports: [TranslateModule.forRoot(), RouterTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              params: {
+                id: mockProgramId,
               },
             },
           },
-          provideMagicalMock(AuthService),
-          provideMagicalMock(ProgramsServiceApiService),
-          provideMagicalMock(TranslatableStringService),
-        ],
-      }).compileComponents();
+        },
+        provideMagicalMock(AuthService),
+        provideMagicalMock(ProgramsServiceApiService),
+        provideMagicalMock(TranslatableStringService),
+      ],
+    }).compileComponents();
 
-      mockProgramsApi = TestBed.inject(ProgramsServiceApiService);
-      mockProgramsApi.getProgramById.and.returnValue(
-        new Promise((r) => r(apiProgramsMock.programs[mockProgramId])),
-      );
+    mockProgramsApi = TestBed.inject(ProgramsServiceApiService);
+    mockProgramsApi.getProgramById.and.returnValue(
+      new Promise((r) => r(apiProgramsMock.programs[mockProgramId])),
+    );
 
-      fixture = TestBed.createComponent(ProgramNavigationComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
-    }),
-  );
+    fixture = TestBed.createComponent(ProgramNavigationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
 
   it('should create', async () => {
     expect(component).toBeTruthy();

--- a/interfaces/HO-Portal/src/app/components/system-notification/system-notification.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/components/system-notification/system-notification.component.spec.ts
@@ -6,14 +6,12 @@ describe('SystemNotification', () => {
   let component: SystemNotificationComponent;
   let fixture: ComponentFixture<SystemNotificationComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [SystemNotificationComponent],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [SystemNotificationComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SystemNotificationComponent);

--- a/interfaces/HO-Portal/src/app/components/table-filter/table-filter-popover/table-filter-popover.component.html
+++ b/interfaces/HO-Portal/src/app/components/table-filter/table-filter-popover/table-filter-popover.component.html
@@ -1,36 +1,87 @@
 <ng-container [ngSwitch]="type">
   <ng-container *ngSwitchCase="tableFilterType.multipleChoice">
-    <ion-grid class="ion-padding ion-no-margin table-filter-popover--multiple-choice--list">
-      <ion-row class="ion-justify-content-between ion-align-items-center table-filter-popover--multiple-choice--item">
+    <ion-grid
+      class="ion-padding ion-no-margin table-filter-popover--multiple-choice--list"
+    >
+      <ion-row
+        class="ion-justify-content-between ion-align-items-center table-filter-popover--multiple-choice--item"
+      >
         <div class="ion-margin-end">
-          <ion-label class="ion-text-wrap">{{ 'page.program.program-people-affected.filter-btn.common.all-options' | translate }}</ion-label>
+          <ion-label class="ion-text-wrap">{{
+            'page.program.program-people-affected.filter-btn.common.all-options'
+              | translate
+          }}</ion-label>
         </div>
         <div class="ion-margin-start">
           <ion-row class="ion-justify-content-end">
             <ion-label color="medium">{{ state[type].totalCount }}</ion-label>
-            <ion-checkbox [(ngModel)]="state[type].selectAll" (ionChange)="onSelectAll()" class="ion-margin-start"></ion-checkbox>
+            <ion-checkbox
+              [(ngModel)]="state[type].selectAll"
+              (ionChange)="onSelectAll()"
+              class="ion-margin-start"
+            >
+            </ion-checkbox>
           </ion-row>
         </div>
       </ion-row>
-      <ion-row *ngFor="let option of filterProps.allOptions" lines="none" class="ion-justify-content-between ion-align-items-center table-filter-popover--multiple-choice--item">
-        <ion-col size="7" class="ion-no-padding">
+      <ion-row
+        *ngFor="let option of filterProps.allOptions"
+        lines="none"
+        class="ion-justify-content-between ion-align-items-center table-filter-popover--multiple-choice--item"
+      >
+        <ion-col
+          size="7"
+          class="ion-no-padding"
+        >
           <ion-label class="ion-text-wrap">{{ option.label }}</ion-label>
         </ion-col>
-        <ion-col size="4" class="ion-no-padding">
+        <ion-col
+          size="4"
+          class="ion-no-padding"
+        >
           <ion-row class="ion-justify-content-end">
-            <ion-label color="medium">{{ option.count}}</ion-label>
-            <ion-checkbox [(ngModel)]="state[type].options[option.name]" class="ion-margin-start"></ion-checkbox>
+            <ion-label color="medium">{{ option.count }}</ion-label>
+            <ion-checkbox
+              [(ngModel)]="state[type].options[option.name]"
+              class="ion-margin-start"
+            ></ion-checkbox>
           </ion-row>
         </ion-col>
       </ion-row>
     </ion-grid>
     <div class="ion-padding table-filter-popover--multiple-choice--note">
-      <ion-label color="medium" class="ion-text-wrap">
-        <small>{{ 'page.program.program-people-affected.filter-btn.multiple-choice-hidden-options' | translate }}</small>
+      <ion-label
+        color="medium"
+        class="ion-text-wrap"
+      >
+        <small>{{
+          'page.program.program-people-affected.filter-btn.multiple-choice-hidden-options'
+            | translate
+        }}</small>
       </ion-label>
     </div>
+  </ng-container>
+  <ion-footer class="ion-text-end ion-padding ion-no-margin">
+    <ion-button
+      (click)="cancel()"
+      fill="clear"
+      color="danger"
+      size="small"
+    >
+      {{
+        'page.program.program-people-affected.filter-btn.common.cancel-btn'
+          | translate
+      }}
+    </ion-button>
+    <ion-button
+      (click)="applyFilter()"
+      size="small"
+      class="ion-margin-start"
+    >
+      {{
+        'page.program.program-people-affected.filter-btn.common.apply-btn'
+          | translate
+      }}
+    </ion-button>
+  </ion-footer>
 </ng-container>
-<ion-footer class="ion-text-end ion-padding ion-no-margin">
-  <ion-button (click)="cancel()" fill="clear" color="danger" size="small">{{'page.program.program-people-affected.filter-btn.common.cancel-btn' | translate}}</ion-button>
-  <ion-button (click)="applyFilter()" size="small" class="ion-margin-start">{{'page.program.program-people-affected.filter-btn.common.apply-btn' | translate}}</ion-button>
-</ion-footer>

--- a/interfaces/HO-Portal/src/app/components/table-filter/table-filter-popover/table-filter-popover.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/components/table-filter/table-filter-popover/table-filter-popover.component.spec.ts
@@ -7,18 +7,16 @@ describe('TableFilterPopoverComponent', () => {
   let component: TableFilterPopoverComponent;
   let fixture: ComponentFixture<TableFilterPopoverComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [TableFilterPopoverComponent],
-        imports: [IonicModule.forRoot(), TranslateModule.forRoot()],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [TableFilterPopoverComponent],
+      imports: [IonicModule.forRoot(), TranslateModule.forRoot()],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(TableFilterPopoverComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
-    }),
-  );
+    fixture = TestBed.createComponent(TableFilterPopoverComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/interfaces/HO-Portal/src/app/components/table-filter/table-filter.component.html
+++ b/interfaces/HO-Portal/src/app/components/table-filter/table-filter.component.html
@@ -1,1 +1,11 @@
-<ion-button (click)="openPopover($event)" color="dark" fill="clear"> {{ buttonLabel }} <ion-icon [name]="popoverOpen ? 'chevron-up' : 'chevron-down'" slot="end"></ion-icon> </ion-button>
+<ion-button
+  (click)="openPopover($event)"
+  color="dark"
+  fill="clear"
+>
+  {{ buttonLabel }}
+  <ion-icon
+    [name]="popoverOpen ? 'chevron-up' : 'chevron-down'"
+    slot="end"
+  ></ion-icon>
+</ion-button>

--- a/interfaces/HO-Portal/src/app/components/table-filter/table-filter.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/components/table-filter/table-filter.component.spec.ts
@@ -6,18 +6,16 @@ describe('TableFilterComponent', () => {
   let component: TableFilterComponent;
   let fixture: ComponentFixture<TableFilterComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [TableFilterComponent],
-        imports: [IonicModule.forRoot()],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [TableFilterComponent],
+      imports: [IonicModule.forRoot()],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(TableFilterComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
-    }),
-  );
+    fixture = TestBed.createComponent(TableFilterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/interfaces/HO-Portal/src/app/components/update-fsp/update-fsp.component.html
+++ b/interfaces/HO-Portal/src/app/components/update-fsp/update-fsp.component.html
@@ -1,4 +1,8 @@
-<form method="POST" #updatePropertyForm="ngForm" (ngSubmit)="updateChosenFsp()">
+<form
+  method="POST"
+  #updatePropertyForm="ngForm"
+  (ngSubmit)="updateChosenFsp()"
+>
   <div class="input-item ion-padding-vertical">
     <label class="input-item--label text-bold">
       {{ label }}
@@ -26,7 +30,10 @@
           </ion-select>
         </ion-item>
         <ng-container *ngIf="propertyModel != startingFspName">
-          <ion-text class="ion-padding" *ngIf="attributeDifference.length > 0">
+          <ion-text
+            class="ion-padding"
+            *ngIf="attributeDifference.length > 0"
+          >
             {{
               'page.program.program-people-affected.edit-person-affected-popup.fspChangeWarning'
                 | translate

--- a/interfaces/HO-Portal/src/app/components/update-fsp/update-fsp.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/components/update-fsp/update-fsp.component.spec.ts
@@ -11,24 +11,18 @@ describe('UpdateFspComponent', () => {
   let component: UpdateFspComponent;
   let fixture: ComponentFixture<UpdateFspComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [UpdateFspComponent],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        imports: [
-          FormsModule,
-          HttpClientTestingModule,
-          TranslateModule.forRoot(),
-        ],
-        providers: [
-          ProgramsServiceApiService,
-          AlertController,
-          TranslateService,
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [UpdateFspComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      imports: [
+        FormsModule,
+        HttpClientTestingModule,
+        TranslateModule.forRoot(),
+      ],
+      providers: [ProgramsServiceApiService, AlertController, TranslateService],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(UpdateFspComponent);

--- a/interfaces/HO-Portal/src/app/components/update-property-item/update-property-item.component.html
+++ b/interfaces/HO-Portal/src/app/components/update-property-item/update-property-item.component.html
@@ -3,9 +3,7 @@
   #updatePropertyForm="ngForm"
   (ngSubmit)="doUpdate()"
 >
-  <div
-    class="input-item update-property-item"
-  >
+  <div class="input-item update-property-item">
     <label class="input-item--label text-bold">
       {{ label }}
     </label>
@@ -45,7 +43,7 @@
             <ng-container *ngSwitchCase="'dropdown'">
               <ion-item class="ion-margin-bottom">
                 <ion-select
-                  style="max-width: 100%;"
+                  style="max-width: 100%"
                   ngDefaultControl
                   name="propertyInput"
                   [(ngModel)]="propertyModel"
@@ -56,19 +54,20 @@
                 >
                   <ion-select-option
                     *ngFor="let option of translatedOptions()"
-                    value="{{ option.option }}">
-                      {{ option.label }}
+                    value="{{ option.option }}"
+                  >
+                    {{ option.label }}
                   </ion-select-option>
                 </ion-select>
               </ion-item>
             </ng-container>
             <ng-container *ngSwitchCase="'boolean'">
               <ion-checkbox
-              ngDefaultControl
-              [(ngModel)]="propertyModel"
-              name="propertyInput"
-              [checked]="value"
-              class="ion-margin-top"
+                ngDefaultControl
+                [(ngModel)]="propertyModel"
+                name="propertyInput"
+                [checked]="value"
+                class="ion-margin-top"
               ></ion-checkbox>
             </ng-container>
             <ng-container *ngSwitchDefault>
@@ -86,33 +85,39 @@
         </ion-col>
       </ion-row>
       <ion-row class="ion-align-items-center">
-        <ion-col size="10" class="ion-no-padding">
+        <ion-col
+          size="10"
+          class="ion-no-padding"
+        >
           <ion-note
             *ngIf="explanation"
             class="ion-margin-bottom explanation"
           >
-          {{ explanation }}
-        </ion-note>
-      </ion-col>
-      <ion-col size="2" class="ion-no-padding">
-        <ng-container *ngIf="showSubmit">
-          <ion-button
-            *ngIf="!inProgress"
-            type="submit"
-            class="ion-margin-start ion-float-right text-bold ion-text-uppercase"
-            fill=clear
-            [disabled]="disableSaveButton()"
-          >
-          {{ 'common.save'|translate }}
-        </ion-button>
-        <ion-spinner
-          *ngIf="inProgress"
-          color="primary"
-          class="ion-margin-start ion-float-right"
-        ></ion-spinner>
-      </ng-container>
-    </ion-col>
-  </ion-row>
+            {{ explanation }}
+          </ion-note>
+        </ion-col>
+        <ion-col
+          size="2"
+          class="ion-no-padding"
+        >
+          <ng-container *ngIf="showSubmit">
+            <ion-button
+              *ngIf="!inProgress"
+              type="submit"
+              class="ion-margin-start ion-float-right text-bold ion-text-uppercase"
+              fill="clear"
+              [disabled]="disableSaveButton()"
+            >
+              {{ 'common.save' | translate }}
+            </ion-button>
+            <ion-spinner
+              *ngIf="inProgress"
+              color="primary"
+              class="ion-margin-start ion-float-right"
+            ></ion-spinner>
+          </ng-container>
+        </ion-col>
+      </ion-row>
+    </div>
   </div>
-</div>
 </form>

--- a/interfaces/HO-Portal/src/app/components/update-property-item/update-property-item.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/components/update-property-item/update-property-item.component.spec.ts
@@ -8,15 +8,13 @@ describe('UpdatePropertyItemComponent', () => {
   let component: UpdatePropertyItemComponent;
   let fixture: ComponentFixture<UpdatePropertyItemComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [UpdatePropertyItemComponent],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        imports: [FormsModule, TranslateModule.forRoot()],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [UpdatePropertyItemComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      imports: [FormsModule, TranslateModule.forRoot()],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(UpdatePropertyItemComponent);

--- a/interfaces/HO-Portal/src/app/components/user-state/user-state.component.html
+++ b/interfaces/HO-Portal/src/app/components/user-state/user-state.component.html
@@ -1,6 +1,6 @@
-<span style="display: inline-block;">
-  {{ 'user-state.logged-in-as'|translate }}:
-  <br>
+<span style="display: inline-block">
+  {{ 'user-state.logged-in-as' | translate }}:
+  <br />
   <a [routerLink]="['/user']">
     <ion-note class="ion-text-nowrap">{{ userName }}</ion-note>
   </a>
@@ -17,17 +17,25 @@
   title="Show all Permissions"
   aria-label="Show all Permissions"
 >
-  <ion-icon name="id-card" slot="icon-only" size="small" aria-hidden="true"></ion-icon>
+  <ion-icon
+    name="id-card"
+    slot="icon-only"
+    size="small"
+    aria-hidden="true"
+  ></ion-icon>
 </ion-button>
 
 <ion-button
   type="button"
-  [title]="'user-state.log-out'|translate"
-  [attr.aria-label]="'user-state.log-out'|translate"
+  [title]="'user-state.log-out' | translate"
+  [attr.aria-label]="'user-state.log-out' | translate"
   size="small"
   fill="clear"
   (click)="doLogout()"
 >
-  <span class="ion-hide-sm-down">{{ 'user-state.log-out'|translate }}</span>
-  <ion-icon name="log-out" slot="end"></ion-icon>
+  <span class="ion-hide-sm-down">{{ 'user-state.log-out' | translate }}</span>
+  <ion-icon
+    name="log-out"
+    slot="end"
+  ></ion-icon>
 </ion-button>

--- a/interfaces/HO-Portal/src/app/components/user-state/user-state.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/components/user-state/user-state.component.spec.ts
@@ -21,21 +21,19 @@ describe('UserStateComponent', () => {
     authenticationState$: of(mockUser),
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [UserStateComponent],
-        providers: [
-          {
-            provide: AuthService,
-            useValue: authServiceMock,
-          },
-        ],
-        imports: [TranslateModule.forRoot(), RouterTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [UserStateComponent],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: authServiceMock,
+        },
+      ],
+      imports: [TranslateModule.forRoot(), RouterTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(UserStateComponent);

--- a/interfaces/HO-Portal/src/app/directives/only-allowed-input.directive.spec.ts
+++ b/interfaces/HO-Portal/src/app/directives/only-allowed-input.directive.spec.ts
@@ -5,12 +5,10 @@ describe('OnlyAllowedInputDirective', () => {
   let testElement;
   let directive;
 
-  beforeEach(
-    waitForAsync(() => {
-      testElement = document.createElement('input');
-      directive = new OnlyAllowedInputDirective();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    testElement = document.createElement('input');
+    directive = new OnlyAllowedInputDirective();
+  }));
 
   it('should create an instance', () => {
     expect(directive).toBeTruthy();

--- a/interfaces/HO-Portal/src/app/help/help.page.html
+++ b/interfaces/HO-Portal/src/app/help/help.page.html
@@ -1,7 +1,9 @@
-<app-header [title]="'page.help.pageTitle'|translate" [showHome]="true"></app-header>
+<app-header
+  [title]="'page.help.pageTitle'|translate"
+  [showHome]="true"
+></app-header>
 
 <ion-content class="ion-padding">
   <h2>{{ 'page.help.user-manual'|translate }}</h2>
   <p>{{ 'page.help.user-manual-content'|translate }}</p>
-
 </ion-content>

--- a/interfaces/HO-Portal/src/app/help/help.page.spec.ts
+++ b/interfaces/HO-Portal/src/app/help/help.page.spec.ts
@@ -7,15 +7,13 @@ describe('HelpPage', () => {
   let component: HelpPage;
   let fixture: ComponentFixture<HelpPage>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [HelpPage],
-        imports: [TranslateModule.forRoot()],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [HelpPage],
+      imports: [TranslateModule.forRoot()],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HelpPage);

--- a/interfaces/HO-Portal/src/app/home/home.page.html
+++ b/interfaces/HO-Portal/src/app/home/home.page.html
@@ -1,5 +1,10 @@
-<app-header [title]="'page.home.pageTitle'|translate" [showHelp]="true"></app-header>
+<app-header
+  [title]="'page.home.pageTitle'|translate"
+  [showHelp]="true"
+></app-header>
 
 <ion-content class="ion-padding">
-  <app-programs-list *appIfPermissions="[Permission.ProgramAllREAD]"></app-programs-list>
+  <app-programs-list
+    *appIfPermissions="[Permission.ProgramAllREAD]"
+  ></app-programs-list>
 </ion-content>

--- a/interfaces/HO-Portal/src/app/home/home.page.spec.ts
+++ b/interfaces/HO-Portal/src/app/home/home.page.spec.ts
@@ -7,15 +7,13 @@ describe('HomePage', () => {
   let component: HomePage;
   let fixture: ComponentFixture<HomePage>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [HomePage],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        imports: [TranslateModule.forRoot()],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [HomePage],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      imports: [TranslateModule.forRoot()],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HomePage);

--- a/interfaces/HO-Portal/src/app/login/login.page.html
+++ b/interfaces/HO-Portal/src/app/login/login.page.html
@@ -1,20 +1,56 @@
-<app-system-notification [message]="'system-notifications.compatible-browsers'|translate" color="tertiary" #systemNotification></app-system-notification>
+<app-system-notification
+  [message]="'system-notifications.compatible-browsers'|translate"
+  color="tertiary"
+  #systemNotification
+></app-system-notification>
 <ion-content>
   <ion-grid class="full-height">
-    <ion-row class="ion-justify-content-center ion-align-items-center full-height">
-      <ion-col size="4">
-      </ion-col>
-      <ion-col size="12" size-lg="4">
-        <div id="portal-title" class="ion-margin-vertical">
+    <ion-row
+      class="ion-justify-content-center ion-align-items-center full-height"
+    >
+      <ion-col size="4"> </ion-col>
+      <ion-col
+        size="12"
+        size-lg="4"
+      >
+        <div
+          id="portal-title"
+          class="ion-margin-vertical"
+        >
           <div id="logo-container">
-            <img src="./assets/img/121-logo.png" alt="121">
+            <img
+              src="./assets/img/121-logo.png"
+              alt="121"
+            />
           </div>
-          <h1 class="text-uppercase">{{ 'page.login.portalTitle'|translate }}</h1>
+          <h1 class="text-uppercase">
+            {{ 'page.login.portalTitle'|translate }}
+          </h1>
         </div>
-        <ion-item *ngIf="errorStatusCode != 0" color="danger" lines="none" class="login-notification ion-margin-vertical">
-          <ng-container color="warning" [ngSwitch]="errorStatusCode">
-            <ion-text *ngSwitchCase="401" ><small><strong>{{ 'page.login.form.error-messages.401'|translate }}</strong></small></ion-text>
-            <ion-text *ngSwitchCase="500" ><small><strong>{{ 'page.login.form.error-messages.500'|translate }}</strong></small></ion-text>
+        <ion-item
+          *ngIf="errorStatusCode != 0"
+          color="danger"
+          lines="none"
+          class="login-notification ion-margin-vertical"
+        >
+          <ng-container
+            color="warning"
+            [ngSwitch]="errorStatusCode"
+          >
+            <ion-text *ngSwitchCase="401"
+              ><small
+                ><strong
+                  >{{ 'page.login.form.error-messages.401'|translate }}</strong
+                ></small
+              ></ion-text
+            >
+            <ion-text *ngSwitchCase="500"
+              ><small
+                ><strong
+                  >{{ 'page.login.form.error-messages.500'|translate }}</strong
+                ></small
+              ></ion-text
+            >
           </ng-container>
         </ion-item>
         <div class="ion-padding auth-form-container">
@@ -52,9 +88,23 @@
                   (ionBlur)="onEmailBlur()"
                 ></ion-input>
               </div>
-              <div class="validation-message"><ion-text *ngIf="invalidEmail" color="danger"><small><strong>{{ 'page.login.form.error-messages.invalid-email'|translate }}</strong></small></ion-text></div>
+              <div class="validation-message">
+                <ion-text
+                  *ngIf="invalidEmail"
+                  color="danger"
+                  ><small
+                    ><strong
+                      >{{
+                      'page.login.form.error-messages.invalid-email'|translate
+                      }}</strong
+                    ></small
+                  ></ion-text
+                >
+              </div>
             </div>
-            <div class="input-item auth-item ion-margin-bottom ion-padding-bottom">
+            <div
+              class="input-item auth-item ion-margin-bottom ion-padding-bottom"
+            >
               <label
                 color="medium"
                 class="input-item--label auth-label"
@@ -79,7 +129,19 @@
                   (ionBlur)="onPasswordBlur()"
                 ></ion-input>
               </div>
-              <div class="validation-message"><ion-text *ngIf="emptyPassword" color="danger"><small><strong>{{ 'page.login.form.error-messages.empty-password'|translate }}</strong></small></ion-text></div>
+              <div class="validation-message">
+                <ion-text
+                  *ngIf="emptyPassword"
+                  color="danger"
+                  ><small
+                    ><strong
+                      >{{
+                      'page.login.form.error-messages.empty-password'|translate
+                      }}</strong
+                    ></small
+                  ></ion-text
+                >
+              </div>
             </div>
 
             <div class="ion-margin-top ion-no-padding">
@@ -96,8 +158,7 @@
           </form>
         </div>
       </ion-col>
-      <ion-col size="4">
-      </ion-col>
+      <ion-col size="4"> </ion-col>
     </ion-row>
   </ion-grid>
 </ion-content>

--- a/interfaces/HO-Portal/src/app/login/login.page.spec.ts
+++ b/interfaces/HO-Portal/src/app/login/login.page.spec.ts
@@ -14,21 +14,19 @@ describe('LoginPage', () => {
     authenticationState$: of(null),
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [LoginPage],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        imports: [FormsModule, TranslateModule.forRoot()],
-        providers: [
-          {
-            provide: AuthService,
-            useValue: authServiceMock,
-          },
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [LoginPage],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      imports: [FormsModule, TranslateModule.forRoot()],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: authServiceMock,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LoginPage);

--- a/interfaces/HO-Portal/src/app/pages/aid-workers/aid-workers.page.html
+++ b/interfaces/HO-Portal/src/app/pages/aid-workers/aid-workers.page.html
@@ -1,12 +1,9 @@
 <app-header
-  [title]="'page.aid-workers.pageTitle'|translate" [showHome]="true"
+  [title]="'page.aid-workers.pageTitle'|translate"
+  [showHome]="true"
 ></app-header>
 <app-program-navigation></app-program-navigation>
 
 <ion-content class="ion-padding">
-
-  <app-manage-aidworkers
-    [programId]="programId"
-  ></app-manage-aidworkers>
-
+  <app-manage-aidworkers [programId]="programId"></app-manage-aidworkers>
 </ion-content>

--- a/interfaces/HO-Portal/src/app/pages/aid-workers/aid-workers.page.spec.ts
+++ b/interfaces/HO-Portal/src/app/pages/aid-workers/aid-workers.page.spec.ts
@@ -8,15 +8,13 @@ describe('AidWorkersPage', () => {
   let component: AidWorkersPage;
   let fixture: ComponentFixture<AidWorkersPage>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [AidWorkersPage],
-        imports: [TranslateModule.forRoot(), RouterTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [AidWorkersPage],
+      imports: [TranslateModule.forRoot(), RouterTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AidWorkersPage);

--- a/interfaces/HO-Portal/src/app/pages/dashboard/dashboard.page.html
+++ b/interfaces/HO-Portal/src/app/pages/dashboard/dashboard.page.html
@@ -1,42 +1,38 @@
 <app-header
-    [title]="'page.dashboard.pageTitle'|translate" [showHome]="true"
+  [title]="'page.dashboard.pageTitle'|translate"
+  [showHome]="true"
 ></app-header>
 <app-program-navigation></app-program-navigation>
 
 <ion-content class="ion-padding">
-
   <ion-grid>
     <ion-row>
       <ion-col
         [sizeXs]="12"
         [sizeLg]="3"
       >
-
         <ion-card color="light">
           <ion-card-content>
             <p class="ion-margin-vertical">
               {{ 'page.dashboard.introduction'|translate }}
 
-              <br><br>
+              <br /><br />
 
               {{ 'page.dashboard.help-explanation'|translate }}
 
-              <tooltip [value]="'page.dashboard.help-explanation-tooltip'|translate"></tooltip>
+              <tooltip
+                [value]="'page.dashboard.help-explanation-tooltip'|translate"
+              ></tooltip>
             </p>
           </ion-card-content>
         </ion-card>
-
       </ion-col>
       <ion-col
         [sizeXs]="12"
         [sizeLg]="9"
         class="horizontal-scroll-container"
       >
-
-        <app-metrics-states
-          [program]="program"
-        ></app-metrics-states>
-
+        <app-metrics-states [program]="program"></app-metrics-states>
       </ion-col>
     </ion-row>
     <ion-row>
@@ -45,32 +41,26 @@
         [sizeLg]="8"
         class="ion-margin-vertical"
       >
-
         <app-metrics-states-over-time
           [program]="program"
         ></app-metrics-states-over-time>
-
       </ion-col>
       <ion-col
         [sizeXs]="12"
         [sizeLg]="4"
         class="ion-margin-vertical"
       >
-        <app-metrics-totals
-          [program]="program"
-        ></app-metrics-totals>
+        <app-metrics-totals [program]="program"></app-metrics-totals>
       </ion-col>
     </ion-row>
   </ion-grid>
 
-  <br><br>
+  <br /><br />
 
-  <div style="max-width: 33em; margin: auto;">
+  <div style="max-width: 33em; margin: auto">
     <app-metrics
       [isCollapsed]="false"
       [program]="program"
     ></app-metrics>
   </div>
-
-
 </ion-content>

--- a/interfaces/HO-Portal/src/app/pages/dashboard/dashboard.page.spec.ts
+++ b/interfaces/HO-Portal/src/app/pages/dashboard/dashboard.page.spec.ts
@@ -13,24 +13,22 @@ describe('DashboardPage', () => {
   let component: DashboardPage;
   let fixture: ComponentFixture<DashboardPage>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [DashboardPage],
-        imports: [
-          TranslateModule.forRoot(),
-          RouterTestingModule,
-          SharedModule,
-          NoopAnimationsModule,
-        ],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          provideMagicalMock(ProgramsServiceApiService),
-          provideMagicalMock(ProgramPhaseService),
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [DashboardPage],
+      imports: [
+        TranslateModule.forRoot(),
+        RouterTestingModule,
+        SharedModule,
+        NoopAnimationsModule,
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        provideMagicalMock(ProgramsServiceApiService),
+        provideMagicalMock(ProgramPhaseService),
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DashboardPage);

--- a/interfaces/HO-Portal/src/app/pages/design/design.page.html
+++ b/interfaces/HO-Portal/src/app/pages/design/design.page.html
@@ -1,10 +1,10 @@
 <app-header
-  [title]="'page.program.phases.design.label'|translate" [showHome]="true"
+  [title]="'page.program.phases.design.label'|translate"
+  [showHome]="true"
 ></app-header>
 <app-program-navigation></app-program-navigation>
 
 <ion-content class="ion-padding">
-
   <app-phase-next
     *appIfPermissions="[Permission.ProgramPhaseUPDATE]"
     [programId]="programId"
@@ -16,5 +16,4 @@
     *appIfPermissions="[Permission.ProgramAllREAD]"
     [programId]="programId"
   ></app-program-details>
-
 </ion-content>

--- a/interfaces/HO-Portal/src/app/pages/design/design.page.spec.ts
+++ b/interfaces/HO-Portal/src/app/pages/design/design.page.spec.ts
@@ -8,15 +8,13 @@ describe('DesignPage', () => {
   let component: DesignPage;
   let fixture: ComponentFixture<DesignPage>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [DesignPage],
-        imports: [TranslateModule.forRoot(), RouterTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [DesignPage],
+      imports: [TranslateModule.forRoot(), RouterTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DesignPage);

--- a/interfaces/HO-Portal/src/app/pages/evaluation/evaluation.page.html
+++ b/interfaces/HO-Portal/src/app/pages/evaluation/evaluation.page.html
@@ -1,15 +1,14 @@
 <app-header
-    [title]="'page.program.phases.evaluation.label'|translate" [showHome]="true"
+  [title]="'page.program.phases.evaluation.label'|translate"
+  [showHome]="true"
 ></app-header>
 <app-program-navigation></app-program-navigation>
 
 <ion-content class="ion-padding">
-
   <app-phase-next
     *appIfPermissions="[Permission.ProgramPhaseUPDATE]"
     [programId]="programId"
     [thisPhaseName]="thisPhase"
     [phaseReady]="true"
   ></app-phase-next>
-
 </ion-content>

--- a/interfaces/HO-Portal/src/app/pages/evaluation/evaluation.page.spec.ts
+++ b/interfaces/HO-Portal/src/app/pages/evaluation/evaluation.page.spec.ts
@@ -8,15 +8,13 @@ describe('EvaluationPage', () => {
   let component: EvaluationPage;
   let fixture: ComponentFixture<EvaluationPage>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [EvaluationPage],
-        imports: [TranslateModule.forRoot(), RouterTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [EvaluationPage],
+      imports: [TranslateModule.forRoot(), RouterTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(EvaluationPage);

--- a/interfaces/HO-Portal/src/app/pages/inclusion/inclusion.page.spec.ts
+++ b/interfaces/HO-Portal/src/app/pages/inclusion/inclusion.page.spec.ts
@@ -10,16 +10,14 @@ describe('InclusionPage', () => {
   let component: InclusionPage;
   let fixture: ComponentFixture<InclusionPage>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [InclusionPage],
-        imports: [TranslateModule.forRoot(), RouterTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [provideMagicalMock(AuthService)],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [InclusionPage],
+      imports: [TranslateModule.forRoot(), RouterTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [provideMagicalMock(AuthService)],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(InclusionPage);

--- a/interfaces/HO-Portal/src/app/pages/payment/payment.page.html
+++ b/interfaces/HO-Portal/src/app/pages/payment/payment.page.html
@@ -1,5 +1,6 @@
 <app-header
-  [title]="'page.program.phases.payment.label'|translate" [showHome]="true"
+  [title]="'page.program.phases.payment.label'|translate"
+  [showHome]="true"
 ></app-header>
 <app-program-navigation></app-program-navigation>
 
@@ -23,5 +24,4 @@
     [thisPhase]="thisPhase"
     (isCompleted)="onReady($event)"
   ></app-program-people-affected>
-
 </ion-content>

--- a/interfaces/HO-Portal/src/app/pages/payment/payment.page.spec.ts
+++ b/interfaces/HO-Portal/src/app/pages/payment/payment.page.spec.ts
@@ -11,19 +11,17 @@ describe('PaymentPage', () => {
   let component: PaymentPage;
   let fixture: ComponentFixture<PaymentPage>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [PaymentPage],
-        imports: [TranslateModule.forRoot(), RouterTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          provideMagicalMock(ProgramsServiceApiService),
-          provideMagicalMock(AuthService),
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [PaymentPage],
+      imports: [TranslateModule.forRoot(), RouterTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        provideMagicalMock(ProgramsServiceApiService),
+        provideMagicalMock(AuthService),
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PaymentPage);

--- a/interfaces/HO-Portal/src/app/pages/registration-validation/registration-validation.page.html
+++ b/interfaces/HO-Portal/src/app/pages/registration-validation/registration-validation.page.html
@@ -42,7 +42,10 @@
               [exportType]="enumExportType.selectedForValidation"
             ></app-export-list>
           </div>
-          <div class="ion-no-padding ion-margin-end" *ngIf="hasDuplicateAttributes">
+          <div
+            class="ion-no-padding ion-margin-end"
+            *ngIf="hasDuplicateAttributes"
+          >
             <app-export-list
               *appIfPermissions="[Permission.RegistrationPersonalEXPORT]"
               [programId]="programId"

--- a/interfaces/HO-Portal/src/app/pages/registration-validation/registration-validation.page.spec.ts
+++ b/interfaces/HO-Portal/src/app/pages/registration-validation/registration-validation.page.spec.ts
@@ -13,24 +13,22 @@ describe('RegistrationValidationPage', () => {
   let component: RegistrationValidationPage;
   let fixture: ComponentFixture<RegistrationValidationPage>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [RegistrationValidationPage],
-        imports: [
-          TranslateModule.forRoot(),
-          RouterTestingModule,
-          HttpClientTestingModule,
-        ],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          provideMagicalMock(AuthService),
-          provideMagicalMock(ProgramsServiceApiService),
-          provideMagicalMock(ProgramPhaseService),
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [RegistrationValidationPage],
+      imports: [
+        TranslateModule.forRoot(),
+        RouterTestingModule,
+        HttpClientTestingModule,
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        provideMagicalMock(AuthService),
+        provideMagicalMock(ProgramsServiceApiService),
+        provideMagicalMock(ProgramPhaseService),
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RegistrationValidationPage);

--- a/interfaces/HO-Portal/src/app/program/bulk-import/bulk-import.component.html
+++ b/interfaces/HO-Portal/src/app/program/bulk-import/bulk-import.component.html
@@ -3,24 +3,36 @@
     <confirm-prompt
       [disabled]="isInProgress"
       (confirm)="importPeopleAffected($event, PaStatus.imported)"
-      [subHeader]="'page.program.bulk-import.imported.confirm-message'|translate"
+      [subHeader]="
+        'page.program.bulk-import.imported.confirm-message' | translate
+      "
       [message]="message?.imported"
       [filePickerProps]="filePickerProps?.imported"
     >
-      <ion-icon name="cloud-upload" slot="start" aria-hidden="true"></ion-icon>
-      {{ 'page.program.bulk-import.imported.btn-text'|translate }}
+      <ion-icon
+        name="cloud-upload"
+        slot="start"
+        aria-hidden="true"
+      ></ion-icon>
+      {{ 'page.program.bulk-import.imported.btn-text' | translate }}
     </confirm-prompt>
   </div>
   <div class="ion-no-padding">
     <confirm-prompt
       [disabled]="isInProgress"
       (confirm)="importPeopleAffected($event, PaStatus.registered)"
-      [subHeader]="'page.program.bulk-import.registered.confirm-message'|translate"
+      [subHeader]="
+        'page.program.bulk-import.registered.confirm-message' | translate
+      "
       [message]="message?.registered"
       [filePickerProps]="filePickerProps?.registered"
     >
-      <ion-icon name="cloud-upload" slot="start" aria-hidden="true"></ion-icon>
-      {{ 'page.program.bulk-import.registered.btn-text'|translate }}
+      <ion-icon
+        name="cloud-upload"
+        slot="start"
+        aria-hidden="true"
+      ></ion-icon>
+      {{ 'page.program.bulk-import.registered.btn-text' | translate }}
     </confirm-prompt>
   </div>
   <ion-spinner

--- a/interfaces/HO-Portal/src/app/program/bulk-import/bulk-import.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/bulk-import/bulk-import.component.spec.ts
@@ -10,19 +10,17 @@ describe('BulkImportComponent', () => {
   let component: BulkImportComponent;
   let fixture: ComponentFixture<BulkImportComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [BulkImportComponent],
-        imports: [TranslateModule.forRoot()],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          provideMagicalMock(AuthService),
-          provideMagicalMock(ProgramsServiceApiService),
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [BulkImportComponent],
+      imports: [TranslateModule.forRoot()],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        provideMagicalMock(AuthService),
+        provideMagicalMock(ProgramsServiceApiService),
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(BulkImportComponent);

--- a/interfaces/HO-Portal/src/app/program/disable-registration/disable-registration.component.html
+++ b/interfaces/HO-Portal/src/app/program/disable-registration/disable-registration.component.html
@@ -2,7 +2,12 @@
   *ngIf="program"
   class="ion-align-items-center"
 >
-  <ion-label>{{ 'page.program.phases.registrationValidation.toggleText-enable-registrations'|translate }} </ion-label>
+  <ion-label>
+    {{
+      'page.program.phases.registrationValidation.toggleText-enable-registrations'
+        | translate
+    }}
+  </ion-label>
   <ion-toggle
     [(ngModel)]="publishedStatus"
     (click)="updateRegistrationStatus()"

--- a/interfaces/HO-Portal/src/app/program/disable-registration/disable-registration.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/disable-registration/disable-registration.component.spec.ts
@@ -11,19 +11,17 @@ describe('DisableRegistrationComponent', () => {
   let component: DisableRegistrationComponent;
   let fixture: ComponentFixture<DisableRegistrationComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [DisableRegistrationComponent],
-        imports: [TranslateModule.forRoot(), RouterTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          provideMagicalMock(AuthService),
-          provideMagicalMock(ProgramsServiceApiService),
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [DisableRegistrationComponent],
+      imports: [TranslateModule.forRoot(), RouterTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        provideMagicalMock(AuthService),
+        provideMagicalMock(ProgramsServiceApiService),
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DisableRegistrationComponent);

--- a/interfaces/HO-Portal/src/app/program/edit-person-affected-popup/edit-person-affected-popup.component.html
+++ b/interfaces/HO-Portal/src/app/program/edit-person-affected-popup/edit-person-affected-popup.component.html
@@ -12,7 +12,11 @@
         [attr.title]="'common.cancel' | translate"
         [attr.aria-label]="'common.cancel' | translate"
       >
-        <ion-icon name="close" slot="icon-only" aria-hidden="true"></ion-icon>
+        <ion-icon
+          name="close"
+          slot="icon-only"
+          aria-hidden="true"
+        ></ion-icon>
       </ion-button>
     </ion-buttons>
   </ion-toolbar>
@@ -109,7 +113,10 @@
       </ng-container>
     </div>
   </section>
-  <section *ngIf="canViewPersonalData" class="ion-margin-vertical">
+  <section
+    *ngIf="canViewPersonalData"
+    class="ion-margin-vertical"
+  >
     <h4 class="text-bold">
       {{
         'page.program.program-people-affected.edit-person-affected-popup.note.section-title'
@@ -146,7 +153,10 @@
                 }
         }}
       </ion-note>
-      <div *ngIf="canUpdatePersonalData" class="ml-auto">
+      <div
+        *ngIf="canUpdatePersonalData"
+        class="ml-auto"
+      >
         <ion-button
           (click)="saveNote()"
           [disabled]="inProgress?.note || false"

--- a/interfaces/HO-Portal/src/app/program/edit-person-affected-popup/edit-person-affected-popup.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/edit-person-affected-popup/edit-person-affected-popup.component.spec.ts
@@ -18,22 +18,20 @@ describe('EditPersonAffectedPopupComponent', () => {
   let component: EditPersonAffectedPopupComponent;
   let fixture: ComponentFixture<EditPersonAffectedPopupComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [EditPersonAffectedPopupComponent],
-        imports: [TranslateModule.forRoot(), HttpClientTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          {
-            provide: ModalController,
-            useValue: modalCtrlSpy,
-          },
-          provideMagicalMock(ProgramsServiceApiService),
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [EditPersonAffectedPopupComponent],
+      imports: [TranslateModule.forRoot(), HttpClientTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        {
+          provide: ModalController,
+          useValue: modalCtrlSpy,
+        },
+        provideMagicalMock(ProgramsServiceApiService),
+      ],
+    }).compileComponents();
+  }));
 
   let mockProgramsApi: jasmine.SpyObj<any>;
 

--- a/interfaces/HO-Portal/src/app/program/export-duplicates-popup/export-duplicates-popup.component.html
+++ b/interfaces/HO-Portal/src/app/program/export-duplicates-popup/export-duplicates-popup.component.html
@@ -1,46 +1,64 @@
 <ion-header>
-    <ion-toolbar>
-      <ion-title>{{ 'common.confirm'|translate }}</ion-title>
-      <ion-buttons slot="end">
-        <ion-button (click)="closeModal()" [attr.title]="'common.cancel'|translate"
-          [attr.aria-label]="'common.cancel'|translate">
-          <ion-icon name="close" slot="icon-only" aria-hidden="true"></ion-icon>
-        </ion-button>
-      </ion-buttons>
-    </ion-toolbar>
-  </ion-header>
+  <ion-toolbar>
+    <ion-title>{{ 'common.confirm' | translate }}</ion-title>
+    <ion-buttons slot="end">
+      <ion-button
+        (click)="closeModal()"
+        [attr.title]="'common.cancel' | translate"
+        [attr.aria-label]="'common.cancel' | translate"
+      >
+        <ion-icon
+          name="close"
+          slot="icon-only"
+          aria-hidden="true"
+        ></ion-icon>
+      </ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
 
-  <ion-content class="ion-padding">
-    <h2>{{ 'page.program.export-list.duplicates.confirm-message'|translate }}</h2>
-    <p *ngIf="!!duplicateAttributesProps.attributes">
-      {{ 'page.program.export-list.duplicates.basedOn'|translate:{
-           duplicateAttributes: duplicateAttributesProps.attributes.join(', ') + '.'
-         } }}
-    </p>
-    <p *ngIf="duplicateAttributesProps.timestamp">
-      {{ 'page.program.export-list.timestamp'|translate:{ dateTime: duplicateAttributesProps.timestamp } }}
-    </p>
-    <p>{{ 'page.program.export-list.duplicates.canTakeFewMinutes'|translate }}</p>
-  </ion-content>
+<ion-content class="ion-padding">
+  <h2>
+    {{ 'page.program.export-list.duplicates.confirm-message' | translate }}
+  </h2>
+  <p *ngIf="!!duplicateAttributesProps.attributes">
+    {{
+      'page.program.export-list.duplicates.basedOn'
+        | translate
+          : {
+              duplicateAttributes:
+                duplicateAttributesProps.attributes.join(', ') + '.'
+            }
+    }}
+  </p>
+  <p *ngIf="duplicateAttributesProps.timestamp">
+    {{
+      'page.program.export-list.timestamp'
+        | translate: { dateTime: duplicateAttributesProps.timestamp }
+    }}
+  </p>
+  <p>
+    {{ 'page.program.export-list.duplicates.canTakeFewMinutes' | translate }}
+  </p>
+</ion-content>
 
-  <ion-footer>
-    <ion-toolbar>
-      <ion-buttons slot="primary">
-        <ion-button
-          fill="clear"
-          color="danger"
-          (click)="closeModal()"
-        >
-          {{ 'common.cancel'|translate }}
-        </ion-button>
-        <ion-button
-          fill="solid"
-          color="primary"
-          (click)="submitConfirm()"
-        >
-          {{ 'common.ok'|translate }}
-        </ion-button>
-      </ion-buttons>
-
-    </ion-toolbar>
-  </ion-footer>
+<ion-footer>
+  <ion-toolbar>
+    <ion-buttons slot="primary">
+      <ion-button
+        fill="clear"
+        color="danger"
+        (click)="closeModal()"
+      >
+        {{ 'common.cancel' | translate }}
+      </ion-button>
+      <ion-button
+        fill="solid"
+        color="primary"
+        (click)="submitConfirm()"
+      >
+        {{ 'common.ok' | translate }}
+      </ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-footer>

--- a/interfaces/HO-Portal/src/app/program/export-fsp-instructions/export-fsp-instructions.component.html
+++ b/interfaces/HO-Portal/src/app/program/export-fsp-instructions/export-fsp-instructions.component.html
@@ -1,5 +1,5 @@
 <div
-  style="display: inline-flex;"
+  style="display: inline-flex"
   class="ion-align-items-center"
 >
   <confirm-prompt
@@ -8,7 +8,11 @@
     [subHeader]="subHeader"
     [message]="message"
   >
-    <ion-icon name="download" slot="start" aria-hidden="true"></ion-icon>
+    <ion-icon
+      name="download"
+      slot="start"
+      aria-hidden="true"
+    ></ion-icon>
     {{ btnText }}
   </confirm-prompt>
   <ion-spinner

--- a/interfaces/HO-Portal/src/app/program/export-fsp-instructions/export-fsp-instructions.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/export-fsp-instructions/export-fsp-instructions.component.spec.ts
@@ -13,20 +13,18 @@ describe('ExportFspInstructionsComponent', () => {
 
   const mockProgramId = 1;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ExportFspInstructionsComponent],
-        imports: [
-          TranslateModule.forRoot(),
-          HttpClientTestingModule,
-          RouterTestingModule,
-        ],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [provideMagicalMock(ProgramsServiceApiService)],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ExportFspInstructionsComponent],
+      imports: [
+        TranslateModule.forRoot(),
+        HttpClientTestingModule,
+        RouterTestingModule,
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [provideMagicalMock(ProgramsServiceApiService)],
+    }).compileComponents();
+  }));
 
   let mockProgramsApi: jasmine.SpyObj<any>;
 

--- a/interfaces/HO-Portal/src/app/program/export-list/export-list.component.html
+++ b/interfaces/HO-Portal/src/app/program/export-list/export-list.component.html
@@ -5,7 +5,11 @@
   [message]="message"
   [duplicateAttributesProps]="duplicateAttributesProps"
 >
-  <ion-icon name="download" slot="start" aria-hidden="true"></ion-icon>
+  <ion-icon
+    name="download"
+    slot="start"
+    aria-hidden="true"
+  ></ion-icon>
   {{ btnText }}
 </confirm-prompt>
 <ion-spinner

--- a/interfaces/HO-Portal/src/app/program/export-list/export-list.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/export-list/export-list.component.spec.ts
@@ -13,19 +13,17 @@ describe('ExportListComponent', () => {
 
   const mockProgramId = 1;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ExportListComponent],
-        imports: [TranslateModule.forRoot(), HttpClientTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          provideMagicalMock(AuthService),
-          provideMagicalMock(ProgramsServiceApiService),
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ExportListComponent],
+      imports: [TranslateModule.forRoot(), HttpClientTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        provideMagicalMock(AuthService),
+        provideMagicalMock(ProgramsServiceApiService),
+      ],
+    }).compileComponents();
+  }));
 
   let mockProgramsApi: jasmine.SpyObj<any>;
 

--- a/interfaces/HO-Portal/src/app/program/make-payment/make-payment.component.html
+++ b/interfaces/HO-Portal/src/app/program/make-payment/make-payment.component.html
@@ -1,7 +1,9 @@
 <ion-row class="ion-align-items-center">
-
   <ion-note class="ion-margin-end">
-    {{ 'page.program.program-payout.make-payment.number-included'|translate:{ number: totalIncluded >= 0 ? totalIncluded : '?' } }}
+    {{
+      'page.program.program-payout.make-payment.number-included'
+        | translate: { number: totalIncluded >= 0 ? totalIncluded : '?' }
+    }}
   </ion-note>
 
   <ion-item
@@ -9,7 +11,7 @@
     class="ion-margin-end"
   >
     <ion-label position="stacked">
-      {{ 'page.program.program-details.fixedTransferValue'|translate }}
+      {{ 'page.program.program-details.fixedTransferValue' | translate }}
     </ion-label>
     <ion-input
       type="number"
@@ -31,24 +33,29 @@
     [subHeader]="totalIncludedMessage"
     [message]="totalAmountMessage"
   >
-    {{ 'page.program.program-payout.start-payout'|translate }}
+    {{ 'page.program.program-payout.start-payout' | translate }}
   </confirm-prompt>
   <div
     *ngIf="paymentInProgress"
     class="ion-margin-start ion-align-items-center"
-    style="display: flex;"
+    style="display: flex"
   >
     <ion-note>
-      {{ 'page.program.program-payout.in-progress'|translate }}
+      {{ 'page.program.program-payout.in-progress' | translate }}
     </ion-note>
     <ion-button
       size="small"
       fill="clear"
-      [title]="'common.update'|translate"
-      [attr.aria-label]="'common.update'|translate"
+      [title]="'common.update' | translate"
+      [attr.aria-label]="'common.update' | translate"
       (click)="refresh()"
     >
-      <ion-icon name="refresh" size="small" slot="icon-only" aria-hidden="true"></ion-icon>
+      <ion-icon
+        name="refresh"
+        size="small"
+        slot="icon-only"
+        aria-hidden="true"
+      ></ion-icon>
     </ion-button>
   </div>
 
@@ -57,5 +64,4 @@
     color="primary"
     class="ion-margin-start"
   ></ion-spinner>
-
 </ion-row>

--- a/interfaces/HO-Portal/src/app/program/make-payment/make-payment.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/make-payment/make-payment.component.spec.ts
@@ -9,20 +9,18 @@ describe('MakePaymentComponent', () => {
   let component: MakePaymentComponent;
   let fixture: ComponentFixture<MakePaymentComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MakePaymentComponent],
-        imports: [
-          TranslateModule.forRoot(),
-          RouterTestingModule,
-          HttpClientTestingModule,
-        ],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MakePaymentComponent],
+      imports: [
+        TranslateModule.forRoot(),
+        RouterTestingModule,
+        HttpClientTestingModule,
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MakePaymentComponent);

--- a/interfaces/HO-Portal/src/app/program/manage-aidworkers/manage-aidworkers.component.html
+++ b/interfaces/HO-Portal/src/app/program/manage-aidworkers/manage-aidworkers.component.html
@@ -1,5 +1,5 @@
-<h2>{{ 'page.program.manage-aidworkers.section-title'|translate }}</h2>
-<h4>{{ 'page.program.manage-aidworkers.view-aidworkers'|translate }}</h4>
+<h2>{{ 'page.program.manage-aidworkers.section-title' | translate }}</h2>
+<h4>{{ 'page.program.manage-aidworkers.view-aidworkers' | translate }}</h4>
 
 <ngx-datatable
   class="bootstrap"
@@ -15,7 +15,7 @@
   [rows]="aidworkers"
 >
   <ngx-datatable-column
-    *ngFor="let column of columns; let i = index;"
+    *ngFor="let column of columns; let i = index"
     [name]="column.name"
     [prop]="column.prop"
     [sortable]="column.sortable"
@@ -30,12 +30,16 @@
       <ng-container *ngIf="column.prop === 'delete'; else elseBlock">
         <confirm-prompt
           (confirm)="deleteAidworker(row)"
-          [message]="'page.program.manage-aidworkers.column-delete'|translate"
+          [message]="'page.program.manage-aidworkers.column-delete' | translate"
           [disabled]="disableDelete(row)"
           size="small"
           fill="outline"
         >
-          <ion-icon size="small" slot="icon-only" name="trash"></ion-icon>
+          <ion-icon
+            size="small"
+            slot="icon-only"
+            name="trash"
+          ></ion-icon>
         </confirm-prompt>
       </ng-container>
       <ng-template #elseBlock>
@@ -45,14 +49,17 @@
   </ngx-datatable-column>
 </ngx-datatable>
 
-<h4>{{ 'page.program.manage-aidworkers.create-aidworker'|translate }}</h4>
+<h4>{{ 'page.program.manage-aidworkers.create-aidworker' | translate }}</h4>
 
 <form (ngSubmit)="addAidworker()">
-  <input type="submit" hidden /><!-- Include hidden submit-button to enable "enter"-key to trigger ngSubmit -->
+  <input
+    type="submit"
+    hidden
+  /><!-- Include hidden submit-button to enable "enter"-key to trigger ngSubmit -->
   <ion-row class="ion-align-items-center">
     <ion-item>
       <ion-label position="stacked">
-        {{ 'page.program.manage-aidworkers.email'|translate }}
+        {{ 'page.program.manage-aidworkers.email' | translate }}
       </ion-label>
       <ion-input
         type="email"
@@ -69,13 +76,20 @@
       ngDefaultControl
       autocomplete="new-password"
       [minLength]="passwordMinLength"
-      [labelShow]="'password-toggle.show'|translate"
-      [labelHide]="'password-toggle.hide'|translate"
-      [label]="'page.program.manage-aidworkers.create-password'|translate:{ minimalLength: passwordMinLength }"
+      [labelShow]="'password-toggle.show' | translate"
+      [labelHide]="'password-toggle.hide' | translate"
+      [label]="
+        'page.program.manage-aidworkers.create-password'
+          | translate: { minimalLength: passwordMinLength }
+      "
     ></password-toggle-input>
     <ion-button type="submit">
-      <ion-icon name="person-add" size="small" slot="start"></ion-icon>
-      {{ 'page.program.manage-aidworkers.confirm'|translate }}
+      <ion-icon
+        name="person-add"
+        size="small"
+        slot="start"
+      ></ion-icon>
+      {{ 'page.program.manage-aidworkers.confirm' | translate }}
     </ion-button>
   </ion-row>
 </form>

--- a/interfaces/HO-Portal/src/app/program/manage-aidworkers/manage-aidworkers.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/manage-aidworkers/manage-aidworkers.component.spec.ts
@@ -13,16 +13,14 @@ describe('ManageAidworkersComponent', () => {
 
   const mockProgramId = 1;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ManageAidworkersComponent],
-        imports: [TranslateModule.forRoot()],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [provideMagicalMock(ProgramsServiceApiService)],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ManageAidworkersComponent],
+      imports: [TranslateModule.forRoot()],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [provideMagicalMock(ProgramsServiceApiService)],
+    }).compileComponents();
+  }));
 
   let mockProgramsApi: jasmine.SpyObj<any>;
 

--- a/interfaces/HO-Portal/src/app/program/metrics-states-over-time/metrics-states-over-time.component.html
+++ b/interfaces/HO-Portal/src/app/program/metrics-states-over-time/metrics-states-over-time.component.html
@@ -4,8 +4,9 @@
 ></app-refresh-data>
 
 <div class="chart-container">
-
-  <tooltip [value]="'page.program.metrics.over-time.tooltip'|translate"></tooltip>
+  <tooltip
+    [value]="'page.program.metrics.over-time.tooltip' | translate"
+  ></tooltip>
   <ngx-charts-bar-vertical-stacked
     [scheme]="'ocean'"
     [results]="chartData"
@@ -16,10 +17,9 @@
     [legendTitle]="''"
     [legendPosition]="'bottom'"
     [showXAxisLabel]="true"
-    [xAxisLabel]="'page.program.metrics.over-time.payment-label'|translate"
+    [xAxisLabel]="'page.program.metrics.over-time.payment-label' | translate"
     [showYAxisLabel]="false"
     [showGridLines]="true"
     [showDataLabel]="false"
   ></ngx-charts-bar-vertical-stacked>
-
 </div>

--- a/interfaces/HO-Portal/src/app/program/metrics-states-over-time/metrics-states-over-time.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/metrics-states-over-time/metrics-states-over-time.component.spec.ts
@@ -42,21 +42,19 @@ describe('MetricsStatesOverTimeComponent', () => {
 
   const fixtureProgram = apiProgramsMock.programs[0];
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MetricsStatesOverTimeComponent, TestHostComponent],
-        imports: [
-          TranslateModule.forRoot(),
-          FormsModule,
-          SharedModule,
-          NoopAnimationsModule,
-        ],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [provideMagicalMock(PastPaymentsService)],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MetricsStatesOverTimeComponent, TestHostComponent],
+      imports: [
+        TranslateModule.forRoot(),
+        FormsModule,
+        SharedModule,
+        NoopAnimationsModule,
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [provideMagicalMock(PastPaymentsService)],
+    }).compileComponents();
+  }));
 
   let mockPastPaymentsService: jasmine.SpyObj<any>;
 

--- a/interfaces/HO-Portal/src/app/program/metrics-states/metrics-states.component.html
+++ b/interfaces/HO-Portal/src/app/program/metrics-states/metrics-states.component.html
@@ -4,7 +4,7 @@
       (click)="exportCSV()"
       size="small"
     >
-      {{ 'page.program.metrics.export-button.label'|translate }}
+      {{ 'page.program.metrics.export-button.label' | translate }}
     </ion-button>
   </ion-col>
   <ion-col class="ion-text-end">
@@ -18,8 +18,11 @@
   <ion-col size="12">
     <table class="metrics-states--table">
       <colgroup>
-        <col>
-        <col [span]="paStates.length" class="state-col">
+        <col />
+        <col
+          [span]="paStates.length"
+          class="state-col"
+        />
       </colgroup>
       <thead>
         <tr>
@@ -32,7 +35,7 @@
             <span *ngIf="!col.explanation">{{ col.label }}</span>
             <span *ngIf="col.explanation">
               <tooltip [value]="col.explanation"></tooltip>
-              <br>
+              <br />
               {{ col.label }}
             </span>
           </th>
@@ -44,43 +47,71 @@
             scope="row"
             class="row-header"
           >
-            {{ 'page.program.metrics.timeframe.payment.label'|translate }}
-            <tooltip [value]="'page.program.metrics.timeframe.payment.explanation'|translate"></tooltip>
+            {{ 'page.program.metrics.timeframe.payment.label' | translate }}
+            <tooltip
+              [value]="
+                'page.program.metrics.timeframe.payment.explanation' | translate
+              "
+            ></tooltip>
             <select
               name="time-payment"
               [(ngModel)]="chosenPayment"
               (change)="changeDataset(chosenPayment, 'forPayment')"
               class="styled-select timeframe-select"
-              [title]="'page.program.metrics.timeframe.payment.select-hint'|translate"
+              [title]="
+                'page.program.metrics.timeframe.payment.select-hint' | translate
+              "
             >
               <option value="">
-                {{ 'page.program.metrics.timeframe.payment.select-hint'|translate }}
+                {{
+                  'page.program.metrics.timeframe.payment.select-hint'
+                    | translate
+                }}
               </option>
               <option
                 *ngFor="let item of pastPayments"
                 [value]="item.value"
               >
-                {{ 'page.program.metrics.timeframe.payment.option'|translate:{ number: item.id, date: item.date|date:'yyyy-MM-dd' } }}
+                {{
+                  'page.program.metrics.timeframe.payment.option'
+                    | translate
+                      : {
+                          number: item.id,
+                          date: item.date | date: 'yyyy-MM-dd'
+                        }
+                }}
               </option>
             </select>
           </th>
           <td
             *ngFor="let cell of paStates"
             class="cell-number"
-          >{{ cell.forPayment }}</td>
+          >
+            {{ cell.forPayment }}
+          </td>
         </tr>
         <tr>
           <th
             scope="row"
             class="row-header"
           >
-            {{ 'page.program.metrics.timeframe.payment-from-start.label'|translate }}
-            <tooltip [value]="'page.program.metrics.timeframe.payment-from-start.explanation'|translate"></tooltip>
+            {{
+              'page.program.metrics.timeframe.payment-from-start.label'
+                | translate
+            }}
+            <tooltip
+              [value]="
+                'page.program.metrics.timeframe.payment-from-start.explanation'
+                  | translate
+              "
+            ></tooltip>
           </th>
           <td
             *ngFor="let cell of paStates"
             class="cell-number"
-          >{{ cell.forPaymentFromStart }}</td>
+          >
+            {{ cell.forPaymentFromStart }}
+          </td>
         </tr>
       </tbody>
       <tbody class="border-bottom">
@@ -89,43 +120,68 @@
             scope="row"
             class="row-header"
           >
-            {{ 'page.program.metrics.timeframe.calendar-month.label'|translate }}
-            <tooltip [value]="'page.program.metrics.timeframe.calendar-month.explanation'|translate"></tooltip>
+            {{
+              'page.program.metrics.timeframe.calendar-month.label' | translate
+            }}
+            <tooltip
+              [value]="
+                'page.program.metrics.timeframe.calendar-month.explanation'
+                  | translate
+              "
+            ></tooltip>
             <select
               name="time-calendar-month"
               [(ngModel)]="chosenMonth"
               (change)="changeDataset(chosenMonth, 'forMonth')"
               class="styled-select timeframe-select"
-              [title]="'page.program.metrics.timeframe.calendar-month.select-hint'|translate"
+              [title]="
+                'page.program.metrics.timeframe.calendar-month.select-hint'
+                  | translate
+              "
             >
               <option value="">
-                {{ 'page.program.metrics.timeframe.calendar-month.select-hint'|translate }}
+                {{
+                  'page.program.metrics.timeframe.calendar-month.select-hint'
+                    | translate
+                }}
               </option>
               <option
                 *ngFor="let item of pastMonths"
                 [value]="item.value"
               >
-                {{ item.date|date:'yyyy-MM' }}
+                {{ item.date | date: 'yyyy-MM' }}
               </option>
             </select>
           </th>
           <td
             *ngFor="let cell of paStates"
             class="cell-number"
-          >{{ cell.forMonth }}</td>
+          >
+            {{ cell.forMonth }}
+          </td>
         </tr>
         <tr>
           <th
             scope="row"
             class="row-header"
           >
-            {{ 'page.program.metrics.timeframe.month-from-start.label'|translate }}
-            <tooltip [value]="'page.program.metrics.timeframe.month-from-start.explanation'|translate"></tooltip>
+            {{
+              'page.program.metrics.timeframe.month-from-start.label'
+                | translate
+            }}
+            <tooltip
+              [value]="
+                'page.program.metrics.timeframe.month-from-start.explanation'
+                  | translate
+              "
+            ></tooltip>
           </th>
           <td
             *ngFor="let cell of paStates"
             class="cell-number"
-          >{{ cell.forMonthFromStart }}</td>
+          >
+            {{ cell.forMonthFromStart }}
+          </td>
         </tr>
       </tbody>
       <tbody>
@@ -134,16 +190,21 @@
             scope="row"
             class="row-header"
           >
-            {{ 'page.program.metrics.timeframe.to-date.label'|translate }}
-            <tooltip [value]="'page.program.metrics.timeframe.to-date.explanation'|translate"></tooltip>
+            {{ 'page.program.metrics.timeframe.to-date.label' | translate }}
+            <tooltip
+              [value]="
+                'page.program.metrics.timeframe.to-date.explanation' | translate
+              "
+            ></tooltip>
           </th>
           <td
             *ngFor="let cell of paStates"
             class="cell-number"
-          >{{ cell.toDate }}</td>
+          >
+            {{ cell.toDate }}
+          </td>
         </tr>
       </tbody>
     </table>
   </ion-col>
 </ion-row>
-

--- a/interfaces/HO-Portal/src/app/program/metrics-states/metrics-states.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/metrics-states/metrics-states.component.spec.ts
@@ -64,19 +64,17 @@ describe('MetricsStatesComponent', () => {
     },
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MetricsStatesComponent, TestHostComponent],
-        imports: [TranslateModule.forRoot(), FormsModule, SharedModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          provideMagicalMock(ProgramsServiceApiService),
-          provideMagicalMock(PastPaymentsService),
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MetricsStatesComponent, TestHostComponent],
+      imports: [TranslateModule.forRoot(), FormsModule, SharedModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        provideMagicalMock(ProgramsServiceApiService),
+        provideMagicalMock(PastPaymentsService),
+      ],
+    }).compileComponents();
+  }));
 
   let mockProgramsApi: jasmine.SpyObj<any>;
   let mockPastPaymentsService: jasmine.SpyObj<any>;

--- a/interfaces/HO-Portal/src/app/program/metrics-totals/metrics-totals.component.html
+++ b/interfaces/HO-Portal/src/app/program/metrics-totals/metrics-totals.component.html
@@ -5,7 +5,10 @@
 
 <table class="metrics-totals--table">
   <tr>
-    <th scope="row" class="ion-padding ion-text-start shaded">
+    <th
+      scope="row"
+      class="ion-padding ion-text-start shaded"
+    >
       {{ 'page.program.metrics.totals.total-helped-to-date' | translate }}
       <tooltip
         [value]="'page.program.metrics.totals.tooltip' | translate"

--- a/interfaces/HO-Portal/src/app/program/metrics-totals/metrics-totals.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/metrics-totals/metrics-totals.component.spec.ts
@@ -45,21 +45,19 @@ describe('MetricsTotalsComponent', () => {
 
   const fixtureProgram = apiProgramsMock.programs[0];
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MetricsTotalsComponent, TestHostComponent],
-        imports: [
-          TranslateModule.forRoot(),
-          FormsModule,
-          SharedModule,
-          NoopAnimationsModule,
-        ],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [provideMagicalMock(ProgramsServiceApiService)],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MetricsTotalsComponent, TestHostComponent],
+      imports: [
+        TranslateModule.forRoot(),
+        FormsModule,
+        SharedModule,
+        NoopAnimationsModule,
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [provideMagicalMock(ProgramsServiceApiService)],
+    }).compileComponents();
+  }));
 
   let mockProgramsApi: jasmine.SpyObj<any>;
 

--- a/interfaces/HO-Portal/src/app/program/metrics/metrics.component.html
+++ b/interfaces/HO-Portal/src/app/program/metrics/metrics.component.html
@@ -1,19 +1,20 @@
-
-<div class="metrics" [ngClass]="{ 'is-collapsed': isCollapsed }">
-
+<div
+  class="metrics"
+  [ngClass]="{ 'is-collapsed': isCollapsed }"
+>
   <table class="metrics--table">
     <thead>
       <th class="metrics--cell-icon">&nbsp;</th>
       <th class="metrics--cell-label ion-text-start">
-        {{ 'page.program.metrics.header.metric'|translate }}
+        {{ 'page.program.metrics.header.metric' | translate }}
       </th>
       <th class="metrics--cell-value ion-text-end">
-        {{ 'page.program.metrics.header.latest-value'|translate }}
+        {{ 'page.program.metrics.header.latest-value' | translate }}
       </th>
     </thead>
     <tbody>
       <ng-container *ngFor="let metric of metricList">
-        <tr [class]="(metric.group) ? 'metrics--group-' + metric.group : ''">
+        <tr [class]="metric.group ? 'metrics--group-' + metric.group : ''">
           <td class="metrics--cell-icon">
             <ion-icon
               *ngIf="metric.icon"
@@ -22,7 +23,7 @@
             ></ion-icon>
           </td>
           <td class="metrics--cell-label">
-            {{ metric.label|translate }}
+            {{ metric.label | translate }}
           </td>
           <td class="metrics--cell-value ion-text-end">
             {{ metric.value }}
@@ -32,10 +33,7 @@
     </tbody>
   </table>
 
-
-  <div
-    *ngIf="!isCollapsed"
-  >
+  <div *ngIf="!isCollapsed">
     <app-refresh-data
       [lastUpdated]="lastUpdated"
       (refresh)="update()"

--- a/interfaces/HO-Portal/src/app/program/metrics/metrics.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/metrics/metrics.component.spec.ts
@@ -17,16 +17,14 @@ describe('MetricsComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let testHost: TestHostComponent;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MetricsComponent, TestHostComponent],
-        imports: [TranslateModule.forRoot()],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [provideMagicalMock(TranslatableStringService)],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MetricsComponent, TestHostComponent],
+      imports: [TranslateModule.forRoot()],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [provideMagicalMock(TranslatableStringService)],
+    }).compileComponents();
+  }));
 
   let mockTranslatableStringService: jasmine.SpyObj<any>;
 

--- a/interfaces/HO-Portal/src/app/program/payment-history-popup/payment-history-popup.component.html
+++ b/interfaces/HO-Portal/src/app/program/payment-history-popup/payment-history-popup.component.html
@@ -12,7 +12,11 @@
         [attr.title]="'common.cancel' | translate"
         [attr.aria-label]="'common.cancel' | translate"
       >
-        <ion-icon name="close" slot="icon-only" aria-hidden="true"></ion-icon>
+        <ion-icon
+          name="close"
+          slot="icon-only"
+          aria-hidden="true"
+        ></ion-icon>
       </ion-button>
     </ion-buttons>
   </ion-toolbar>
@@ -22,10 +26,22 @@
   <h3>{{ paDisplayName }}</h3>
   <ion-grid>
     <ion-col>
-      <ion-row *ngFor="let paymentRow of paymentRows" class="full-width ion-justify-content-between ion-padding-bottom ion-margin-vertical">
+      <ion-row
+        *ngFor="let paymentRow of paymentRows"
+        class="full-width ion-justify-content-between ion-padding-bottom ion-margin-vertical"
+      >
         <div>
           <h5 class="ion-no-margin">Payment #{{ paymentRow.paymentIndex }}</h5>
-          <ion-text *ngIf="paymentRow.transaction?.status" [color]="paymentRow.transaction?.status === 'success' ? 'dark' : 'danger'">{{ 'page.program.program-payout.last-payment.' + paymentRow.transaction?.status | translate }}</ion-text>
+          <ion-text
+            *ngIf="paymentRow.transaction?.status"
+            [color]="
+              paymentRow.transaction?.status === 'success' ? 'dark' : 'danger'
+            "
+            >{{
+              'page.program.program-payout.last-payment.' +
+                paymentRow.transaction?.status | translate
+            }}</ion-text
+          >
         </div>
         <ng-container *ngIf="paymentRow.transaction">
           <button
@@ -33,14 +49,23 @@
             (click)="rowClick(paymentRow)"
             [ngClass]="{
               'is-error': hasError(paymentRow),
-              'no-action': !hasVoucherSupport(paymentRow.fsp) && !hasError(paymentRow),
+              'no-action':
+                !hasVoucherSupport(paymentRow.fsp) && !hasError(paymentRow),
               'ion-no-padding popup-button': true
             }"
           >
             {{ paymentRow.text }}
-            <div style="display: flex;" class="ion-justify-content-center ion-align-items-center">
+            <div
+              style="display: flex"
+              class="ion-justify-content-center ion-align-items-center"
+            >
               {{ paymentRow.amount }}
-              <span *ngIf="paymentRow.hasMessageIcon || paymentRow.hasMoneyIconTable">&nbsp;</span>
+              <span
+                *ngIf="
+                  paymentRow.hasMessageIcon || paymentRow.hasMoneyIconTable
+                "
+                >&nbsp;</span
+              >
               <ion-icon
                 *ngIf="paymentRow.hasMessageIcon"
                 name="mail"
@@ -57,9 +82,7 @@
           </button>
         </ng-container>
 
-        <ng-container
-          *ngIf="enableSinglePayment(personRow, paymentRow)"
-        >
+        <ng-container *ngIf="enableSinglePayment(personRow, paymentRow)">
           <button
             type="button"
             (click)="rowClick(paymentRow)"
@@ -68,8 +91,11 @@
               'ion-no-padding popup-button': true
             }"
           >
-            {{ 'page.program.program-people-affected.transaction.do-single-payment'|translate }}
-            <br>
+            {{
+              'page.program.program-people-affected.transaction.do-single-payment'
+                | translate
+            }}
+            <br />
             <ion-icon
               name="add-circle-outline"
               size="small"

--- a/interfaces/HO-Portal/src/app/program/payment-history-popup/payment-history-popup.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/payment-history-popup/payment-history-popup.component.spec.ts
@@ -17,26 +17,24 @@ describe('PaymentHistoryPopupComponent', () => {
   let component: PaymentHistoryPopupComponent;
   let fixture: ComponentFixture<PaymentHistoryPopupComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [PaymentHistoryPopupComponent],
-        imports: [TranslateModule.forRoot(), HttpClientTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          {
-            provide: ModalController,
-            useValue: modalCtrlSpy,
-          },
-          provideMagicalMock(ProgramsServiceApiService),
-          {
-            provide: ModalController,
-            useValue: modalCtrlSpy,
-          },
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [PaymentHistoryPopupComponent],
+      imports: [TranslateModule.forRoot(), HttpClientTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        {
+          provide: ModalController,
+          useValue: modalCtrlSpy,
+        },
+        provideMagicalMock(ProgramsServiceApiService),
+        {
+          provide: ModalController,
+          useValue: modalCtrlSpy,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PaymentHistoryPopupComponent);

--- a/interfaces/HO-Portal/src/app/program/payment-status-popup/payment-status-popup.component.html
+++ b/interfaces/HO-Portal/src/app/program/payment-status-popup/payment-status-popup.component.html
@@ -13,18 +13,18 @@
           name="mail"
           size="small"
           aria-hidden="true"
-          style="vertical-align: middle;"
+          style="vertical-align: middle"
         >
         </ion-icon>
         {{ titleMessageIcon }}
-        <br>
+        <br />
       </ng-container>
       <ng-container *ngIf="titleMoneyIcon && !titleError">
         <ion-icon
           name="cash"
           size="small"
           aria-hidden="true"
-          style="vertical-align: middle;"
+          style="vertical-align: middle"
         >
         </ion-icon>
         {{ titleMoneyIcon }}
@@ -33,10 +33,14 @@
     <ion-buttons slot="end">
       <ion-button
         (click)="closeModal()"
-        [attr.title]="'common.cancel'|translate"
-        [attr.aria-label]="'common.cancel'|translate"
+        [attr.title]="'common.cancel' | translate"
+        [attr.aria-label]="'common.cancel' | translate"
       >
-        <ion-icon name="close" slot="icon-only" aria-hidden="true"></ion-icon>
+        <ion-icon
+          name="close"
+          slot="icon-only"
+          aria-hidden="true"
+        ></ion-icon>
       </ion-button>
     </ion-buttons>
   </ion-toolbar>
@@ -46,12 +50,17 @@
   color="light"
   class="ion-padding"
 >
-  <div *ngIf="content" [innerHTML]="content">
-  </div>
+  <div
+    *ngIf="content"
+    [innerHTML]="content"
+  ></div>
   <div *ngIf="showRetryButton">
-    <br>
+    <br />
     <ion-button (click)="retryPayment()">
-      {{ 'page.program.program-people-affected.payment-status-popup.retry'|translate }}
+      {{
+        'page.program.program-people-affected.payment-status-popup.retry'
+          | translate
+      }}
     </ion-button>
     <ion-spinner
       *ngIf="isInProgress"
@@ -60,34 +69,60 @@
     ></ion-spinner>
   </div>
   <div *ngIf="content && voucherButtons">
-    <hr style="border-width: 1px 0 0 0 ">
+    <hr style="border-width: 1px 0 0 0" />
   </div>
   <div *ngIf="voucherButtons">
     <ion-button (click)="getBalance()">
-      {{ 'page.program.program-people-affected.payment-status-popup.get-balance'|translate }}
+      {{
+        'page.program.program-people-affected.payment-status-popup.get-balance'
+          | translate
+      }}
     </ion-button>
-    <br>
-    <ion-button *ngIf="imageUrl" [href]="imageUrl" [download]="titleMoneyIcon">
-      <ion-icon name="download" slot="start" aria-hidden="true"></ion-icon>
-      {{ 'page.program.program-people-affected.payment-status-popup.download-voucher'|translate }}
+    <br />
+    <ion-button
+      *ngIf="imageUrl"
+      [href]="imageUrl"
+      [download]="titleMoneyIcon"
+    >
+      <ion-icon
+        name="download"
+        slot="start"
+        aria-hidden="true"
+      ></ion-icon>
+      {{
+        'page.program.program-people-affected.payment-status-popup.download-voucher'
+          | translate
+      }}
     </ion-button>
-    <ion-button *ngIf="sanitizedIimageUrl" (click)="printVoucher()">
-      <ion-icon name="print" slot="start" aria-hidden="true"></ion-icon>
-      {{ 'page.program.program-people-affected.payment-status-popup.print-voucher'|translate }}
+    <ion-button
+      *ngIf="sanitizedIimageUrl"
+      (click)="printVoucher()"
+    >
+      <ion-icon
+        name="print"
+        slot="start"
+        aria-hidden="true"
+      ></ion-icon>
+      {{
+        'page.program.program-people-affected.payment-status-popup.print-voucher'
+          | translate
+      }}
     </ion-button>
   </div>
   <div *ngIf="sanitizedIimageUrl">
-    <iframe id="voucherIframe" [src]="sanitizedIimageUrl" style="width: 100%; height: 450px; border:0;"></iframe>
+    <iframe
+      id="voucherIframe"
+      [src]="sanitizedIimageUrl"
+      style="width: 100%; height: 450px; border: 0"
+    ></iframe>
   </div>
 
   <div *ngIf="titleSinglePayment">
-    <br>
+    <br />
     <ion-row class="ion-align-items-center">
-      <ion-item
-        class="ion-margin-end"
-      >
+      <ion-item class="ion-margin-end">
         <ion-label position="stacked">
-          {{ 'page.program.program-details.fixedTransferValue'|translate }}
+          {{ 'page.program.program-details.fixedTransferValue' | translate }}
         </ion-label>
         <ion-input
           type="number"

--- a/interfaces/HO-Portal/src/app/program/payment-status-popup/payment-status-popup.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/payment-status-popup/payment-status-popup.component.spec.ts
@@ -17,26 +17,24 @@ describe('PaymentStatusPopupComponent', () => {
   let component: PaymentStatusPopupComponent;
   let fixture: ComponentFixture<PaymentStatusPopupComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [PaymentStatusPopupComponent],
-        imports: [TranslateModule.forRoot(), HttpClientTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          {
-            provide: ModalController,
-            useValue: modalCtrlSpy,
-          },
-          provideMagicalMock(ProgramsServiceApiService),
-          {
-            provide: ModalController,
-            useValue: modalCtrlSpy,
-          },
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [PaymentStatusPopupComponent],
+      imports: [TranslateModule.forRoot(), HttpClientTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        {
+          provide: ModalController,
+          useValue: modalCtrlSpy,
+        },
+        provideMagicalMock(ProgramsServiceApiService),
+        {
+          provide: ModalController,
+          useValue: modalCtrlSpy,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PaymentStatusPopupComponent);

--- a/interfaces/HO-Portal/src/app/program/phase-navigation/phase-navigation.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/phase-navigation/phase-navigation.component.spec.ts
@@ -25,19 +25,17 @@ describe('PhaseNavigationComponent', () => {
     active: true,
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [PhaseNavigationComponent],
-        imports: [TranslateModule.forRoot(), RouterTestingModule],
-        providers: [
-          provideMagicalMock(ProgramsServiceApiService),
-          provideMagicalMock(ProgramPhaseService),
-        ],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [PhaseNavigationComponent],
+      imports: [TranslateModule.forRoot(), RouterTestingModule],
+      providers: [
+        provideMagicalMock(ProgramsServiceApiService),
+        provideMagicalMock(ProgramPhaseService),
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+  }));
 
   let mockProgramsApi: jasmine.SpyObj<any>;
   let mockProgramPhaseService: jasmine.SpyObj<any>;

--- a/interfaces/HO-Portal/src/app/program/phase-next/phase-next.component.html
+++ b/interfaces/HO-Portal/src/app/program/phase-next/phase-next.component.html
@@ -1,5 +1,5 @@
 <div
-  style="display: flex;"
+  style="display: flex"
   class="ion-align-items-center ion-justify-content-end"
 >
   <ion-spinner

--- a/interfaces/HO-Portal/src/app/program/phase-next/phase-next.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/phase-next/phase-next.component.spec.ts
@@ -25,19 +25,17 @@ describe('PhaseNextComponent', () => {
     active: true,
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [PhaseNextComponent],
-        imports: [HttpClientTestingModule, RouterTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          provideMagicalMock(ProgramsServiceApiService),
-          provideMagicalMock(ProgramPhaseService),
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [PhaseNextComponent],
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        provideMagicalMock(ProgramsServiceApiService),
+        provideMagicalMock(ProgramPhaseService),
+      ],
+    }).compileComponents();
+  }));
 
   let mockProgramsApi: jasmine.SpyObj<any>;
   let mockProgramPhaseService: jasmine.SpyObj<any>;

--- a/interfaces/HO-Portal/src/app/program/program-details/program-details.component.html
+++ b/interfaces/HO-Portal/src/app/program/program-details/program-details.component.html
@@ -1,9 +1,9 @@
-<h2>{{ 'page.program.program-details.section-title'|translate }}</h2>
+<h2>{{ 'page.program.program-details.section-title' | translate }}</h2>
 
 <ion-list lines="full">
   <ion-item>
     <ion-button (click)="openProgramJson()">
-      {{ 'page.program.program-details.all'|translate }}
+      {{ 'page.program.program-details.all' | translate }}
     </ion-button>
   </ion-item>
   <ion-item *ngFor="let item of programProperties">

--- a/interfaces/HO-Portal/src/app/program/program-details/program-details.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/program-details/program-details.component.spec.ts
@@ -19,22 +19,20 @@ describe('ProgramDetailsComponent', () => {
 
   const mockProgramId = 1;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ProgramDetailsComponent],
-        imports: [TranslateModule.forRoot()],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          {
-            provide: ModalController,
-            useValue: modalCtrlSpy,
-          },
-          provideMagicalMock(ProgramsServiceApiService),
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProgramDetailsComponent],
+      imports: [TranslateModule.forRoot()],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        {
+          provide: ModalController,
+          useValue: modalCtrlSpy,
+        },
+        provideMagicalMock(ProgramsServiceApiService),
+      ],
+    }).compileComponents();
+  }));
 
   let mockProgramsApi: jasmine.SpyObj<any>;
 

--- a/interfaces/HO-Portal/src/app/program/program-json/program-json.component.html
+++ b/interfaces/HO-Portal/src/app/program/program-json/program-json.component.html
@@ -1,14 +1,22 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>{{'page.program.program-modal.pageTitle' | translate}}</ion-title>
+    <ion-title>
+      {{ 'page.program.program-modal.pageTitle' | translate }}
+    </ion-title>
     <ion-buttons slot="end">
-      <ion-button (click)="closeModal()" [attr.title]="'common.cancel'|translate">
-        <ion-icon name="close" slot="icon-only"></ion-icon>
+      <ion-button
+        (click)="closeModal()"
+        [attr.title]="'common.cancel' | translate"
+      >
+        <ion-icon
+          name="close"
+          slot="icon-only"
+        ></ion-icon>
       </ion-button>
     </ion-buttons>
   </ion-toolbar>
 </ion-header>
 
 <ion-content color="light">
-  <pre>{{program | json}}</pre>
+  <pre>{{ program | json }}</pre>
 </ion-content>

--- a/interfaces/HO-Portal/src/app/program/program-json/program-json.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/program-json/program-json.component.spec.ts
@@ -14,21 +14,19 @@ describe('ProgramJsonComponent', () => {
   let component: ProgramJsonComponent;
   let fixture: ComponentFixture<ProgramJsonComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ProgramJsonComponent],
-        imports: [TranslateModule.forRoot()],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          {
-            provide: ModalController,
-            useValue: modalCtrlSpy,
-          },
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProgramJsonComponent],
+      imports: [TranslateModule.forRoot()],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        {
+          provide: ModalController,
+          useValue: modalCtrlSpy,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProgramJsonComponent);

--- a/interfaces/HO-Portal/src/app/program/program-payout/program-payout.component.html
+++ b/interfaces/HO-Portal/src/app/program/program-payout/program-payout.component.html
@@ -1,4 +1,7 @@
-<div *ngIf="canMakeExport" class="ion-margin-vertical">
+<div
+  *ngIf="canMakeExport"
+  class="ion-margin-vertical"
+>
   <h3>{{ 'page.program.program-payout.make-export' | translate }}</h3>
   <ion-row class="ion-align-items-center">
     <select
@@ -12,7 +15,10 @@
           'page.program.program-payout.choose-payment' | translate
         }}</ng-container>
       </option>
-      <option [value]="-1" [disabled]="lastPaymentId < 1">
+      <option
+        [value]="-1"
+        [disabled]="lastPaymentId < 1"
+      >
         {{ 'page.program.program-payout.all-closed-payments' | translate }}
       </option>
       <option
@@ -51,7 +57,10 @@
       [lastPaymentId]="lastPaymentId"
     ></app-export-fsp-instructions>
   </ion-row>
-  <ion-row *ngIf="isIntersolve" class="ion-margin-vertical">
+  <ion-row
+    *ngIf="isIntersolve"
+    class="ion-margin-vertical"
+  >
     <app-export-list
       [programId]="programId"
       [exportType]="enumExportType.unusedVouchers"
@@ -60,8 +69,15 @@
   </ion-row>
 </div>
 
-<ion-row *ngIf="canMakePayment" class="ion-margin-vertical">
-  <ion-col *ngIf="!!lastPaymentId" [sizeXs]="12" [sizeMd]="4">
+<ion-row
+  *ngIf="canMakePayment"
+  class="ion-margin-vertical"
+>
+  <ion-col
+    *ngIf="!!lastPaymentId"
+    [sizeXs]="12"
+    [sizeMd]="4"
+  >
     <h3>
       {{
         'page.program.program-payout.last-payment.last-payment'

--- a/interfaces/HO-Portal/src/app/program/program-payout/program-payout.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/program-payout/program-payout.component.spec.ts
@@ -16,23 +16,21 @@ describe('ProgramPayoutComponent', () => {
 
   const mockProgramId = 1;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ProgramPayoutComponent],
-        imports: [TranslateModule.forRoot(), FormsModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          provideMagicalMock(AuthService),
-          provideMagicalMock(ProgramsServiceApiService),
-          provideMagicalMock(PastPaymentsService),
-          {
-            provide: AlertController,
-          },
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProgramPayoutComponent],
+      imports: [TranslateModule.forRoot(), FormsModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        provideMagicalMock(AuthService),
+        provideMagicalMock(ProgramsServiceApiService),
+        provideMagicalMock(PastPaymentsService),
+        {
+          provide: AlertController,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   let mockAuthService: jasmine.SpyObj<any>;
   let mockProgramsApi: jasmine.SpyObj<any>;

--- a/interfaces/HO-Portal/src/app/program/program-people-affected/program-people-affected.component.html
+++ b/interfaces/HO-Portal/src/app/program/program-people-affected/program-people-affected.component.html
@@ -54,7 +54,10 @@
     </ion-row>
   </div>
   <div>
-    <ion-row *ngIf="program" class="ion-align-items-center">
+    <ion-row
+      *ngIf="program"
+      class="ion-align-items-center"
+    >
       <ion-input
         [placeholder]="
           'page.program.program-people-affected.filter-placeholder' | translate
@@ -84,10 +87,18 @@
         ></ion-icon>
       </ion-input>
 
-      <ion-label class="ion-margin-start">{{ 'page.program.program-people-affected.filter-btn.common.filter-by' | translate }}</ion-label>
+      <ion-label class="ion-margin-start">
+        {{
+          'page.program.program-people-affected.filter-btn.common.filter-by'
+            | translate
+        }}
+      </ion-label>
 
       <app-table-filter
-        [buttonLabel]="'page.program.program-people-affected.filter-btn.btn-label.status' | translate"
+        [buttonLabel]="
+          'page.program.program-people-affected.filter-btn.btn-label.status'
+            | translate
+        "
         [type]="tableFilterType.multipleChoice"
         [optionsList]="getPaStatusesFilterOptions()"
         [optionsSelectedByDefault]="tableFilter.paStatus.default"
@@ -97,7 +108,6 @@
           currentSelection: tableFilter.paStatus.selected
         }"
       ></app-table-filter>
-
     </ion-row>
   </div>
 </ion-row>
@@ -183,8 +193,15 @@
     [sortable]="columnDefaults.sortable"
     [headerClass]="columnDefaults.headerClass"
   >
-    <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
-      <div class="ion-align-items-center" style="display: flex">
+    <ng-template
+      ngx-datatable-cell-template
+      let-value="value"
+      let-row="row"
+    >
+      <div
+        class="ion-align-items-center"
+        style="display: flex"
+      >
         <button
           *ngIf="canViewPersonalData"
           id="edit-button"
@@ -245,7 +262,11 @@
     [cellClass]="column.cellClass"
     [frozenLeft]="column.frozenLeft"
   >
-    <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
+    <ng-template
+      ngx-datatable-cell-template
+      let-value="value"
+      let-row="row"
+    >
       <ng-container *ngIf="value === true || value === false">
         <span
           [title]="
@@ -312,7 +333,11 @@
     [sortable]="paymentHistoryColumn?.sortable"
     [headerClass]="paymentHistoryColumn?.headerClass"
   >
-    <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
+    <ng-template
+      ngx-datatable-cell-template
+      let-value="value"
+      let-row="row"
+    >
       <ng-container *ngIf="value">
         <button
           *ngIf="row.paymentHistory?.paymentIndex"

--- a/interfaces/HO-Portal/src/app/program/program-people-affected/program-people-affected.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/program-people-affected/program-people-affected.component.spec.ts
@@ -28,27 +28,25 @@ describe('ProgramPeopleAffectedComponent', () => {
 
   const mockProgramId = 1;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ProgramPeopleAffectedComponent],
-        imports: [TranslateModule.forRoot(), FormsModule, RouterTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          provideMagicalMock(AuthService),
-          provideMagicalMock(ProgramsServiceApiService),
-          {
-            provide: ModalController,
-            useValue: modalCtrlSpy,
-          },
-          {
-            provide: PopoverController,
-            useValue: popoverCtrlSpy,
-          },
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProgramPeopleAffectedComponent],
+      imports: [TranslateModule.forRoot(), FormsModule, RouterTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        provideMagicalMock(AuthService),
+        provideMagicalMock(ProgramsServiceApiService),
+        {
+          provide: ModalController,
+          useValue: modalCtrlSpy,
+        },
+        {
+          provide: PopoverController,
+          useValue: popoverCtrlSpy,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   let mockProgramsApi: jasmine.SpyObj<any>;
 

--- a/interfaces/HO-Portal/src/app/program/submit-payment-popup/submit-payment-popup.component.html
+++ b/interfaces/HO-Portal/src/app/program/submit-payment-popup/submit-payment-popup.component.html
@@ -3,19 +3,34 @@
     <ion-title>
       {{
         'page.program.program-payout.make-payment.make-payment'
-          | translate: { nr: submitPaymentProps.payment ? '#' + submitPaymentProps.payment : '-' }
+          | translate
+            : {
+                nr: submitPaymentProps.payment
+                  ? '#' + submitPaymentProps.payment
+                  : '-'
+              }
       }}
     </ion-title>
     <ion-buttons slot="end">
-      <ion-button (click)="closeModal()" [attr.title]="'common.cancel'|translate"
-        [attr.aria-label]="'common.cancel'|translate">
-        <ion-icon name="close" slot="icon-only" aria-hidden="true"></ion-icon>
+      <ion-button
+        (click)="closeModal()"
+        [attr.title]="'common.cancel' | translate"
+        [attr.aria-label]="'common.cancel' | translate"
+      >
+        <ion-icon
+          name="close"
+          slot="icon-only"
+          aria-hidden="true"
+        ></ion-icon>
       </ion-button>
     </ion-buttons>
   </ion-toolbar>
 </ion-header>
 
 <ion-content class="ion-padding">
-  <app-make-payment [programId]="submitPaymentProps.programId" [payment]="submitPaymentProps.payment"
-    [referenceIds]="submitPaymentProps.referenceIds"></app-make-payment>
+  <app-make-payment
+    [programId]="submitPaymentProps.programId"
+    [payment]="submitPaymentProps.payment"
+    [referenceIds]="submitPaymentProps.referenceIds"
+  ></app-make-payment>
 </ion-content>

--- a/interfaces/HO-Portal/src/app/program/submit-payment-popup/submit-payment-popup.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/program/submit-payment-popup/submit-payment-popup.component.spec.ts
@@ -15,21 +15,19 @@ describe('SubmitPaymentPopupComponent', () => {
   let component: SubmitPaymentPopupComponent;
   let fixture: ComponentFixture<SubmitPaymentPopupComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [SubmitPaymentPopupComponent],
-        imports: [TranslateModule.forRoot(), HttpClientTestingModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [
-          {
-            provide: ModalController,
-            useValue: modalCtrlSpy,
-          },
-        ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [SubmitPaymentPopupComponent],
+      imports: [TranslateModule.forRoot(), HttpClientTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        {
+          provide: ModalController,
+          useValue: modalCtrlSpy,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SubmitPaymentPopupComponent);

--- a/interfaces/HO-Portal/src/app/programs-list/programs-list.component.html
+++ b/interfaces/HO-Portal/src/app/programs-list/programs-list.component.html
@@ -1,9 +1,9 @@
 <section>
   <h2>
-    {{ 'page.programs-list.pageTitle'|translate }}
+    {{ 'page.programs-list.pageTitle' | translate }}
   </h2>
   <ion-note *ngIf="!items">
-    {{ 'page.programs-list.not-available'|translate }}
+    {{ 'page.programs-list.not-available' | translate }}
   </ion-note>
   <ion-list *ngIf="items">
     <ion-item
@@ -12,12 +12,12 @@
       [routerLink]="['/program', program.id, 'dashboard']"
     >
       <ion-label>
-        {{ program.titlePortal }}<br>
+        {{ program.titlePortal }}<br />
         <ion-note>
           {{ program.description }}
         </ion-note>
         <ion-note class="ion-float-end ion-padding-end">
-          {{ program.updated|date:"yyyy-MM-dd, HH:mm" }}
+          {{ program.updated | date: 'yyyy-MM-dd, HH:mm' }}
         </ion-note>
       </ion-label>
     </ion-item>

--- a/interfaces/HO-Portal/src/app/programs-list/programs-list.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/programs-list/programs-list.component.spec.ts
@@ -10,16 +10,14 @@ describe('ProgramListComponent', () => {
   let component: ProgramsListComponent;
   let fixture: ComponentFixture<ProgramsListComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ProgramsListComponent],
-        imports: [TranslateModule.forRoot()],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        providers: [provideMagicalMock(ProgramsServiceApiService)],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProgramsListComponent],
+      imports: [TranslateModule.forRoot()],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [provideMagicalMock(ProgramsServiceApiService)],
+    }).compileComponents();
+  }));
 
   let mockProgramsApi: jasmine.SpyObj<any>;
 

--- a/interfaces/HO-Portal/src/app/shared/confirm-prompt/confirm-prompt.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/shared/confirm-prompt/confirm-prompt.component.spec.ts
@@ -7,14 +7,12 @@ describe('ConfirmPromptComponent', () => {
   let component: ConfirmPromptComponent;
   let fixture: ComponentFixture<ConfirmPromptComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ConfirmPromptComponent],
-        imports: [TranslateModule.forRoot(), IonicModule],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ConfirmPromptComponent],
+      imports: [TranslateModule.forRoot(), IonicModule],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfirmPromptComponent);

--- a/interfaces/HO-Portal/src/app/shared/file-picker-prompt/file-picker-prompt.component.html
+++ b/interfaces/HO-Portal/src/app/shared/file-picker-prompt/file-picker-prompt.component.html
@@ -1,13 +1,17 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>{{ 'common.confirm'|translate }}</ion-title>
+    <ion-title>{{ 'common.confirm' | translate }}</ion-title>
     <ion-buttons slot="end">
       <ion-button
         (click)="closeModal()"
-        [attr.title]="'common.cancel'|translate"
-        [attr.aria-label]="'common.cancel'|translate"
+        [attr.title]="'common.cancel' | translate"
+        [attr.aria-label]="'common.cancel' | translate"
       >
-        <ion-icon name="close" slot="icon-only" aria-hidden="true"></ion-icon>
+        <ion-icon
+          name="close"
+          slot="icon-only"
+          aria-hidden="true"
+        ></ion-icon>
       </ion-button>
     </ion-buttons>
   </ion-toolbar>
@@ -19,8 +23,8 @@
 >
   <h2
     *ngIf="subHeader"
-    [innerHTML]="subHeader">
-  </h2>
+    [innerHTML]="subHeader"
+  ></h2>
   <div
     *ngIf="message"
     [innerHTML]="message"
@@ -31,7 +35,6 @@
     *ngIf="filePickerProps"
     class="ion-margin-vertical"
   >
-
     <div
       *ngIf="filePickerProps.explanation"
       [innerHTML]="filePickerProps.explanation"
@@ -44,12 +47,21 @@
       class="ion-margin-vertical"
     >
       <ion-button
-        (click)="downloadTemplate(filePickerProps.programId, filePickerProps.downloadTemplate)"
+        (click)="
+          downloadTemplate(
+            filePickerProps.programId,
+            filePickerProps.downloadTemplate
+          )
+        "
         color="primary"
         fill="outline"
       >
-        <ion-icon name="download" slot="start" aria-hidden="true"></ion-icon>
-        {{ 'file-picker.download-template-button'|translate }}
+        <ion-icon
+          name="download"
+          slot="start"
+          aria-hidden="true"
+        ></ion-icon>
+        {{ 'file-picker.download-template-button' | translate }}
       </ion-button>
     </div>
 
@@ -63,12 +75,11 @@
         'is-file-selected': !!fileInput?.value,
         'file-picker-prompt--input': true
       }"
-      (dragover)="isDraggedOver=true;"
-      (dragleave)="isDraggedOver=false;"
-      [title]="'file-picker.label'|translate"
-      [attr.aria-label]="'file-picker.label'|translate"
+      (dragover)="isDraggedOver = true"
+      (dragleave)="isDraggedOver = false"
+      [title]="'file-picker.label' | translate"
+      [attr.aria-label]="'file-picker.label' | translate"
     ></ion-input>
-
   </div>
 </ion-content>
 
@@ -80,7 +91,7 @@
         color="danger"
         (click)="closeModal()"
       >
-        {{ 'common.cancel'|translate }}
+        {{ 'common.cancel' | translate }}
       </ion-button>
       <ion-button
         fill="solid"
@@ -88,9 +99,8 @@
         (click)="submitConfirm()"
         [disabled]="checkOkDisabled()"
       >
-        {{ 'common.ok'|translate }}
+        {{ 'common.ok' | translate }}
       </ion-button>
     </ion-buttons>
-
   </ion-toolbar>
 </ion-footer>

--- a/interfaces/HO-Portal/src/app/shared/file-picker-prompt/file-picker-prompt.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/shared/file-picker-prompt/file-picker-prompt.component.spec.ts
@@ -10,15 +10,13 @@ describe('FilePickerPromptComponent', () => {
   let component: FilePickerPromptComponent;
   let fixture: ComponentFixture<FilePickerPromptComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [FilePickerPromptComponent],
-        imports: [TranslateModule.forRoot(), IonicModule, FormsModule],
-        providers: [provideMagicalMock(ProgramsServiceApiService)],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [FilePickerPromptComponent],
+      imports: [TranslateModule.forRoot(), IonicModule, FormsModule],
+      providers: [provideMagicalMock(ProgramsServiceApiService)],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(FilePickerPromptComponent);

--- a/interfaces/HO-Portal/src/app/shared/input-prompt/input-prompt.component.html
+++ b/interfaces/HO-Portal/src/app/shared/input-prompt/input-prompt.component.html
@@ -1,25 +1,27 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>{{ 'common.confirm'|translate }}</ion-title>
+    <ion-title>{{ 'common.confirm' | translate }}</ion-title>
     <ion-buttons slot="end">
       <ion-button
         (click)="closeModal()"
-        [attr.title]="'common.cancel'|translate"
-        [attr.aria-label]="'common.cancel'|translate"
+        [attr.title]="'common.cancel' | translate"
+        [attr.aria-label]="'common.cancel' | translate"
       >
-        <ion-icon name="close" slot="icon-only" aria-hidden="true"></ion-icon>
+        <ion-icon
+          name="close"
+          slot="icon-only"
+          aria-hidden="true"
+        ></ion-icon>
       </ion-button>
     </ion-buttons>
   </ion-toolbar>
 </ion-header>
 
-<ion-content
-  class="ion-padding"
->
+<ion-content class="ion-padding">
   <h2
     *ngIf="subHeader"
-    [innerHTML]="subHeader">
-  </h2>
+    [innerHTML]="subHeader"
+  ></h2>
   <div
     *ngIf="message"
     [innerHTML]="message"
@@ -30,15 +32,12 @@
     *ngIf="inputProps"
     class="ion-margin-vertical"
   >
-
     <ion-item
       *ngIf="inputProps.checkbox"
       lines="none"
-      style="--background:none"
+      style="--background: none"
     >
-      <ion-label
-        [innerHTML]="inputProps.checkbox"
-      ></ion-label>
+      <ion-label [innerHTML]="inputProps.checkbox"></ion-label>
       <ion-checkbox
         slot="start"
         [checked]="checked"
@@ -54,9 +53,12 @@
       ></div>
 
       <ion-label>
-        {{ 'common.confirm-message-label'|translate:{
-            minLength: inputProps.minLength
-          }
+        {{
+          'common.confirm-message-label'
+            | translate
+              : {
+                  minLength: inputProps.minLength
+                }
         }}
       </ion-label>
       <ion-textarea
@@ -71,13 +73,17 @@
         [minlength]="inputProps.minLength"
         [value]="inputProps.defaultValue"
         [placeholder]="inputProps.placeholder"
-        style="font-family: monospace; border: 1px solid currentColor; height:66px"
+        style="
+          font-family: monospace;
+          border: 1px solid currentColor;
+          height: 66px;
+        "
       ></ion-textarea>
       <ion-note>
-        {{ input?.value ? input?.value?.length : 0 }} (≥ {{ inputProps.minLength }})
+        {{ input?.value ? input?.value?.length : 0 }} (≥
+        {{ inputProps.minLength }})
       </ion-note>
     </div>
-
   </div>
 </ion-content>
 
@@ -89,7 +95,7 @@
         color="danger"
         (click)="closeModal()"
       >
-        {{ 'common.cancel'|translate }}
+        {{ 'common.cancel' | translate }}
       </ion-button>
       <ion-button
         fill="solid"
@@ -97,9 +103,8 @@
         (click)="submitConfirm()"
         [disabled]="checkOkDisabled()"
       >
-        {{ 'common.ok'|translate }}
+        {{ 'common.ok' | translate }}
       </ion-button>
     </ion-buttons>
-
   </ion-toolbar>
 </ion-footer>

--- a/interfaces/HO-Portal/src/app/shared/input-prompt/input-prompt.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/shared/input-prompt/input-prompt.component.spec.ts
@@ -8,14 +8,12 @@ describe('InputPromptComponent', () => {
   let component: InputPromptComponent;
   let fixture: ComponentFixture<InputPromptComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [InputPromptComponent],
-        imports: [TranslateModule.forRoot(), IonicModule, FormsModule],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [InputPromptComponent],
+      imports: [TranslateModule.forRoot(), IonicModule, FormsModule],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(InputPromptComponent);

--- a/interfaces/HO-Portal/src/app/shared/password-toggle-input/password-toggle-input.component.html
+++ b/interfaces/HO-Portal/src/app/shared/password-toggle-input/password-toggle-input.component.html
@@ -1,4 +1,4 @@
-<ion-item style="--inner-padding-end: 0;">
+<ion-item style="--inner-padding-end: 0">
   <ion-label
     position="stacked"
     (click)="passwordInput.setFocus()"
@@ -6,7 +6,7 @@
     {{ label }}
   </ion-label>
   <div
-    style="display: flex; width: 100%;"
+    style="display: flex; width: 100%"
     class="ion-align-items-center"
   >
     <ion-input
@@ -31,8 +31,18 @@
       [title]="isPassword() ? this.labelShow : this.labelHide"
       [attr.aria-label]="isPassword() ? this.labelShow : this.labelHide"
     >
-      <ion-icon *ngIf="isPassword()" slot="icon-only" name="eye" aria-hidden="true"></ion-icon>
-      <ion-icon *ngIf="!isPassword()" slot="icon-only" name="eye-off" aria-hidden="true"></ion-icon>
+      <ion-icon
+        *ngIf="isPassword()"
+        slot="icon-only"
+        name="eye"
+        aria-hidden="true"
+      ></ion-icon>
+      <ion-icon
+        *ngIf="!isPassword()"
+        slot="icon-only"
+        name="eye-off"
+        aria-hidden="true"
+      ></ion-icon>
     </ion-button>
   </div>
 </ion-item>

--- a/interfaces/HO-Portal/src/app/shared/password-toggle-input/password-toggle-input.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/shared/password-toggle-input/password-toggle-input.component.spec.ts
@@ -6,14 +6,12 @@ describe('PasswordToggleInputComponent', () => {
   let component: PasswordToggleInputComponent;
   let fixture: ComponentFixture<PasswordToggleInputComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [PasswordToggleInputComponent],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [PasswordToggleInputComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PasswordToggleInputComponent);

--- a/interfaces/HO-Portal/src/app/shared/refresh-data/refresh-data.component.html
+++ b/interfaces/HO-Portal/src/app/shared/refresh-data/refresh-data.component.html
@@ -1,19 +1,27 @@
 <div
-  style="display: flex;"
+  style="display: flex"
   class="ion-align-items-center ion-justify-content-end"
 >
   <ion-note>
-    {{ 'refresh-data.last-updated'|translate:{ date:lastUpdated|date:'EEEE, dd-MM-yyyy - HH:mm' } }}
+    {{
+      'refresh-data.last-updated'
+        | translate: { date: lastUpdated | date: 'EEEE, dd-MM-yyyy - HH:mm' }
+    }}
   </ion-note>
   <ion-button
     size="small"
     fill="clear"
     color="medium"
-    [title]="'common.update'|translate"
-    [attr.aria-label]="'common.update'|translate"
+    [title]="'common.update' | translate"
+    [attr.aria-label]="'common.update' | translate"
     (click)="doRefresh()"
     id="refresh"
   >
-    <ion-icon name="refresh" size="small" slot="icon-only" aria-hidden="true"></ion-icon>
+    <ion-icon
+      name="refresh"
+      size="small"
+      slot="icon-only"
+      aria-hidden="true"
+    ></ion-icon>
   </ion-button>
 </div>

--- a/interfaces/HO-Portal/src/app/shared/refresh-data/refresh-data.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/shared/refresh-data/refresh-data.component.spec.ts
@@ -7,15 +7,13 @@ describe('RefreshDataComponent', () => {
   let component: RefreshDataComponent;
   let fixture: ComponentFixture<RefreshDataComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [RefreshDataComponent],
-        imports: [TranslateModule.forRoot()],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [RefreshDataComponent],
+      imports: [TranslateModule.forRoot()],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RefreshDataComponent);

--- a/interfaces/HO-Portal/src/app/shared/tooltip/tooltip.component.spec.ts
+++ b/interfaces/HO-Portal/src/app/shared/tooltip/tooltip.component.spec.ts
@@ -7,15 +7,13 @@ describe('TooltipComponent', () => {
   let component: TooltipComponent;
   let fixture: ComponentFixture<TooltipComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [TooltipComponent],
-        imports: [NgxPopperjsModule],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [TooltipComponent],
+      imports: [NgxPopperjsModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TooltipComponent);

--- a/interfaces/HO-Portal/src/app/user/user.page.html
+++ b/interfaces/HO-Portal/src/app/user/user.page.html
@@ -1,109 +1,152 @@
-<app-header [title]="'page.user.pageTitle'|translate" [showHome]="true"></app-header>
+<app-header
+  [title]="'page.user.pageTitle'|translate"
+  [showHome]="true"
+></app-header>
 
 <ion-content>
   <ion-grid class="full-height">
-    <ion-row class="ion-justify-content-center ion-align-items-center full-height">
+    <ion-row
+      class="ion-justify-content-center ion-align-items-center full-height"
+    >
       <ion-col size="4"></ion-col>
-      <ion-col size="12" size-lg="4">
-        <div id="portal-title" class="ion-margin-vertical">
+      <ion-col
+        size="12"
+        size-lg="4"
+      >
+        <div
+          id="portal-title"
+          class="ion-margin-vertical"
+        >
           <div id="logo-container">
-            <img src="./assets/img/121-logo.png" alt="121">
+            <img
+              src="./assets/img/121-logo.png"
+              alt="121"
+            />
           </div>
-          <h1 class="text-uppercase">{{ 'page.login.portalTitle'|translate }}</h1>
+          <h1 class="text-uppercase">
+            {{ 'page.login.portalTitle'|translate }}
+          </h1>
         </div>
         <div class="ion-padding auth-form-container">
-            <form
-              *ngIf="!passwordChanged"
-              method="POST"
-              #newPasswordForm="ngForm"
-              (ngSubmit)="updatePassword()"
-              (keyup.enter)="updatePassword()"
-            >
-              <div class="input-item auth-item ion-margin-bottom ion-padding-bottom">
-                <label
-                  color="medium"
-                  class="input-item--label auth-label"
-                  (click)="newPasswordInput.setFocus()"
-                >
-                  {{ 'page.user.change-password.new-password'|translate }}
-                </label>
-                <div class="input-item--content">
-                  <ion-input
-                    #newPasswordInput
-                    type="password"
-                    autocomplete="new-password"
-                    autocapitalize="off"
-                    clearInput="true"
-                    clearOnEdit="false"
-                    required
-                    [minlength]="minLength"
-                    name="new-password"
-                    [(ngModel)]="newPassword"
-                    ngDefaultControl
-                    pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).{8,}"
-                    (ionBlur)="checkNewPassword()"
-                    [ngClass]="newPasswordBorder"
-                    class="ion-margin-vertical">
-                  </ion-input>
-                  <div class="validation-message">
-                    <ion-note [color]="!validPassword ? 'danger' : 'medium'"><small><strong>{{ 'page.user.notification-messages.password-requirements'|translate: {minLength: minLength} }}</strong></small></ion-note>
-                  </div>
-                </div>
-              </div>
-              <div class="input-item auth-item ion-margin-bottom ion-padding-bottom">
-                <label
-                  color="medium"
-                  class="input-item--label auth-label"
-                  (click)="confirmPasswordInput.setFocus()"
-                >
-                  {{ 'page.user.change-password.confirm-password'|translate }}
-                </label>
-                <div class="input-item--content">
-                  <ion-input
-                    #confirmPasswordInput
-                    type="password"
-                    autocomplete="off"
-                    autocapitalize="off"
-                    clearInput="true"
-                    clearOnEdit="false"
-                    required
-                    [minlength]="minLength"
-                    name="confirm-password"
-                    [(ngModel)]="confirmPassword"
-                    ngDefaultControl
-                    pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).{8,}"
-                    (ionBlur)="checkConfirmPasswords()"
-                    (ionChange)="onChange()"
-                    [ngClass]="confirmPasswordBorder"
-                    class="ion-margin-vertical">
-                  </ion-input>
-                </div>
-                <div class="validation-message">
-                  <ion-note color="danger" *ngIf="!samePassword"><small><strong>{{ "page.user.notification-messages.different-passwords" |translate }}</strong></small></ion-note>
-                </div>
-              </div>
-              <div class="ion-margin-top ion-no-padding">
-                <ion-button
-                  type="submit"
-                  expand="block"
-                  size="default"
-                  [disabled]="!newPasswordForm?.form?.valid"
-                  color="secondary"
-                >
-                  {{ 'common.update'|translate }}
-                </ion-button>
-              </div>
-
-            </form>
-          </div>
-          <div
-            *ngIf="passwordChanged"
-           class="ion-text-center"
+          <form
+            *ngIf="!passwordChanged"
+            method="POST"
+            #newPasswordForm="ngForm"
+            (ngSubmit)="updatePassword()"
+            (keyup.enter)="updatePassword()"
           >
-            <ion-icon name="checkmark-circle" color="success" size="large" aria-hidden="true"></ion-icon>
-            <br>
-            <strong>{{ 'page.user.change-password.success'|translate }}</strong>
-          </div>
+            <div
+              class="input-item auth-item ion-margin-bottom ion-padding-bottom"
+            >
+              <label
+                color="medium"
+                class="input-item--label auth-label"
+                (click)="newPasswordInput.setFocus()"
+              >
+                {{ 'page.user.change-password.new-password'|translate }}
+              </label>
+              <div class="input-item--content">
+                <ion-input
+                  #newPasswordInput
+                  type="password"
+                  autocomplete="new-password"
+                  autocapitalize="off"
+                  clearInput="true"
+                  clearOnEdit="false"
+                  required
+                  [minlength]="minLength"
+                  name="new-password"
+                  [(ngModel)]="newPassword"
+                  ngDefaultControl
+                  pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).{8,}"
+                  (ionBlur)="checkNewPassword()"
+                  [ngClass]="newPasswordBorder"
+                  class="ion-margin-vertical"
+                >
+                </ion-input>
+                <div class="validation-message">
+                  <ion-note [color]="!validPassword ? 'danger' : 'medium'"
+                    ><small
+                      ><strong
+                        >{{
+                        'page.user.notification-messages.password-requirements'|translate:
+                        {minLength: minLength} }}</strong
+                      ></small
+                    ></ion-note
+                  >
+                </div>
+              </div>
+            </div>
+            <div
+              class="input-item auth-item ion-margin-bottom ion-padding-bottom"
+            >
+              <label
+                color="medium"
+                class="input-item--label auth-label"
+                (click)="confirmPasswordInput.setFocus()"
+              >
+                {{ 'page.user.change-password.confirm-password'|translate }}
+              </label>
+              <div class="input-item--content">
+                <ion-input
+                  #confirmPasswordInput
+                  type="password"
+                  autocomplete="off"
+                  autocapitalize="off"
+                  clearInput="true"
+                  clearOnEdit="false"
+                  required
+                  [minlength]="minLength"
+                  name="confirm-password"
+                  [(ngModel)]="confirmPassword"
+                  ngDefaultControl
+                  pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).{8,}"
+                  (ionBlur)="checkConfirmPasswords()"
+                  (ionChange)="onChange()"
+                  [ngClass]="confirmPasswordBorder"
+                  class="ion-margin-vertical"
+                >
+                </ion-input>
+              </div>
+              <div class="validation-message">
+                <ion-note
+                  color="danger"
+                  *ngIf="!samePassword"
+                  ><small
+                    ><strong
+                      >{{ "page.user.notification-messages.different-passwords"
+                      |translate }}</strong
+                    ></small
+                  ></ion-note
+                >
+              </div>
+            </div>
+            <div class="ion-margin-top ion-no-padding">
+              <ion-button
+                type="submit"
+                expand="block"
+                size="default"
+                [disabled]="!newPasswordForm?.form?.valid"
+                color="secondary"
+              >
+                {{ 'common.update'|translate }}
+              </ion-button>
+            </div>
+          </form>
+        </div>
+        <div
+          *ngIf="passwordChanged"
+          class="ion-text-center"
+        >
+          <ion-icon
+            name="checkmark-circle"
+            color="success"
+            size="large"
+            aria-hidden="true"
+          ></ion-icon>
+          <br />
+          <strong>{{ 'page.user.change-password.success'|translate }}</strong>
+        </div>
       </ion-col>
       <ion-col size="4"></ion-col>
     </ion-row>

--- a/interfaces/HO-Portal/src/app/user/user.page.spec.ts
+++ b/interfaces/HO-Portal/src/app/user/user.page.spec.ts
@@ -11,16 +11,14 @@ describe('UserPage', () => {
   let component: UserPage;
   let fixture: ComponentFixture<UserPage>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [UserPage],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-        imports: [FormsModule, TranslateModule.forRoot()],
-        providers: [provideMagicalMock(AuthService)],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [UserPage],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      imports: [FormsModule, TranslateModule.forRoot()],
+      providers: [provideMagicalMock(AuthService)],
+    }).compileComponents();
+  }));
 
   let mockAuthService: jasmine.SpyObj<any>;
 

--- a/interfaces/HO-Portal/src/environments/environment.prod.ts.template.js
+++ b/interfaces/HO-Portal/src/environments/environment.prod.ts.template.js
@@ -10,7 +10,7 @@ export const environment = {
   envName: '${process.env.NG_ENV_NAME || ''}',
 
   // APIs:
-  url_121_service_api: '${process.env.NG_URL_121_SERVICE_API}',
+  url_121_service_api: '${process.env.NG_URL_121_SERVICE_API || ''}',
 
   // Third-party tokens:
   ai_ikey: '${process.env.NG_AI_IKEY}',


### PR DESCRIPTION
See also #3085
See also #3086


@arsforza @RubenGeo :

This might require a review of you local VSCode settings.

Check your "User settings.json" so it doesn't contain any settings/overrides for formatting `[html]`-files, of other options other then: "editor.defaultFormatter": "esbenp.prettier-vscode"

It is also necessary to restart VSCode after 'cleaning up' these settings.