### PR TITLE
fix: broken workflow check

### DIFF
--- a/.github/actions/build-service/action.yml
+++ b/.github/actions/build-service/action.yml
@@ -2,7 +2,7 @@
 # More specific about composite actions: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions
 
 name: 'Build: Service'
-description: ''
+description: 'Builds a service for deployment.'
 
 inputs:
   servicePath:

--- a/.github/workflows/test_workflows.yml
+++ b/.github/workflows/test_workflows.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - '.github/actions/*'
-      - '.github/workflows/*'
+      - '.github/actions/**'
+      - '.github/workflows/**'
 
 jobs:
   test:


### PR DESCRIPTION
[AB#28086](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/28086)

Looks like actionlint started ignoring the empty string and it didn't like it. This should make it stop complaining.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
