### PR TITLE
fix: fixed the bug related to phoneNumber validation AB#28262

### DIFF
--- a/services/121-service/src/registration/services/registrations-import.service.ts
+++ b/services/121-service/src/registration/services/registrations-import.service.ts
@@ -469,9 +469,16 @@ export class RegistrationsImportService {
   ): Promise<ImportRegistrationsDto[]> {
     const { allowEmptyPhoneNumber } =
       await this.programService.findProgramOrThrow(programId);
+
+    // Checking if there is any phoneNumber values in the submitted CSV file
+    const hasPhoneNumber = csvArray.some((row) => row.phoneNumber);
+
     const validationConfig = new ValidationConfigDto({
       validateExistingReferenceId: false,
-      validatePhoneNumberEmpty: !allowEmptyPhoneNumber,
+      // if there is no phoneNumber column in the submitted CSV file, but program is configured to not allow empty phone number
+      // then we are considering, in database we already have phone numbers for registrations and we are not expecting to update phone number through mas update.
+      // So ignoring phone number validation
+      validatePhoneNumberEmpty: hasPhoneNumber && !allowEmptyPhoneNumber,
       validatePhoneNumberLookup: false,
       validateClassValidator: true,
       validateUniqueReferenceId: false,

--- a/services/121-service/test-registration-data/test-registrations-patch-OCW-without-phoneNumber-column.csv
+++ b/services/121-service/test-registration-data/test-registrations-patch-OCW-without-phoneNumber-column.csv
@@ -1,0 +1,4 @@
+referenceId,preferredLanguage,paymentAmountMultiplier,lastName,addressStreet,addressHouseNumber,addressHouseNumberAddition
+00dc9451-1273-484c-b2e8-ae21b51a96ab,ar,2,updated name1,newStreet1,2,
+01dc9451-1273-484c-b2e8-ae21b51a96ab,nl,3,updated name 2,newStreet2,3,updated
+16dc9451-1273-484c-b2e8-ae21b51a96ab,en,1,New NAme mate,,,,

--- a/services/121-service/test/registrations/mass-update-registration.test.ts
+++ b/services/121-service/test/registrations/mass-update-registration.test.ts
@@ -103,4 +103,48 @@ describe('Update attribute of multiple PAs via Bulk update', () => {
     const pa2patchedResponse = pa2patched.body.data[0];
     assertRegistrationImport(pa2patchedResponse, PA2Patch);
   });
+
+  it('Should bulk update if phoneNumber column is empty and program is configured as not allowing empty phone number', async () => {
+    const PA1Patch = {
+      phoneNumber: '14155238886',
+      lastName: 'updated name1',
+      addressStreet: 'newStreet1',
+      addressHouseNumber: '2',
+      addressHouseNumberAddition: '',
+    };
+    const PA2Patch = {
+      phoneNumber: '14155238886',
+      lastName: 'updated name 2',
+      addressStreet: 'newStreet2',
+      addressHouseNumber: '3',
+      addressHouseNumberAddition: 'updated',
+    };
+
+    const bulkUpdateResult = await bulkUpdateRegistrationsCSV(
+      programIdOcw,
+      './test-registration-data/test-registrations-patch-OCW-without-phoneNumber-column.csv',
+      accessToken,
+    );
+    expect(bulkUpdateResult.statusCode).toBe(200);
+
+    await waitFor(2000);
+
+    const pa1patched = await searchRegistrationByReferenceId(
+      '00dc9451-1273-484c-b2e8-ae21b51a96ab',
+      programIdOcw,
+      accessToken,
+    );
+
+    const pa1patchedResponse = pa1patched.body.data[0];
+    assertRegistrationImport(pa1patchedResponse, PA1Patch);
+
+    const pa2patched = await searchRegistrationByReferenceId(
+      '01dc9451-1273-484c-b2e8-ae21b51a96ab',
+      programIdOcw,
+      accessToken,
+    );
+
+    const pa2patchedResponse = pa2patched.body.data[0];
+    assertRegistrationImport(pa2patchedResponse, PA2Patch);
+  });
 });


### PR DESCRIPTION
[AB#28262](https://dev.azure.com/redcrossnl/121%20Platform/_workitems/edit/28262)

## Describe your changes

During the mass update, if program is configured as not allowing empty phone number and the uploaded CSV file doesn't contain phoneNumber column, the it shouldn't complain about phone number not exists since we can consider, the already registered PAs have the phone number in database. if column exists and has some value for phoneNumber in uploaded CSV file then it should do the normal validation as it is.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
