### PR TITLE
Add back missing endpoint for getting a CSV template from the portal

### DIFF
--- a/services/121-service/README.md
+++ b/services/121-service/README.md
@@ -60,6 +60,10 @@ To run a single test suite, amend the name of the test file, for example:
 
     docker exec 121-service  npm run test:e2e:all update-program.test.ts
 
+To update snapshots, amend the `-- -u` option, for example:
+
+    docker exec 121-service  npm run test:e2e:all -- -u
+
 ### Debugging
 
 To enter the 121-service in the terminal use: (Or use the "Exec"-tab inside Docker Desktop)

--- a/services/121-service/src/registration/registrations.controller.ts
+++ b/services/121-service/src/registration/registrations.controller.ts
@@ -207,6 +207,23 @@ export class RegistrationsController {
     );
   }
 
+  @ApiTags('programs/registrations')
+  @AuthenticatedUser({
+    permissions: [PermissionEnum.RegistrationImportTemplateREAD],
+  })
+  @ApiOperation({
+    summary: 'Get a CSV template for importing registrations',
+  })
+  @ApiParam({ name: 'programId', required: true, type: 'integer' })
+  @Get('programs/:programId/registrations/import-template')
+  public async getImportRegistrationsTemplate(
+    @Param() params,
+  ): Promise<string[]> {
+    return await this.registrationsService.getImportRegistrationsTemplate(
+      Number(params.programId),
+    );
+  }
+
   @AuthenticatedUser()
   @ApiTags('programs/registrations')
   @ApiResponse({

--- a/services/121-service/test/helpers/registration.helper.ts
+++ b/services/121-service/test/helpers/registration.helper.ts
@@ -406,3 +406,14 @@ export async function getRegistrationEvents(
     .set('Cookie', [accessToken])
     .send();
 }
+
+export async function getImportRegistrationsTemplate(
+  programId: number,
+): Promise<any> {
+  const accessToken = await getAccessToken();
+
+  return getServer()
+    .get(`/programs/${programId}/registrations/import-template`)
+    .set('Cookie', [accessToken])
+    .send();
+}

--- a/services/121-service/test/registrations/__snapshots__/import-registration.test.ts.snap
+++ b/services/121-service/test/registrations/__snapshots__/import-registration.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Import a registration should give me a CSV template when I request it 1`] = `
+[
+  "addressCity",
+  "addressHouseNumber",
+  "addressHouseNumberAddition",
+  "addressPostalCode",
+  "addressStreet",
+  "firstName",
+  "fspName",
+  "lastName",
+  "paymentAmountMultiplier",
+  "phoneNumber",
+  "preferredLanguage",
+  "referenceId",
+  "whatsappPhoneNumber",
+]
+`;

--- a/services/121-service/test/registrations/import-registration.test.ts
+++ b/services/121-service/test/registrations/import-registration.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../fixtures/scoped-registrations';
 import { patchProgram } from '../helpers/program.helper';
 import {
+  getImportRegistrationsTemplate,
   importRegistrations,
   searchRegistrationByReferenceId,
 } from '../helpers/registration.helper';
@@ -172,5 +173,14 @@ describe('Import a registration', () => {
         expect(registration[key]).toBe(registrationVisa[key]);
       }
     }
+  });
+
+  it('should give me a CSV template when I request it', async () => {
+    // Arrange
+    accessToken = await getAccessToken();
+
+    const response = await getImportRegistrationsTemplate(programIdOCW);
+    expect(response.statusCode).toBe(HttpStatus.OK);
+    expect(response.body.sort()).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
This endpoint was accidentally removed in a previous commit. Adding it back.