### PR TITLE
fix: added `tmp` & `documentation` for lint ignore

### DIFF
--- a/services/121-service/.eslintignore
+++ b/services/121-service/.eslintignore
@@ -1,1 +1,3 @@
 dist
+tmp
+documentation


### PR DESCRIPTION
fix: added `tmp` & `documentation` directory for lint ignore