### PR TITLE
Improve speed of E2E-test runs

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -18,7 +18,7 @@ on:
       - '!**.md'
 
 env:
-  e2eTestsPath: 'e2e/'
+  e2eTestsPath: './e2e'
 
 jobs:
   test:
@@ -46,7 +46,7 @@ jobs:
 
       - name: Set ENV-variables for test-environment
         run: |
-          cp ./services/.env.example services/.env
+          cp services/.env.example services/.env
 
       - name: Run Services with Docker
         working-directory: ./services
@@ -77,7 +77,7 @@ jobs:
           timeout 90s sh -c 'until curl http://localhost:8088 -I; do echo "Waiting for the Portal to be running..."; sleep 1; done'
 
       - name: Run E2E-Tests with Playwright
-        working-directory: ./e2e
+        working-directory: ${{ env.e2eTestsPath }}
         env:
           BASE_URL: http://localhost:8088
         run: |
@@ -88,7 +88,7 @@ jobs:
         with:
           name: test-result-artifacts
           path: |
-            ./e2e/test-results/
+            ${{ env.e2eTestsPath }}/test-results/
             ./interfaces/Portal/portal-server-logs.txt
           retention-days: 30
 

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -35,6 +35,15 @@ jobs:
           cache: 'npm'
           cache-dependency-path: '${{ env.e2eTestsPath }}/package-lock.json'
 
+      - name: Install E2E-Tests code-dependencies
+        working-directory: ${{ env.e2eTestsPath }}
+        run: |
+          npm ci --omit=optional --no-fund --no-audit
+
+      - name: Lint E2E-Tests code
+        working-directory: ${{ env.e2eTestsPath }}
+        run: 'npm run lint'
+
       - name: Set ENV-variables for test-environment
         run: |
           cp ./services/.env.example services/.env
@@ -52,27 +61,22 @@ jobs:
           npm install
           npm run start:debug-production > portal-server-logs.txt 2>&1 &
 
-      - name: Install e2e dependencies
-        working-directory: ${{ env.e2eTestsPath }}
-        run: |
-          npm ci --omit=optional --no-fund --no-audit
-          npx playwright install chromium --with-deps
-
-      - name: Lint e2e tests
-        working-directory: ${{ env.e2eTestsPath }}
-        run: 'npm run lint'
-
-      - name: Install service dependencies
+      - name: Install 121-Service dependencies
         # This step is necessary because the tests run functions in this folder
         working-directory: ./services/121-service
         run: |
           npm install
 
+      - name: Install E2E-Tests runtime-dependencies
+        working-directory: ${{ env.e2eTestsPath }}
+        run: |
+          npx playwright install chromium --with-deps
+
       - name: Wait for Portal
         run: |
           timeout 90s sh -c 'until curl http://localhost:8088 -I; do echo "Waiting for the Portal to be running..."; sleep 1; done'
 
-      - name: Run e2e tests with Playwright
+      - name: Run E2E-Tests with Playwright
         working-directory: ./e2e
         env:
           BASE_URL: http://localhost:8088


### PR DESCRIPTION
- Fail as early as possible with the 'lightest' tests (linting)
- Add some caching-steps to reuse effort of previous test-runs

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
