### PR TITLE
Add retry to flaky API test

### DIFF
--- a/services/121-service/test/registrations/send-templated-message.test.ts
+++ b/services/121-service/test/registrations/send-templated-message.test.ts
@@ -17,6 +17,9 @@ import {
 import { getAccessToken, resetDB } from '../helpers/utility.helper';
 import { programIdPV } from './pagination/pagination-data';
 
+// this test is flaky, so we retry it before failing the whole 8-minute CI job just because of it
+jest.retryTimes(2);
+
 describe('Send templated message', () => {
   const programId = programIdPV; // status change templates are only available for PV
   const registrationAh = {


### PR DESCRIPTION
This test keeps failing the whole API integration test job in CI. And then it works fine on a re-run. I don't have enough context to actually fix the test, but this at least should avoid this routine annoyance and waste of time :)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have communicated above whether I need any deviation from our PR guidelines (eg. "I don't want the reviewer to merge on my behalf because...")
