### PR TITLE
chore: add explicit type information to nullable properties

### DIFF
--- a/services/121-service/src/base-audited.entity.ts
+++ b/services/121-service/src/base-audited.entity.ts
@@ -10,6 +10,6 @@ export class Base121AuditedEntity extends Base121Entity {
 // In some entities the userId is not applicable (e.g event entity of type registrationStatusChange
 // where status changes are done by the system, such as moving to status completed).
 export class Base121OptionalAuditedEntity extends Base121Entity {
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public userId: number | null;
 }

--- a/services/121-service/src/events/entities/event-attribute.entity.ts
+++ b/services/121-service/src/events/entities/event-attribute.entity.ts
@@ -15,6 +15,6 @@ export class EventAttributeEntity extends Base121Entity {
   @Column()
   public key: EventAttributeKeyEnum;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public value: string | null;
 }

--- a/services/121-service/src/exchange-rate/exchange-rate.entity.ts
+++ b/services/121-service/src/exchange-rate/exchange-rate.entity.ts
@@ -9,6 +9,6 @@ export class ExchangeRateEntity extends Base121Entity {
   @Column({ type: 'real' })
   public euroExchangeRate: number;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public closeTime: string | null;
 }

--- a/services/121-service/src/financial-service-providers/fsp-question.entity.ts
+++ b/services/121-service/src/financial-service-providers/fsp-question.entity.ts
@@ -42,7 +42,7 @@ export class FspQuestionEntity extends Base121Entity {
   @ApiProperty({ example: [] })
   public export: ExportType[];
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   @ApiProperty({ example: 'pattern' })
   public pattern: string | null;
 

--- a/services/121-service/src/notifications/twilio.entity.ts
+++ b/services/121-service/src/notifications/twilio.entity.ts
@@ -26,7 +26,7 @@ export class TwilioMessageEntity extends Base121Entity {
   @Column()
   public body: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public mediaUrl: string | null;
 
   @Column()
@@ -52,13 +52,13 @@ export class TwilioMessageEntity extends Base121Entity {
   @Column({ default: MessageContentType.custom })
   public contentType: MessageContentType;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public processType: MessageProcessType | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public errorCode: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public errorMessage: string | null;
 
   @ManyToOne(

--- a/services/121-service/src/notifications/whatsapp/whatsapp-pending-message.entity.ts
+++ b/services/121-service/src/notifications/whatsapp/whatsapp-pending-message.entity.ts
@@ -10,10 +10,10 @@ export class WhatsappPendingMessageEntity extends Base121Entity {
   @Column()
   public body: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public mediaUrl: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public messageType: string | null;
 
   @Column()

--- a/services/121-service/src/notifications/whatsapp/whatsapp-template-test.entity.ts
+++ b/services/121-service/src/notifications/whatsapp/whatsapp-template-test.entity.ts
@@ -17,10 +17,10 @@ export class WhatsappTemplateTestEntity extends Base121Entity {
   @Column()
   public messageKey: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'boolean', nullable: true })
   public succes: boolean | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public callback: string | null;
 
   @Index()

--- a/services/121-service/src/payments/fsp-integration/africas-talking/africas-talking-notification.entity.ts
+++ b/services/121-service/src/payments/fsp-integration/africas-talking/africas-talking-notification.entity.ts
@@ -21,13 +21,13 @@ export class AfricasTalkingNotificationEntity extends Base121Entity {
   @Column()
   public provider: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public providerRefId: string | null;
 
   @Column()
   public providerChannel: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public clientAccount: string | null;
 
   @Column()
@@ -48,10 +48,10 @@ export class AfricasTalkingNotificationEntity extends Base121Entity {
   @Column()
   public value: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public transactionFee: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public providerFee: string | null;
 
   @Column()
@@ -66,6 +66,6 @@ export class AfricasTalkingNotificationEntity extends Base121Entity {
   @Column('json', { default: null })
   public providerMetadata: Record<string, unknown>;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public transactionDate: string | null;
 }

--- a/services/121-service/src/payments/fsp-integration/belcash/belcash-request.entity.ts
+++ b/services/121-service/src/payments/fsp-integration/belcash/belcash-request.entity.ts
@@ -38,25 +38,25 @@ export class BelcashRequestEntity {
   @Column()
   public statusdetail: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public id: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public date: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public processdate: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public statuscomment: string | null;
 
   @Column()
   public status: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public referenceid: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public tracenumber: string | null;
 
   @Column()

--- a/services/121-service/src/payments/fsp-integration/commercial-bank-ethiopia/commercial-bank-ethiopia-account-enquiries.entity.ts
+++ b/services/121-service/src/payments/fsp-integration/commercial-bank-ethiopia/commercial-bank-ethiopia-account-enquiries.entity.ts
@@ -10,21 +10,21 @@ export class CommercialBankEthiopiaAccountEnquiriesEntity extends Base121Entity 
   @Column({ type: 'int', nullable: true })
   public registrationId: number | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public fullNameUsedForTheMatch: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public bankAccountNumberUsedForCall: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public cbeName: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'boolean', nullable: true })
   public namesMatch: boolean | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public cbeStatus: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public errorMessage: string | null;
 }

--- a/services/121-service/src/payments/fsp-integration/intersolve-visa/intersolve-visa-customer.entity.ts
+++ b/services/121-service/src/payments/fsp-integration/intersolve-visa/intersolve-visa-customer.entity.ts
@@ -14,7 +14,7 @@ import {
 @Entity('intersolve_visa_customer')
 export class IntersolveVisaCustomerEntity extends CascadeDeleteEntity {
   @Index()
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public holderId: string | null;
 
   @OneToOne(() => RegistrationEntity)

--- a/services/121-service/src/payments/fsp-integration/intersolve-visa/intersolve-visa-wallet.entity.ts
+++ b/services/121-service/src/payments/fsp-integration/intersolve-visa/intersolve-visa-wallet.entity.ts
@@ -27,10 +27,10 @@ export enum IntersolveVisaCardStatus {
 @Entity('intersolve_visa_wallet')
 export class IntersolveVisaWalletEntity extends Base121Entity {
   @Index()
-  @Column({ unique: true, nullable: true })
+  @Column({ type: 'character varying', unique: true, nullable: true })
   public tokenCode: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'boolean', nullable: true })
   public tokenBlocked: boolean | null;
 
   @Column({ default: false })
@@ -39,20 +39,20 @@ export class IntersolveVisaWalletEntity extends Base121Entity {
   @Column({ default: false })
   public debitCardCreated: boolean;
 
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public balance: number | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public walletStatus: IntersolveVisaWalletStatus | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public cardStatus: IntersolveVisaCardStatus | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'timestamp', nullable: true })
   public lastUsedDate: Date | null;
 
   // Last time we got an update from Intersolve about the wallet status or balance or when it was last used
-  @Column({ nullable: true })
+  @Column({ type: 'timestamp', nullable: true })
   public lastExternalUpdate: Date | null;
 
   // This is euro cents

--- a/services/121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-issue-voucher-request.entity.ts
+++ b/services/121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-issue-voucher-request.entity.ts
@@ -7,32 +7,32 @@ export class IntersolveIssueVoucherRequestEntity extends Base121Entity {
   @Column({ type: 'bigint' })
   public refPos: number;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public EAN: string | null;
 
   @Column()
   public value: number;
 
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public clientReference: number | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public resultCodeIssueCard: IntersolveVoucherResultCode | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public cardId: string | null;
 
   // The values stored in this column should be 6 digits however some entries could be missing their first
   // 0 because convert this value from string to number. Currently however the data stores in this
   // column is never used. But when we do use this data we have to find a solution for this.
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public PIN: number | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public balance: number | null;
 
   // TODO: REFACTOR: into a JoinColumn with the Transaction Entity
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public transactionId: number | null;
 
   @Column({ default: false })
@@ -41,10 +41,10 @@ export class IntersolveIssueVoucherRequestEntity extends Base121Entity {
   @Column({ default: 0 })
   public cancellationAttempts: number;
 
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public cancelByRefPosResultCode: IntersolveVoucherResultCode | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public cancelResultCode: IntersolveVoucherResultCode | null;
 
   @Column({ default: false })

--- a/services/121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-voucher.entity.ts
+++ b/services/121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-voucher.entity.ts
@@ -4,10 +4,10 @@ import { Column, Entity, Index, OneToMany } from 'typeorm';
 
 @Entity('intersolve_voucher')
 export class IntersolveVoucherEntity extends Base121Entity {
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public payment: number | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public whatsappPhoneNumber: string | null;
 
   @Column()
@@ -21,7 +21,7 @@ export class IntersolveVoucherEntity extends Base121Entity {
   public amount: number | null;
 
   @Index()
-  @Column({ nullable: true })
+  @Column({ type: 'boolean', nullable: true })
   public send: boolean | null;
 
   @Index()
@@ -33,11 +33,11 @@ export class IntersolveVoucherEntity extends Base121Entity {
   @Column({ nullable: true, default: null, type: 'real' })
   public lastRequestedBalance: number | null;
 
-  @Column({ nullable: true, default: null })
+  @Column({ nullable: true, default: null, type: 'timestamp' })
   public updatedLastRequestedBalance: Date | null;
 
   @Index()
-  @Column({ nullable: true, default: 0 })
+  @Column({ nullable: true, default: 0, type: 'integer' })
   public reminderCount: number | null;
 
   @OneToMany((_type) => ImageCodeExportVouchersEntity, (image) => image.voucher)

--- a/services/121-service/src/payments/transactions/transaction.entity.ts
+++ b/services/121-service/src/payments/transactions/transaction.entity.ts
@@ -26,7 +26,7 @@ export class TransactionEntity extends Base121AuditedEntity {
   @Index()
   public status: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public errorMessage: string | null;
 
   @ManyToOne((_type) => ProgramEntity, (program) => program.transactions)

--- a/services/121-service/src/programs/program-question.entity.ts
+++ b/services/121-service/src/programs/program-question.entity.ts
@@ -65,7 +65,7 @@ export class ProgramQuestionEntity extends CascadeDeleteEntity {
   @ApiProperty({ example: [] })
   public export: ExportType[];
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   @ApiProperty({ example: 'pattern' })
   public pattern: string | null;
 

--- a/services/121-service/src/programs/program.entity.ts
+++ b/services/121-service/src/programs/program.entity.ts
@@ -28,34 +28,34 @@ import {
 
 @Entity('program')
 export class ProgramEntity extends CascadeDeleteEntity {
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public location: string | null;
 
   @Column('json', { nullable: true })
   public titlePortal: LocalizedString | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public ngo: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'timestamp', nullable: true })
   public startDate: Date | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'timestamp', nullable: true })
   public endDate: Date | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public currency: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public distributionFrequency: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public distributionDuration: number | null;
 
   @Column({ nullable: true, type: 'real' })
   public fixedTransferValue: number | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public paymentAmountMultiplierFormula: string | null;
 
   @ManyToMany(
@@ -65,7 +65,7 @@ export class ProgramEntity extends CascadeDeleteEntity {
   @JoinTable()
   public financialServiceProviders: FinancialServiceProviderEntity[];
 
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public targetNrRegistrations: number | null;
 
   @Column('json', { nullable: true })
@@ -131,7 +131,7 @@ export class ProgramEntity extends CascadeDeleteEntity {
   @Column({ default: false })
   public enableScope: boolean;
 
-  @Column({ nullable: true, default: null })
+  @Column({ nullable: true, default: null, type: 'integer' })
   public budget: number | null;
 
   @OneToMany(
@@ -140,7 +140,7 @@ export class ProgramEntity extends CascadeDeleteEntity {
   )
   public programFspConfiguration: ProgramFspConfigurationEntity[];
 
-  @Column({ nullable: true, default: null })
+  @Column({ nullable: true, default: null, type: 'character varying' })
   public monitoringDashboardUrl: string | null;
 
   @Column({ default: false })

--- a/services/121-service/src/registration/registration-data.entity.ts
+++ b/services/121-service/src/registration/registration-data.entity.ts
@@ -35,7 +35,7 @@ export class RegistrationDataEntity extends Base121Entity {
   )
   @JoinColumn({ name: 'programQuestionId' })
   public programQuestion: ProgramQuestionEntity;
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public programQuestionId: number | null;
 
   @ManyToOne(
@@ -44,7 +44,7 @@ export class RegistrationDataEntity extends Base121Entity {
   )
   @JoinColumn({ name: 'fspQuestionId' })
   public fspQuestion: FspQuestionEntity;
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public fspQuestionId: number | null;
 
   @ManyToOne(
@@ -53,7 +53,7 @@ export class RegistrationDataEntity extends Base121Entity {
   )
   @JoinColumn({ name: 'programCustomAttributeId' })
   public programCustomAttribute: ProgramCustomAttributeEntity;
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public programCustomAttributeId: number | null;
 
   @Index()

--- a/services/121-service/src/registration/registration.entity.ts
+++ b/services/121-service/src/registration/registration.entity.ts
@@ -52,7 +52,7 @@ export class RegistrationEntity extends CascadeDeleteEntity {
   public user: UserEntity;
 
   @Index()
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public registrationStatus: RegistrationStatusEnum | null;
 
   @Index({ unique: true })
@@ -62,21 +62,21 @@ export class RegistrationEntity extends CascadeDeleteEntity {
   @OneToMany(() => RegistrationDataEntity, (data) => data.registration)
   public data: RegistrationDataEntity[];
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public phoneNumber: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   @IsEnum(LanguageEnum)
   public preferredLanguage: LanguageEnum | null;
 
   @Index({ unique: false })
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public inclusionScore: number | null;
 
   @ManyToOne((_type) => FinancialServiceProviderEntity)
   @JoinColumn({ name: 'fspId' })
   public fsp: FinancialServiceProviderEntity;
-  @Column({ nullable: true })
+  @Column({ type: 'integer', nullable: true })
   public fspId: number | null;
 
   @Column({ nullable: false, default: 1 })
@@ -91,7 +91,7 @@ export class RegistrationEntity extends CascadeDeleteEntity {
   @Index()
   public registrationProgramId: number;
 
-  @Column({ nullable: true })
+  @Column({ nullable: true, type: 'integer' })
   @IsInt()
   @IsPositive()
   @IsOptional()

--- a/services/121-service/src/user/user-role.entity.ts
+++ b/services/121-service/src/user/user-role.entity.ts
@@ -8,7 +8,7 @@ export class UserRoleEntity extends Base121Entity {
   @Column({ unique: true })
   public role: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   public label: string | null;
 
   @ManyToMany(

--- a/services/121-service/src/user/user.entity.ts
+++ b/services/121-service/src/user/user.entity.ts
@@ -18,7 +18,7 @@ import {
 @Entity('user')
 export class UserEntity extends CascadeDeleteEntity {
   @Index({ unique: true })
-  @Column({ nullable: true })
+  @Column({ type: 'character varying', nullable: true })
   @ApiProperty({ example: 'username' })
   public username: string | null;
 
@@ -79,7 +79,7 @@ export class UserEntity extends CascadeDeleteEntity {
     ]);
   }
 
-  @Column({ nullable: true, select: false })
+  @Column({ nullable: true, select: false, type: 'character varying' })
   @ApiProperty()
   public salt: string | null;
 
@@ -87,7 +87,7 @@ export class UserEntity extends CascadeDeleteEntity {
   @ApiProperty({ example: true })
   public active: boolean;
 
-  @Column({ nullable: true })
+  @Column({ type: 'timestamp', nullable: true })
   @ApiProperty({ example: new Date() })
   public lastLogin: Date | null;
 }


### PR DESCRIPTION
[AB#28379](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/28379)

When enabling `strict: true`, typeorm is not able to coincile nullable properties on entities that don't explicitly have a type: https://github.com/typeorm/typeorm/issues/2567#issuecomment-408599335

It sucks that we have to do this, but I couldn't find a way around it.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
