### PR TITLE
fix: only English used in templated message

### DIFF
--- a/interfaces/Portal/src/app/shared/message-editor/message-editor.component.ts
+++ b/interfaces/Portal/src/app/shared/message-editor/message-editor.component.ts
@@ -205,13 +205,13 @@ export class MessageEditorComponent implements AfterViewInit, OnInit {
       return;
     }
 
+    // Send a templated message custom message
     if (
       this.selectedTemplateType !== this.customTemplateType &&
       this.selectedTemplateType !== undefined
     ) {
       this.modalController.dismiss(
         {
-          message: this.preview,
           messageTemplateKey: this.selectedTemplateType,
         },
         null,
@@ -219,11 +219,13 @@ export class MessageEditorComponent implements AfterViewInit, OnInit {
       return;
     }
 
+    // Send free text message
     if (this.inputProps.inputRequired && this.input && this.input.value) {
       this.modalController.dismiss({ message: this.input.value }, null);
       return;
     }
 
+    // Send templated message on status change
     if (this.inputProps.isTemplated && this.inputProps.checkboxChecked) {
       this.modalController.dismiss(
         { messageTemplateKey: this.inputProps.messageTemplateKey },

--- a/services/121-service/src/notifications/message-job.dto.ts
+++ b/services/121-service/src/notifications/message-job.dto.ts
@@ -10,7 +10,7 @@ export class MessageJobDto {
   phoneNumber: string;
   programId: number;
   message?: string;
-  key?: string;
+  messageTemplateKey?: string;
   messageContentType?: MessageContentType;
   mediaUrl?: string;
   customData?: MessageJobCustomDataDto;

--- a/services/121-service/src/notifications/message.service.spec.ts
+++ b/services/121-service/src/notifications/message.service.spec.ts
@@ -17,7 +17,7 @@ const defaultMessageJob = {
   referenceId: 'ref-test',
   programId: 1,
   message: 'test message',
-  key: 'key',
+  messageTemplateKey: 'messageTemplateKey',
   customData: {},
 } as MessageJobDto;
 const mockDefaultNotificationText = 'default notification';

--- a/services/121-service/src/notifications/message.service.ts
+++ b/services/121-service/src/notifications/message.service.ts
@@ -42,7 +42,7 @@ export class MessageService {
         ? messageJobDto.message
         : await this.getNotificationText(
             messageJobDto.preferredLanguage,
-            messageJobDto.key,
+            messageJobDto.messageTemplateKey,
             messageJobDto.programId,
           );
       if (messageJobDto.customData?.placeholderData) {
@@ -256,12 +256,12 @@ export class MessageService {
 
   private async getNotificationText(
     language: string,
-    key: string,
+    messageTemplateKey: string,
     programId: number,
   ): Promise<string> {
     const messageTemplates = await this.messageTemplateRepo.findBy({
       program: { id: programId },
-      type: key,
+      type: messageTemplateKey,
     });
 
     const notification = messageTemplates.find(

--- a/services/121-service/src/notifications/processors/message.processor.spec.ts
+++ b/services/121-service/src/notifications/processors/message.processor.spec.ts
@@ -14,7 +14,7 @@ const mockMessageJob: MessageJobDto = {
   phoneNumber: '1234567890',
   programId: 1,
   message: 'test message',
-  key: 'key',
+  messageTemplateKey: 'messageTemplateKey',
   messageContentType: MessageContentType.custom,
   messageProcessType: MessageProcessType.whatsappTemplateGeneric,
 };

--- a/services/121-service/src/notifications/queue-message/queue-message.service.spec.ts
+++ b/services/121-service/src/notifications/queue-message/queue-message.service.spec.ts
@@ -21,7 +21,7 @@ const defaultMessageJob = {
   preferredLanguage: LanguageEnum.en,
   referenceId: 'ref-test',
   message: 'test message',
-  key: 'key',
+  messageTemplateKey: 'messageTemplateKey',
   messageContentType: MessageContentType.custom,
 } as MessageJobDto;
 
@@ -62,7 +62,7 @@ describe('QueueMessageService', () => {
     await queueMessageService.addMessageToQueue(
       registration,
       'test message',
-      'key',
+      defaultMessageJob.messageTemplateKey,
       MessageContentType.custom,
       MessageProcessType.whatsappTemplateGeneric,
     );
@@ -100,7 +100,7 @@ describe('QueueMessageService', () => {
     await queueMessageService.addMessageToQueue(
       registration,
       'test message',
-      'key',
+      defaultMessageJob.messageTemplateKey,
       MessageContentType.custom,
       MessageProcessType.whatsappTemplateGeneric,
     );


### PR DESCRIPTION
[AB#27909](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/27909)

## Describe your changes

The fix itself is the change in `message-editor.component.ts`.

AFAIU, this has never worked. I tried checking out the commit that introduced that code (and apparently, the functionality) (764b065aed863458c3db545554f45d07f7d0dca8) and I could recreate the same exact bug.

While making these changes, I also refactored a few things:
- renamed `key` to `messageTemplateKey` wherever applicable
- Replaced if/else in `queue-message.service` with object lookup. This is always preferable for [speed and ease of readability](https://dev.to/b3ns44d/alternative-to-if-else-and-switch-object-literals-in-javascript-3nde)

~I'm not sure whether I should add a test for this, and how it would best be done.~ This would be addressed in [AB#27910](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/27910)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have communicated above whether I need any deviation from our PR guidelines (eg. "I don't want the reviewer to merge on my behalf because...")
