### PR TITLE
Registration program id in payment export

### DIFF
--- a/services/121-service/src/metrics/metrics.service.ts
+++ b/services/121-service/src/metrics/metrics.service.ts
@@ -845,6 +845,7 @@ export class MetricsService {
       .createQueryBuilder('transaction')
       .select([
         'registration.referenceId as "referenceId"',
+        'registration.registrationProgramId as "id"',
         'transaction.status as "status"',
         'transaction.payment as "payment"',
         'transaction.created as "timestamp"',


### PR DESCRIPTION
AB#28675

## Describe your changes

Add registration Program Id to payment export:
![image](https://github.com/global-121/121-platform/assets/34537157/85daa30f-30e9-46af-9598-22bffe318f26)

- I got called by Jade of how to find the referenceId of a PA in the portal which she needed to find the right person in the payment export
- I therefore noticed registrationProgramId was missing in the payment eport so I added it, because I think it should be there
- I though it was not worth the effort to go through refinement and such for this one, so just created this PR


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines
