### PR TITLE
Clean dist on start dev

### DIFF
--- a/services/121-service/nest-cli.json
+++ b/services/121-service/nest-cli.json
@@ -13,6 +13,7 @@
       }
     ],
     "watchAssets": true,
+    "deleteOutDir": true,
     "builder": {
       "type": "swc",
       "typeCheck": true,


### PR DESCRIPTION
[AB#28624](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/28624)

## Describe your changes
 If you remove a typescript files the compiled js file remains in the dist folder. This can be annoying when creating and deleting migrations files. Now the way to fix this is: 1) delete dist folder 2) restart 121-service. With this commit you do not have to do 1 as it is done on startup

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
