### PR TITLE
chore: improve changePreferredLanguage test

### DIFF
--- a/e2e/pages/RegistrationDetails/RegistrationDetailsPage.ts
+++ b/e2e/pages/RegistrationDetails/RegistrationDetailsPage.ts
@@ -193,6 +193,10 @@ class RegistrationDetails {
     await saveButton.waitFor({ state: 'visible' });
     await saveButton.click();
 
+    await expect(
+      this.page.getByText(englishTranslations.common['update-success']),
+    ).toBeVisible();
+
     await okButton.waitFor({ state: 'visible' });
     await okButton.click();
   }


### PR DESCRIPTION
## Describe your changes

In a separate branch, this test was failing, but I couldn't tell why.

Then I realised that the test was proceeding, even though an error occurred. That is because it pressed "ok" twice even if there was an error, without checking the label of what it was clicking "ok" on.

This should improve the messaging when it actually fails.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
