### PR TITLE
Disable spam comments from Azure on PRs

### DIFF
--- a/.github/workflows/deploy_test_portal.yml
+++ b/.github/workflows/deploy_test_portal.yml
@@ -7,7 +7,9 @@ env:
 
 permissions:
   actions: read
-  pull-requests: write
+  # Disabling this to avoid spamming the PR with "Your stage site is ready!" comments
+  # https://github.com/Azure/static-web-apps/issues/1135#issuecomment-1750066331
+  # pull-requests: write
 
 on:
   workflow_call:


### PR DESCRIPTION
These comments have been polluting the PRs without (IMHO) adding much value, given that the deployment status information is already visible elsewhere on the GitHub UI.

Sadly, the Azure team is aware of this issue but isn't prioritising a fix for it: https://github.com/Azure/static-web-apps/issues/1135

The proposed solution seems hacky, but, if it works, it works.