### PR TITLE
Add exclusions to when E2E tests run

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -9,9 +9,12 @@ on:
       - '.github/workflows/test_e2e.yml'
       - 'e2e/**'
       - 'services/.env.example'
-      - 'services/121-service/**'
-      - 'services/mock-service/**'
+      - 'services/**'
+      - '!services/**.test.ts'
+      - '!services/**.spec.ts'
       - 'interfaces/Portal/**'
+      - '!interfaces/Portal/**.test.ts'
+      - '!interfaces/Portal/**.spec.ts'
       - '!**.md'
 
 env:


### PR DESCRIPTION
## Describe your changes

Based on @RubenGeo's suggestion I am extending the list of exclusions for the E2E tests job in CI to avoid running on changes to unit tests.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I have communicated above whether I need any deviation from our PR guidelines (eg. "I don't want the reviewer to merge on my behalf because...")
