### PR TITLE
Randomize API tests

### DIFF
--- a/services/121-service/jest.e2e.config.js
+++ b/services/121-service/jest.e2e.config.js
@@ -14,7 +14,7 @@ module.exports = {
     '^@121-service/(.*)$': '<rootDir>/$1',
   },
   testTimeout: 30_000,
-  randomize: false, // TODO: Some tests still depend on the order, but should not. Toggle locally to test + fix.
+  randomize: true,
   verbose: true,
   reporters: ['default', ['github-actions', { silent: false }], 'summary'],
 };


### PR DESCRIPTION
All API-tests should be able to run in any order, i.e. they should not have a dependency on each other.

So when 1 test-scenario requires an entity/record to be in the database; it should create it (or be created in the `beforeEach/beforeAll`-methods of the test-suite).

Another test-scenario should **not** expect that entity to be there (unless defined in the `beforeEach/beforeAll`-methods).

Also, 1 test-setup/outcome should not affect another test's outcome.

## Tests to fix:
- [ ] `test/registrations/pagination/get-registration.test.ts`
- [ ] `test/programs/users/roles.test.ts`
