### PR TITLE
fix: Add fallback to phone-number in ENV-variable

### DIFF
--- a/services/121-service/src/notifications/twilio.dto.ts
+++ b/services/121-service/src/notifications/twilio.dto.ts
@@ -118,7 +118,9 @@ export class TwilioIncomingCallbackDto {
   public WaId: string;
 
   @ApiProperty({
-    example: formatWhatsAppNumber(process.env.TWILIO_WHATSAPP_NUMBER),
+    example: formatWhatsAppNumber(
+      process.env.TWILIO_WHATSAPP_NUMBER || '31600000000',
+    ),
   })
   @IsString()
   @IsOptional()

--- a/services/twilio-mock-service/src/twilio/twilio.dto.ts
+++ b/services/twilio-mock-service/src/twilio/twilio.dto.ts
@@ -114,7 +114,9 @@ export class TwilioIncomingCallbackDto {
   public WaId: string;
 
   @ApiProperty({
-    example: formatWhatsAppNumber(process.env.TWILIO_WHATSAPP_NUMBER),
+    example: formatWhatsAppNumber(
+      process.env.TWILIO_WHATSAPP_NUMBER || '31600000000',
+    ),
   })
   @IsString()
   @IsOptional()


### PR DESCRIPTION
fix: Add fallback to phone-number value to make the ENV-variables' existence non-blocking/breaking