### PR TITLE
chore: add migrations check to CI

### DIFF
--- a/.github/workflows/test_service_api.yml
+++ b/.github/workflows/test_service_api.yml
@@ -45,6 +45,11 @@ jobs:
           timeout 90s sh -c 'until docker ps | grep mock-service | grep -q healthy; do echo "Waiting for mock-service to be healthy..."; sleep 5; done'
           timeout 90s sh -c 'until docker ps | grep 121-service | grep -q healthy; do echo "Waiting for 121-service to be healthy..."; sleep 5; done'
 
+      - name: Check that no new migrations are necessary
+        working-directory: ./services
+        run: |
+          docker compose exec 121-service npm run migration:generate migration/irrelevant_file_name -- --check
+
       - name: Run API tests with Jest
         working-directory: ./services
         run: |


### PR DESCRIPTION
[AB#27849](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/27849)

## Describe your changes

This adds a check to our CI job, ensuring all entity changes are reflected in our migrations. The check adds ~12s to our API test job, which I consider an acceptable tradeoff.

I first rebased this on main to create an [example of a failing job](https://github.com/global-121/121-platform/actions/runs/8982798899/job/24671183512?pr=5258). The same job should pass fine when rebased on #5247.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have communicated above whether I need any deviation from our PR guidelines (eg. "I don't want the reviewer to merge on my behalf because...")
