### PR TITLE
fix: registrations not allowed without csv import if program is not published yet AB#27479

### DIFF
--- a/interfaces/Portal/src/app/mocks/api.programs.mock.ts
+++ b/interfaces/Portal/src/app/mocks/api.programs.mock.ts
@@ -22,7 +22,7 @@ const programsArray: Program[] = [
     phase: ProgramPhase.design,
     validation: false,
     author: {},
-    published: false,
+    published: true,
     notifications: { en: 'Notification text' },
     programCustomAttributes: [
       {

--- a/services/121-service/seed-data/program/program-demo.json
+++ b/services/121-service/seed-data/program/program-demo.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": true,
   "phase": "design",
   "location": "Demoland",

--- a/services/121-service/seed-data/program/program-drc.json
+++ b/services/121-service/seed-data/program/program-drc.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": true,
   "phase": "design",
   "location": "Democratic Republic of the Congo",

--- a/services/121-service/seed-data/program/program-eth-joint-response.json
+++ b/services/121-service/seed-data/program/program-eth-joint-response.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": false,
   "phase": "registrationValidation",
   "location": "Demoland",

--- a/services/121-service/seed-data/program/program-joint-response-ANE.json
+++ b/services/121-service/seed-data/program/program-joint-response-ANE.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": false,
   "phase": "design",
   "location": "Ethiopia",

--- a/services/121-service/seed-data/program/program-joint-response-EKHCDC.json
+++ b/services/121-service/seed-data/program/program-joint-response-EKHCDC.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": false,
   "phase": "design",
   "location": "Ethiopia",

--- a/services/121-service/seed-data/program/program-joint-response-dorcas.json
+++ b/services/121-service/seed-data/program/program-joint-response-dorcas.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": false,
   "phase": "design",
   "location": "Ethiopia",

--- a/services/121-service/seed-data/program/program-krcs-baringo.json
+++ b/services/121-service/seed-data/program/program-krcs-baringo.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": false,
   "phase": "registrationValidation",
   "location": "Kenya",

--- a/services/121-service/seed-data/program/program-krcs-turkana.json
+++ b/services/121-service/seed-data/program/program-krcs-turkana.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": false,
   "phase": "registrationValidation",
   "location": "Kenya",

--- a/services/121-service/seed-data/program/program-krcs-westpokot.json
+++ b/services/121-service/seed-data/program/program-krcs-westpokot.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": false,
   "phase": "registrationValidation",
   "location": "Kenya",

--- a/services/121-service/seed-data/program/program-nlrc-ocw.json
+++ b/services/121-service/seed-data/program/program-nlrc-ocw.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": false,
   "phase": "design",
   "location": "Nederland",

--- a/services/121-service/seed-data/program/program-nlrc-pv.json
+++ b/services/121-service/seed-data/program/program-nlrc-pv.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": true,
   "phase": "design",
   "location": "Nederland",

--- a/services/121-service/seed-data/program/program-pilot-dorcas-eth.json
+++ b/services/121-service/seed-data/program/program-pilot-dorcas-eth.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": true,
   "phase": "design",
   "location": "Ethiopia",

--- a/services/121-service/seed-data/program/program-pilot-lbn.json
+++ b/services/121-service/seed-data/program/program-pilot-lbn.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": true,
   "phase": "design",
   "location": "Lebanon",

--- a/services/121-service/seed-data/program/program-pilot-ukr.json
+++ b/services/121-service/seed-data/program/program-pilot-ukr.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": true,
   "phase": "design",
   "location": "Ukraine",

--- a/services/121-service/seed-data/program/program-pilot-zoa-eth.json
+++ b/services/121-service/seed-data/program/program-pilot-zoa-eth.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": true,
   "phase": "design",
   "location": "Ethiopia",

--- a/services/121-service/seed-data/program/program-validation.json
+++ b/services/121-service/seed-data/program/program-validation.json
@@ -1,5 +1,5 @@
 {
-  "published": false,
+  "published": true,
   "validation": true,
   "phase": "design",
   "location": "Location A",

--- a/services/121-service/src/registration/registrations.service.ts
+++ b/services/121-service/src/registration/registrations.service.ts
@@ -391,6 +391,11 @@ export class RegistrationsService {
     userId: number,
   ): Promise<ImportResult> {
     const program = await this.findProgramOrThrow(programId);
+    if (!program?.published) {
+      const errors =
+        'Registrations are not allowed for this program yet, try again later.';
+      throw new HttpException({ errors }, HttpStatus.BAD_REQUEST);
+    }
     return await this.registrationsImportService.importValidatedRegistrations(
       validatedImportRecords,
       program,

--- a/services/121-service/test/helpers/program.helper.ts
+++ b/services/121-service/test/helpers/program.helper.ts
@@ -76,6 +76,18 @@ export async function publishProgram(
     .send({ phase: 'registrationValidation' });
 }
 
+export async function unpublishProgram(
+  programId: number,
+  accessToken: string,
+): Promise<request.Response> {
+  return await getServer()
+    .patch(`/programs/${programId}`)
+    .set('Cookie', [accessToken])
+    .send({
+      published: false,
+    });
+}
+
 export async function changePhase(
   programId: number,
   newPhase: ProgramPhase,

--- a/services/121-service/test/registrations/import-registration.test.ts
+++ b/services/121-service/test/registrations/import-registration.test.ts
@@ -6,7 +6,7 @@ import {
   registrationScopedGoesPv,
   registrationScopedUtrechtPv,
 } from '../fixtures/scoped-registrations';
-import { patchProgram } from '../helpers/program.helper';
+import { patchProgram, unpublishProgram } from '../helpers/program.helper';
 import {
   getImportRegistrationsTemplate,
   importRegistrations,
@@ -56,6 +56,25 @@ describe('Import a registration', () => {
         expect(registration[key]).toBe(registrationVisa[key]);
       }
     }
+  });
+
+  it('should fail import registrations due to program is not published yet', async () => {
+    // Arrange
+    accessToken = await getAccessToken();
+
+    // unpublish a program
+    await unpublishProgram(programIdOCW, accessToken);
+
+    const response = await importRegistrations(
+      programIdOCW,
+      [registrationVisa],
+      accessToken,
+    );
+
+    expect(response.statusCode).toBe(HttpStatus.BAD_REQUEST);
+    expect(response.body.errors).toBe(
+      `Registrations are not allowed for this program yet, try again later.`,
+    );
   });
 
   it('should import registration scoped', async () => {


### PR DESCRIPTION
fix: registrations not allowed without csv import if program is not published yet [AB#27479](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/27479)

Task: https://dev.azure.com/redcrossnl/121%20Platform/_workitems/edit/27479