### PR TITLE
chore: update 121-service to Typescript@5.5.2

### DIFF
--- a/services/121-service/package-lock.json
+++ b/services/121-service/package-lock.json
@@ -46,7 +46,7 @@
         "tsconfig-paths": "^4.2.0",
         "twilio": "^5.0.4",
         "typeorm": "^0.3.17",
-        "typescript": "^5.5.0-beta",
+        "typescript": "^5.5.2",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
         "xml-js": "^1.6.11"
       },
@@ -2860,19 +2860,6 @@
       },
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@compodoc/ngd-core/node_modules/typescript": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
-      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@compodoc/ngd-transformer": {
@@ -17430,9 +17417,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/typescript": {
-      "version": "5.5.0-beta",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.0-beta.tgz",
-      "integrity": "sha512-FRg3e/aQg3olEG3ff8YjHOERsO4IM0m4qGrsE4UMvILaq4TdDZ6gQX4+2Rq9SjTpfSe/ebwiHcsjm/7FfWWQ6Q==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20212,14 +20199,6 @@
         "ansi-colors": "^4.1.3",
         "fancy-log": "^2.0.0",
         "typescript": "^5.0.4"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "5.4.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
-          "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
-          "dev": true
-        }
       }
     },
     "@compodoc/ngd-transformer": {
@@ -30740,9 +30719,9 @@
       }
     },
     "typescript": {
-      "version": "5.5.0-beta",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.0-beta.tgz",
-      "integrity": "sha512-FRg3e/aQg3olEG3ff8YjHOERsO4IM0m4qGrsE4UMvILaq4TdDZ6gQX4+2Rq9SjTpfSe/ebwiHcsjm/7FfWWQ6Q=="
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew=="
     },
     "uglify-js": {
       "version": "3.17.4",

--- a/services/121-service/package.json
+++ b/services/121-service/package.json
@@ -76,7 +76,7 @@
     "tsconfig-paths": "^4.2.0",
     "twilio": "^5.0.4",
     "typeorm": "^0.3.17",
-    "typescript": "^5.5.0-beta",
+    "typescript": "^5.5.2",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
     "xml-js": "^1.6.11"
   },

--- a/services/121-service/tsconfig.json
+++ b/services/121-service/tsconfig.json
@@ -8,7 +8,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    // Sadly, no way around this, because of TypeORM limitations: https://github.com/typeorm/typeorm/issues/2797#issuecomment-644769490
+    // TODO: https://dev.azure.com/redcrossnl/121%20Platform/_workitems/edit/28804
     "strictPropertyInitialization": false,
     // TODO: https://dev.azure.com/redcrossnl/121%20Platform/_workitems/edit/28419
     "noImplicitAny": false,


### PR DESCRIPTION
[AB#28807](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/28807) 

During the strict branch efforts, we updated typescript to a beta version to get the latest features.

Now the stable version has been released, and we can stop using the beta.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
