### PR TITLE
AB#28415 add pause visa card test

### DIFF
--- a/e2e/pages/PhysicalCardOverview/PhysicalCardOverview.ts
+++ b/e2e/pages/PhysicalCardOverview/PhysicalCardOverview.ts
@@ -1,0 +1,94 @@
+import { Locator, expect } from '@playwright/test';
+import { Page } from 'playwright';
+
+class PhysicalCardOverview {
+  readonly page: Page;
+  readonly debitCardPaTable: Locator;
+  readonly debitCardStatus: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    this.debitCardPaTable = this.page.getByTestId(
+      'physical-cards-overview-title',
+    );
+    this.debitCardStatus = this.page.getByTestId('card-status-chip');
+  }
+
+  async validateDebitCardStatus(cardOverviewTitle: string, status: string) {
+    await this.page.waitForLoadState('networkidle');
+    const activeCard = this.debitCardStatus.filter({ hasText: status });
+    expect(await this.debitCardPaTable.textContent()).toContain(
+      cardOverviewTitle,
+    );
+    expect(await activeCard.textContent()).toContain(status);
+  }
+
+  async issueNewVisaDebitCard() {
+    try {
+      const activeCard = this.debitCardStatus.filter({ hasText: 'Active' });
+      await activeCard.waitFor({ state: 'visible' });
+      await activeCard.click();
+
+      const issueNewCardButton = this.page.getByRole('button', {
+        name: 'Issue new card',
+      });
+      await issueNewCardButton.waitFor({ state: 'visible' });
+      await issueNewCardButton.click();
+
+      for (let i = 0; i < 2; i++) {
+        const okButton = this.page.getByRole('button', { name: 'OK' });
+        await okButton.waitFor({ state: 'visible' });
+        await okButton.click();
+      }
+    } catch (error) {
+      console.error(`Failed to issue new Visa debit card: ${error}`);
+    }
+  }
+
+  async pauseVisaDebitCard() {
+    try {
+      const activeCard = this.debitCardStatus.filter({ hasText: 'Active' });
+      await activeCard.waitFor({ state: 'visible' });
+      await activeCard.click();
+
+      const pauseCardButton = this.page.getByRole('button', {
+        name: 'Pause card',
+      });
+      await pauseCardButton.waitFor({ state: 'visible' });
+      await pauseCardButton.click();
+
+      for (let i = 0; i < 2; i++) {
+        const okButton = this.page.getByRole('button', { name: 'OK' });
+        await okButton.waitFor({ state: 'visible' });
+        await okButton.click();
+      }
+    } catch (error) {
+      console.error(`Failed to pause new Visa debit card: ${error}`);
+    }
+  }
+
+  async unPauseVisaDebitCard() {
+    try {
+      const activeCard = this.debitCardStatus.filter({ hasText: 'Paused' });
+      await activeCard.waitFor({ state: 'visible' });
+      await activeCard.click();
+
+      const unPauseCardButton = this.page.getByRole('button', {
+        name: 'Unpause card',
+      });
+      await unPauseCardButton.waitFor({ state: 'visible' });
+      await unPauseCardButton.click();
+
+      for (let i = 0; i < 2; i++) {
+        const okButton = this.page.getByRole('button', { name: 'OK' });
+        await okButton.waitFor({ state: 'visible' });
+        await okButton.click();
+      }
+    } catch (error) {
+      console.error(`Failed to unpause new Visa debit card: ${error}`);
+    }
+  }
+}
+
+export default PhysicalCardOverview;

--- a/e2e/pages/RegistrationDetails/RegistrationDetailsPage.ts
+++ b/e2e/pages/RegistrationDetails/RegistrationDetailsPage.ts
@@ -262,6 +262,28 @@ class RegistrationDetails {
     }
   }
 
