### PR TITLE
fix: show completed status on people affected page and default sort as registrationCreated for PAs AB#28422

### DIFF
--- a/interfaces/Portal/src/app/components/status-table-filter/status-table-filter.component.ts
+++ b/interfaces/Portal/src/app/components/status-table-filter/status-table-filter.component.ts
@@ -36,11 +36,9 @@ export class StatusTableFilterComponent {
       RegistrationStatus.paused,
       RegistrationStatus.included,
       RegistrationStatus.declined,
-    ],
-    [ProgramTab.payment]: [
-      RegistrationStatus.included,
       RegistrationStatus.completed,
     ],
+    [ProgramTab.payment]: [RegistrationStatus.included],
   };
 
   constructor(

--- a/interfaces/Portal/src/app/services/programs-service-api.service.ts
+++ b/interfaces/Portal/src/app/services/programs-service-api.service.ts
@@ -4,7 +4,11 @@ import { saveAs } from 'file-saver';
 import { environment } from '../../environments/environment';
 import { UserRole } from '../auth/user-role.enum';
 import { ApiPath } from '../enums/api-path.enum';
-import { FilterOperator, FilterParameter } from '../enums/filters.enum';
+import {
+  FilterOperator,
+  FilterParameter,
+  SortDirection,
+} from '../enums/filters.enum';
 import RegistrationStatus from '../enums/registration-status.enum';
 import { ActionType, LatestAction } from '../models/actions.model';
 import { Event } from '../models/event.model';
@@ -596,6 +600,11 @@ export class ProgramsServiceApiService {
     params = params.append('limit', limit);
     params = params.append('page', page);
 
+    const defaultSortOption: PaginationSort = {
+      column: 'registrationCreated',
+      direction: SortDirection.DESC,
+    };
+
     // TODO: This still needs to be added to the back-end in a future item
     if (referenceId) {
       params = params.append('filter.referenceId', referenceId);
@@ -617,6 +626,11 @@ export class ProgramsServiceApiService {
     }
     if (sort) {
       params = params.append('sortBy', `${sort.column}:${sort.direction}`);
+    } else {
+      params.append(
+        'sortBy',
+        `${defaultSortOption.column}:${defaultSortOption.direction}`,
+      );
     }
 
     const { data, meta, links } = await this.apiService.get(


### PR DESCRIPTION
<!--- [AB#1234](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/1234) Only if relevant, start with a link to an issue on Azure DevOps -->

bug fix: Displaying "completed" status PAs on people affected page with others as default and adding a default sort as `registrationCreated` for pulled PAs data.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines
