### PR TITLE
chore: adding portal server logs to CI job

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -50,7 +50,7 @@ jobs:
           NG_URL_121_SERVICE_API: http://localhost:3000/api
         run: |
           npm install
-          npm run start:debug-production > /dev/null 2>&1 &
+          npm run start:debug-production > portal-server-logs.txt 2>&1 &
 
       - name: Install e2e dependencies
         working-directory: ${{ env.e2eTestsPath }}
@@ -83,7 +83,9 @@ jobs:
         if: always()
         with:
           name: test-result-artifacts
-          path: ./e2e/test-results/
+          path: |
+            ./e2e/test-results/
+            ./interfaces/Portal/portal-server-logs.txt
           retention-days: 30
 
       - name: Docker logs


### PR DESCRIPTION
[AB#28271](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/28271)

This should enable us to debug better what is happening if and when the portal server isn't starting in CI

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
