### PR TITLE
Move Typescript to production dependencies for 121-service

### DIFF
--- a/services/121-service/package-lock.json
+++ b/services/121-service/package-lock.json
@@ -46,6 +46,7 @@
         "tsconfig-paths": "^4.2.0",
         "twilio": "^5.0.4",
         "typeorm": "^0.3.17",
+        "typescript": "^5.5.0-beta",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
         "xml-js": "^1.6.11"
       },
@@ -75,7 +76,6 @@
         "supertest": "^7.0.0",
         "ts-jest": "^29.1.2",
         "tsc-watch": "^6.2.0",
-        "typescript": "^5.5.0-beta",
         "yargs": "^17.7.2"
       }
     },
@@ -14323,10 +14323,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/typescript": {
-      "version": "5.5.0-dev.20240509",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.0-dev.20240509.tgz",
-      "integrity": "sha512-r/zZRQGt3udzXP4ZaxPUs7r+NgrzW94LRfqa0XrFe0IXANWaewB/amTIL8O/zZ9qRv4QN34kr4td6HJsSbG9eA==",
-      "dev": true,
+      "version": "5.5.0-beta",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.0-beta.tgz",
+      "integrity": "sha512-FRg3e/aQg3olEG3ff8YjHOERsO4IM0m4qGrsE4UMvILaq4TdDZ6gQX4+2Rq9SjTpfSe/ebwiHcsjm/7FfWWQ6Q==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -25229,10 +25228,9 @@
       }
     },
     "typescript": {
-      "version": "5.5.0-dev.20240509",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.0-dev.20240509.tgz",
-      "integrity": "sha512-r/zZRQGt3udzXP4ZaxPUs7r+NgrzW94LRfqa0XrFe0IXANWaewB/amTIL8O/zZ9qRv4QN34kr4td6HJsSbG9eA==",
-      "dev": true
+      "version": "5.5.0-beta",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.0-beta.tgz",
+      "integrity": "sha512-FRg3e/aQg3olEG3ff8YjHOERsO4IM0m4qGrsE4UMvILaq4TdDZ6gQX4+2Rq9SjTpfSe/ebwiHcsjm/7FfWWQ6Q=="
     },
     "uglify-js": {
       "version": "3.17.4",

--- a/services/121-service/package.json
+++ b/services/121-service/package.json
@@ -70,6 +70,7 @@
     "tsconfig-paths": "^4.2.0",
     "twilio": "^5.0.4",
     "typeorm": "^0.3.17",
+    "typescript": "^5.5.0-beta",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
     "xml-js": "^1.6.11"
   },
@@ -79,10 +80,10 @@
     "@compodoc/compodoc": "^1.1.23",
     "@types/cookie-parser": "^1.4.7",
     "@types/jest": "^29.5.12",
-    "@types/passport-azure-ad": "^4.3.6",
-    "@types/passport-jwt": "^4.0.1",
     "@types/lodash": "^4.17.1",
     "@types/node": "^18.19.33",
+    "@types/passport-azure-ad": "^4.3.6",
+    "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.2",
     "@types/yargs": "^17.0.32",
     "@typescript-eslint/eslint-plugin": "^7.8.0",
@@ -99,7 +100,6 @@
     "supertest": "^7.0.0",
     "ts-jest": "^29.1.2",
     "tsc-watch": "^6.2.0",
-    "typescript": "^5.5.0-beta",
     "yargs": "^17.7.2"
   }
 }


### PR DESCRIPTION
Merging the PR #5271 seems to have broken the service: https://121-test.scm.azurewebsites.net/api/vfs/LogFiles/2024_05_14_ln0mdlwk00005A_default_docker.log

Error along the lines of (while starting the service):

```
2024-05-14T14:09:10.174478723Z npm start
2024-05-14T14:09:10.174478723Z npm info using npm@9.6.4
2024-05-14T14:09:10.174721026Z npm info using node@v18.19.1
2024-05-14T14:09:10.202707456Z
2024-05-14T14:09:10.202758857Z > start
2024-05-14T14:09:10.202765857Z > GLOBAL_121_VERSION=$(test -f "VERSION.txt" && cat VERSION.txt || echo $GLOBAL_121_VERSION)  node index.js
2024-05-14T14:09:10.202770557Z
2024-05-14T14:09:10.344822639Z node:internal/modules/cjs/loader:1137
2024-05-14T14:09:10.344871540Z   throw err;
2024-05-14T14:09:10.344877840Z   ^
2024-05-14T14:09:10.344882140Z
2024-05-14T14:09:10.344886340Z Error: Cannot find module 'typescript'
```

I think this should fix it. It still remains unclear to me how this happens in test, and we don't catch it sooner. One thing at a time :D

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