+  async pauseVisaDebitCard() {
+    try {
+      const activeCard = this.debitCardStatus.filter({ hasText: 'Active' });
+      await activeCard.waitFor({ state: 'visible' });
+      await activeCard.click();
+
+      const issueNewCardButton = this.page.getByRole('button', {
+        name: 'Pause card',
+      });
+      await issueNewCardButton.waitFor({ state: 'visible' });
+      await issueNewCardButton.click();
+
+      for (let i = 0; i < 2; i++) {
+        const okButton = this.page.getByRole('button', { name: 'OK' });
+        await okButton.waitFor({ state: 'visible' });
+        await okButton.click();
+      }
+    } catch (error) {
+      console.error(`Failed to issue new Visa debit card: ${error}`);
+    }
+  }
+
   async openActivityOverviewTab(tabName: string) {
     await this.page.waitForLoadState('load');
     await this.tabButton
@@ -535,7 +557,6 @@ class RegistrationDetails {
     //if does not pass a new value for multiplier, set new amount= old amount + 1
     if (amount == 'default') {
       amount = (parseInt(oldAmount, 10) + 1).toString();
-      console.log(amount);
     }
     await paymentMultipierInput.fill(amount);
 

--- a/e2e/pages/RegistrationDetails/RegistrationDetailsPage.ts
+++ b/e2e/pages/RegistrationDetails/RegistrationDetailsPage.ts
@@ -15,8 +15,6 @@ class RegistrationDetails {
   readonly showAllButton: Locator;
   readonly editPersonAffectedPopUp: Locator;
   readonly financialServiceProviderDropdown: Locator;
-  readonly debitCardPaTable: Locator;
-  readonly debitCardStatus: Locator;
   readonly tabButton: Locator;
   readonly historyTile: Locator;
   readonly historyTileTitle: Locator;
@@ -64,10 +62,6 @@ class RegistrationDetails {
     this.financialServiceProviderDropdown = this.page.locator(
       'app-update-fsp #select-label',
     );
-    this.debitCardPaTable = this.page.getByTestId(
-      'physical-cards-overview-title',
-    );
-    this.debitCardStatus = this.page.getByTestId('card-status-chip');
     this.tabButton = this.page.getByTestId(
       'registration-activity-detail-tab-button',
     );
@@ -229,59 +223,6 @@ class RegistrationDetails {
     await this.updateReasonTextArea
       .locator('textarea')
       .fill(`Change language to ${language}`);
-  }
-
-  async validateDebitCardStatus(cardOverviewTitle: string, status: string) {
-    await this.page.waitForLoadState('networkidle');
-    const activeCard = this.debitCardStatus.filter({ hasText: status });
-    expect(await this.debitCardPaTable.textContent()).toContain(
-      cardOverviewTitle,
-    );
-    expect(await activeCard.textContent()).toContain(status);
-  }
-
-  async issueNewVisaDebitCard() {
-    try {
-      const activeCard = this.debitCardStatus.filter({ hasText: 'Active' });
-      await activeCard.waitFor({ state: 'visible' });
-      await activeCard.click();
-
-      const issueNewCardButton = this.page.getByRole('button', {
-        name: 'Issue new card',
-      });
-      await issueNewCardButton.waitFor({ state: 'visible' });
-      await issueNewCardButton.click();
-
-      for (let i = 0; i < 2; i++) {
-        const okButton = this.page.getByRole('button', { name: 'OK' });
-        await okButton.waitFor({ state: 'visible' });
-        await okButton.click();
-      }
-    } catch (error) {
-      console.error(`Failed to issue new Visa debit card: ${error}`);
-    }
-  }
-
-  async pauseVisaDebitCard() {
-    try {
-      const activeCard = this.debitCardStatus.filter({ hasText: 'Active' });
-      await activeCard.waitFor({ state: 'visible' });
-      await activeCard.click();
-
-      const issueNewCardButton = this.page.getByRole('button', {
-        name: 'Pause card',
-      });
-      await issueNewCardButton.waitFor({ state: 'visible' });
-      await issueNewCardButton.click();
-
-      for (let i = 0; i < 2; i++) {
-        const okButton = this.page.getByRole('button', { name: 'OK' });
-        await okButton.waitFor({ state: 'visible' });
-        await okButton.click();
-      }
-    } catch (error) {
-      console.error(`Failed to issue new Visa debit card: ${error}`);
-    }
   }
 
   async openActivityOverviewTab(tabName: string) {

--- a/e2e/pages/Table/TableModule.ts
+++ b/e2e/pages/Table/TableModule.ts
@@ -94,7 +94,6 @@ class TableModule {
       i++;
     }
     if (content.includes(text)) {
-      console.log(`Element with text "${content}" was displayed`);
       return;
     } else {
       throw new Error(

--- a/e2e/tests/121-Portal/EditInfoPersonAffected/UpdatePaymentMultiplierInvalid.spec.ts
+++ b/e2e/tests/121-Portal/EditInfoPersonAffected/UpdatePaymentMultiplierInvalid.spec.ts
@@ -26,7 +26,7 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
-test('[28057] Update paymentAmountMultiplier with invalid value', async ({
+test('[28040] Update paymentAmountMultiplier with invalid value', async ({
   page,
 }) => {
   const table = new TableModule(page);

--- a/e2e/tests/121-Portal/MakeNewPayment/OCW/MakeSuccessfulPaymentOCW.spec.ts
+++ b/e2e/tests/121-Portal/MakeNewPayment/OCW/MakeSuccessfulPaymentOCW.spec.ts
@@ -32,7 +32,7 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
-test('[28274] OCW: Make Successful payment', async ({ page }) => {
+test('[28445] OCW: Make Successful payment', async ({ page }) => {
   const tableModule = new TableModule(page);
   const navigationModule = new NavigationModule(page);
   const homePage = new HomePage(page);

--- a/e2e/tests/121-Portal/MakeNewPayment/OCW/PauseCardOCW.spec.ts
+++ b/e2e/tests/121-Portal/MakeNewPayment/OCW/PauseCardOCW.spec.ts
@@ -3,21 +3,21 @@ import LoginPage from '@121-e2e/pages/Login/LoginPage';
 import NavigationModule from '@121-e2e/pages/Navigation/NavigationModule';
 import RegistrationDetails from '@121-e2e/pages/RegistrationDetails/RegistrationDetailsPage';
 import TableModule from '@121-e2e/pages/Table/TableModule';
-import NLRCProgramPV from '@121-service/seed-data/program/program-nlrc-pv.json';
+import NLRCProgram from '@121-service/seed-data/program/program-nlrc-ocw.json';
 import { WalletCardStatus121 } from '@121-service/src/payments/fsp-integration/intersolve-visa/enum/wallet-status-121.enum';
 import { SeedScript } from '@121-service/src/scripts/seed-script.enum';
 import { seedPaidRegistrations } from '@121-service/test/helpers/registration.helper';
 import { resetDB } from '@121-service/test/helpers/utility.helper';
-import { registrationsPV } from '@121-service/test/registrations/pagination/pagination-data';
+import { registrationsOCW } from '@121-service/test/registrations/pagination/pagination-data';
 import { test } from '@playwright/test';
 import englishTranslations from '../../../../../interfaces/Portal/src/assets/i18n/en.json';
 
 test.beforeEach(async ({ page }) => {
   await resetDB(SeedScript.nlrcMultiple);
-  const programIdPV = 2;
-  const pvProgramId = programIdPV;
+  const programIdOCW = 3;
+  const OcwProgramId = programIdOCW;
 
-  await seedPaidRegistrations(registrationsPV, pvProgramId);
+  await seedPaidRegistrations(registrationsOCW, OcwProgramId);
 
   // Login
   const loginPage = new LoginPage(page);
@@ -28,32 +28,31 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
-test('[28428] Re-issue Visa debit cards', async ({ page }) => {
+test('[28441] Pause Visa debit cards', async ({ page }) => {
   const table = new TableModule(page);
   const navigationModule = new NavigationModule(page);
   const registration = new RegistrationDetails(page);
   const homePage = new HomePage(page);
 
   await test.step('Should navigate to PA profile page in Payment table', async () => {
-    await homePage.navigateToProgramme(NLRCProgramPV.titlePortal.en);
+    await homePage.navigateToProgramme(NLRCProgram.titlePortal.en);
     await navigationModule.navigateToProgramTab(
       englishTranslations.page.program.tab.payment.label,
     );
-    await table.clickOnPaNumber(3);
+    await table.clickOnPaNumber(2);
   });
 
-  await test.step('Should Re-Issue Visa Card and details are presented correctly with status: Active and Blocked/ Substituted', async () => {
+  await test.step('Should Pause Visa Card and details are presented correctly with status: Paused', async () => {
     await registration.validateDebitCardStatus(
       englishTranslations['registration-details']['physical-cards-overview']
         .title,
       WalletCardStatus121.Active,
     );
-    await registration.issueNewVisaDebitCard();
-    // FOR NOW STATUS SHOULD BE BLOCKED BUT AFTER NEW CHANGES ARE APPLIED THIS SHOULD BE CHANGED INTO "SUBSTITUTED"
+    await registration.pauseVisaDebitCard();
     await registration.validateDebitCardStatus(
       englishTranslations['registration-details']['physical-cards-overview']
         .title,
-      WalletCardStatus121.Blocked,
+      WalletCardStatus121.Paused,
     );
   });
 });

--- a/e2e/tests/121-Portal/MakeNewPayment/OCW/PauseCardOCW.spec.ts
+++ b/e2e/tests/121-Portal/MakeNewPayment/OCW/PauseCardOCW.spec.ts
@@ -1,7 +1,7 @@
 import HomePage from '@121-e2e/pages/Home/HomePage';
 import LoginPage from '@121-e2e/pages/Login/LoginPage';
 import NavigationModule from '@121-e2e/pages/Navigation/NavigationModule';
-import RegistrationDetails from '@121-e2e/pages/RegistrationDetails/RegistrationDetailsPage';
+import PhysicalCardOverview from '@121-e2e/pages/PhysicalCardOverview/PhysicalCardOverview';
 import TableModule from '@121-e2e/pages/Table/TableModule';
 import NLRCProgram from '@121-service/seed-data/program/program-nlrc-ocw.json';
 import { WalletCardStatus121 } from '@121-service/src/payments/fsp-integration/intersolve-visa/enum/wallet-status-121.enum';
@@ -28,10 +28,10 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
-test('[28441] Pause Visa debit cards', async ({ page }) => {
+test('[28462] Pause Visa debit cards', async ({ page }) => {
   const table = new TableModule(page);
   const navigationModule = new NavigationModule(page);
-  const registration = new RegistrationDetails(page);
+  const physicalCard = new PhysicalCardOverview(page);
   const homePage = new HomePage(page);
 
   await test.step('Should navigate to PA profile page in Payment table', async () => {
@@ -43,16 +43,22 @@ test('[28441] Pause Visa debit cards', async ({ page }) => {
   });
 
   await test.step('Should Pause Visa Card and details are presented correctly with status: Paused', async () => {
-    await registration.validateDebitCardStatus(
+    await physicalCard.validateDebitCardStatus(
       englishTranslations['registration-details']['physical-cards-overview']
         .title,
       WalletCardStatus121.Active,
     );
-    await registration.pauseVisaDebitCard();
-    await registration.validateDebitCardStatus(
+    await physicalCard.pauseVisaDebitCard();
+    await physicalCard.validateDebitCardStatus(
       englishTranslations['registration-details']['physical-cards-overview']
         .title,
       WalletCardStatus121.Paused,
+    );
+    await physicalCard.unPauseVisaDebitCard();
+    await physicalCard.validateDebitCardStatus(
+      englishTranslations['registration-details']['physical-cards-overview']
+        .title,
+      WalletCardStatus121.Active,
     );
   });
 });

--- a/e2e/tests/121-Portal/MakeNewPayment/OCW/ReIssueCardOCW.spec.ts
+++ b/e2e/tests/121-Portal/MakeNewPayment/OCW/ReIssueCardOCW.spec.ts
@@ -28,7 +28,7 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
-test('[28427] View Visa debit cards table', async ({ page }) => {
+test('[28427] Re-issue Visa debit cards', async ({ page }) => {
   const table = new TableModule(page);
   const navigationModule = new NavigationModule(page);
   const registration = new RegistrationDetails(page);

--- a/e2e/tests/121-Portal/MakeNewPayment/OCW/ReIssueCardOCW.spec.ts
+++ b/e2e/tests/121-Portal/MakeNewPayment/OCW/ReIssueCardOCW.spec.ts
@@ -1,7 +1,7 @@
 import HomePage from '@121-e2e/pages/Home/HomePage';
 import LoginPage from '@121-e2e/pages/Login/LoginPage';
 import NavigationModule from '@121-e2e/pages/Navigation/NavigationModule';
-import RegistrationDetails from '@121-e2e/pages/RegistrationDetails/RegistrationDetailsPage';
+import PhysicalCardOverview from '@121-e2e/pages/PhysicalCardOverview/PhysicalCardOverview';
 import TableModule from '@121-e2e/pages/Table/TableModule';
 import NLRCProgram from '@121-service/seed-data/program/program-nlrc-ocw.json';
 import { WalletCardStatus121 } from '@121-service/src/payments/fsp-integration/intersolve-visa/enum/wallet-status-121.enum';
@@ -28,10 +28,10 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
-test('[28427] Re-issue Visa debit cards', async ({ page }) => {
+test('[28461] Re-issue Visa debit cards', async ({ page }) => {
   const table = new TableModule(page);
   const navigationModule = new NavigationModule(page);
-  const registration = new RegistrationDetails(page);
+  const physicalCard = new PhysicalCardOverview(page);
   const homePage = new HomePage(page);
 
   await test.step('Should navigate to PA profile page in Payment table', async () => {
@@ -43,14 +43,14 @@ test('[28427] Re-issue Visa debit cards', async ({ page }) => {
   });
 
   await test.step('Should Re-Issue Visa Card and details are presented correctly with status: Active and Blocked/ Substituted', async () => {
-    await registration.validateDebitCardStatus(
+    await physicalCard.validateDebitCardStatus(
       englishTranslations['registration-details']['physical-cards-overview']
         .title,
       WalletCardStatus121.Active,
     );
-    await registration.issueNewVisaDebitCard();
+    await physicalCard.issueNewVisaDebitCard();
     // FOR NOW STATUS SHOULD BE BLOCKED BUT AFTER NEW CHANGES ARE APPLIED THIS SHOULD BE CHANGED INTO "SUBSTITUTED"
-    await registration.validateDebitCardStatus(
+    await physicalCard.validateDebitCardStatus(
       englishTranslations['registration-details']['physical-cards-overview']
         .title,
       WalletCardStatus121.Blocked,

--- a/e2e/tests/121-Portal/MakeNewPayment/OCW/ShowMaximumTotalAmountOCW.spec.ts
+++ b/e2e/tests/121-Portal/MakeNewPayment/OCW/ShowMaximumTotalAmountOCW.spec.ts
@@ -31,7 +31,7 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
-test('[28297] OCW: Show maximum total amount (Dry Run)', async ({ page }) => {
+test('[28446] OCW: Show maximum total amount (Dry Run)', async ({ page }) => {
   const tableModule = new TableModule(page);
   const navigationModule = new NavigationModule(page);
   const homePage = new HomePage(page);

--- a/e2e/tests/121-Portal/MakeNewPayment/PV/MakeSuccessfulPaymentPV.spec.ts
+++ b/e2e/tests/121-Portal/MakeNewPayment/PV/MakeSuccessfulPaymentPV.spec.ts
@@ -32,7 +32,7 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
-test('[28316] PV: Make Successful payment', async ({ page }) => {
+test('[28463] PV: Make Successful payment', async ({ page }) => {
   const tableModule = new TableModule(page);
   const navigationModule = new NavigationModule(page);
   const homePage = new HomePage(page);

--- a/e2e/tests/121-Portal/MakeNewPayment/PV/PauseCardPV.spec.ts
+++ b/e2e/tests/121-Portal/MakeNewPayment/PV/PauseCardPV.spec.ts
@@ -28,7 +28,7 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
-test('[28428] Re-issue Visa debit cards', async ({ page }) => {
+test('[28442] Pause Visa debit cards', async ({ page }) => {
   const table = new TableModule(page);
   const navigationModule = new NavigationModule(page);
   const registration = new RegistrationDetails(page);
@@ -42,18 +42,17 @@ test('[28428] Re-issue Visa debit cards', async ({ page }) => {
     await table.clickOnPaNumber(3);
   });
 
-  await test.step('Should Re-Issue Visa Card and details are presented correctly with status: Active and Blocked/ Substituted', async () => {
+  await test.step('Should Pause Visa Card and details are presented correctly with status: Paused', async () => {
     await registration.validateDebitCardStatus(
       englishTranslations['registration-details']['physical-cards-overview']
         .title,
       WalletCardStatus121.Active,
     );
-    await registration.issueNewVisaDebitCard();
-    // FOR NOW STATUS SHOULD BE BLOCKED BUT AFTER NEW CHANGES ARE APPLIED THIS SHOULD BE CHANGED INTO "SUBSTITUTED"
+    await registration.pauseVisaDebitCard();
     await registration.validateDebitCardStatus(
       englishTranslations['registration-details']['physical-cards-overview']
         .title,
-      WalletCardStatus121.Blocked,
+      WalletCardStatus121.Paused,
     );
   });
 });

--- a/e2e/tests/121-Portal/MakeNewPayment/PV/PauseCardPV.spec.ts
+++ b/e2e/tests/121-Portal/MakeNewPayment/PV/PauseCardPV.spec.ts
@@ -1,7 +1,7 @@
 import HomePage from '@121-e2e/pages/Home/HomePage';
 import LoginPage from '@121-e2e/pages/Login/LoginPage';
 import NavigationModule from '@121-e2e/pages/Navigation/NavigationModule';
-import RegistrationDetails from '@121-e2e/pages/RegistrationDetails/RegistrationDetailsPage';
+import PhysicalCardOverview from '@121-e2e/pages/PhysicalCardOverview/PhysicalCardOverview';
 import TableModule from '@121-e2e/pages/Table/TableModule';
 import NLRCProgramPV from '@121-service/seed-data/program/program-nlrc-pv.json';
 import { WalletCardStatus121 } from '@121-service/src/payments/fsp-integration/intersolve-visa/enum/wallet-status-121.enum';
@@ -28,10 +28,10 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
-test('[28442] Pause Visa debit cards', async ({ page }) => {
+test('[28480] Pause Visa debit cards', async ({ page }) => {
   const table = new TableModule(page);
   const navigationModule = new NavigationModule(page);
-  const registration = new RegistrationDetails(page);
+  const physicalCard = new PhysicalCardOverview(page);
   const homePage = new HomePage(page);
 
   await test.step('Should navigate to PA profile page in Payment table', async () => {
@@ -43,16 +43,22 @@ test('[28442] Pause Visa debit cards', async ({ page }) => {
   });
 
   await test.step('Should Pause Visa Card and details are presented correctly with status: Paused', async () => {
-    await registration.validateDebitCardStatus(
+    await physicalCard.validateDebitCardStatus(
       englishTranslations['registration-details']['physical-cards-overview']
         .title,
       WalletCardStatus121.Active,
     );
-    await registration.pauseVisaDebitCard();
-    await registration.validateDebitCardStatus(
+    await physicalCard.pauseVisaDebitCard();
+    await physicalCard.validateDebitCardStatus(
       englishTranslations['registration-details']['physical-cards-overview']
         .title,
       WalletCardStatus121.Paused,
+    );
+    await physicalCard.unPauseVisaDebitCard();
+    await physicalCard.validateDebitCardStatus(
+      englishTranslations['registration-details']['physical-cards-overview']
+        .title,
+      WalletCardStatus121.Active,
     );
   });
 });

--- a/e2e/tests/121-Portal/MakeNewPayment/PV/ReIssueCardPV.spec.ts
+++ b/e2e/tests/121-Portal/MakeNewPayment/PV/ReIssueCardPV.spec.ts
@@ -1,7 +1,7 @@
 import HomePage from '@121-e2e/pages/Home/HomePage';
 import LoginPage from '@121-e2e/pages/Login/LoginPage';
 import NavigationModule from '@121-e2e/pages/Navigation/NavigationModule';
-import RegistrationDetails from '@121-e2e/pages/RegistrationDetails/RegistrationDetailsPage';
+import PhysicalCardOverview from '@121-e2e/pages/PhysicalCardOverview/PhysicalCardOverview';
 import TableModule from '@121-e2e/pages/Table/TableModule';
 import NLRCProgramPV from '@121-service/seed-data/program/program-nlrc-pv.json';
 import { WalletCardStatus121 } from '@121-service/src/payments/fsp-integration/intersolve-visa/enum/wallet-status-121.enum';
@@ -28,10 +28,10 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
-test('[28428] Re-issue Visa debit cards', async ({ page }) => {
+test('[28479] Re-issue Visa debit cards', async ({ page }) => {
   const table = new TableModule(page);
   const navigationModule = new NavigationModule(page);
-  const registration = new RegistrationDetails(page);
+  const physicalCard = new PhysicalCardOverview(page);
   const homePage = new HomePage(page);
 
   await test.step('Should navigate to PA profile page in Payment table', async () => {
@@ -43,14 +43,14 @@ test('[28428] Re-issue Visa debit cards', async ({ page }) => {
   });
 
   await test.step('Should Re-Issue Visa Card and details are presented correctly with status: Active and Blocked/ Substituted', async () => {
-    await registration.validateDebitCardStatus(
+    await physicalCard.validateDebitCardStatus(
       englishTranslations['registration-details']['physical-cards-overview']
         .title,
       WalletCardStatus121.Active,
     );
-    await registration.issueNewVisaDebitCard();
+    await physicalCard.issueNewVisaDebitCard();
     // FOR NOW STATUS SHOULD BE BLOCKED BUT AFTER NEW CHANGES ARE APPLIED THIS SHOULD BE CHANGED INTO "SUBSTITUTED"
-    await registration.validateDebitCardStatus(
+    await physicalCard.validateDebitCardStatus(
       englishTranslations['registration-details']['physical-cards-overview']
         .title,
       WalletCardStatus121.Blocked,

--- a/e2e/tests/121-Portal/MakeNewPayment/PV/ShowMaximumTotalAmountPV.spec.ts
+++ b/e2e/tests/121-Portal/MakeNewPayment/PV/ShowMaximumTotalAmountPV.spec.ts
@@ -31,7 +31,7 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
-test('[28317] PV: Show maximum total amount (Dry Run)', async ({ page }) => {
+test('[28464] PV: Show maximum total amount (Dry Run)', async ({ page }) => {
   const tableModule = new TableModule(page);
   const navigationModule = new NavigationModule(page);
   const homePage = new HomePage(page);

--- a/e2e/tests/121-Portal/ViewPaProfilePage/ViewVisaDebitCardsTable.spec.ts
+++ b/e2e/tests/121-Portal/ViewPaProfilePage/ViewVisaDebitCardsTable.spec.ts
@@ -1,6 +1,6 @@
 import HomePage from '@121-e2e/pages/Home/HomePage';
 import LoginPage from '@121-e2e/pages/Login/LoginPage';
-import RegistrationDetails from '@121-e2e/pages/RegistrationDetails/RegistrationDetailsPage';
+import PhysicalCardOverview from '@121-e2e/pages/PhysicalCardOverview/PhysicalCardOverview';
 import TableModule from '@121-e2e/pages/Table/TableModule';
 import NLRCProgram from '@121-service/seed-data/program/program-nlrc-ocw.json';
 import { WalletCardStatus121 } from '@121-service/src/payments/fsp-integration/intersolve-visa/enum/wallet-status-121.enum';
@@ -29,7 +29,7 @@ test.beforeEach(async ({ page }) => {
 
 test('[27494] View Visa debit cards table', async ({ page }) => {
   const table = new TableModule(page);
-  const registration = new RegistrationDetails(page);
+  const physicalCard = new PhysicalCardOverview(page);
   const homePage = new HomePage(page);
 
   await test.step('Should navigate to PA profile page in Payment table', async () => {
@@ -39,16 +39,13 @@ test('[27494] View Visa debit cards table', async ({ page }) => {
   });
 
   await test.step('Should validate PA profile opened succesfully and Visa Card Details are presented correctly with status: Active', async () => {
-    await registration.validateHeaderToContainText(
-      englishTranslations['registration-details'].pageTitle,
-    );
-    await registration.validateDebitCardStatus(
+    await physicalCard.validateDebitCardStatus(
       englishTranslations['registration-details']['physical-cards-overview']
         .title,
       WalletCardStatus121.Active,
     );
-    await registration.issueNewVisaDebitCard();
-    await registration.validateDebitCardStatus(
+    await physicalCard.issueNewVisaDebitCard();
+    await physicalCard.validateDebitCardStatus(
       englishTranslations['registration-details']['physical-cards-overview']
         .title,
       WalletCardStatus121.Blocked,


### PR DESCRIPTION
Adds Pause Visa Debit Card e2e test for both OCW and PV programme & edits the names of Payment related tests.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
