### PR TITLE
chore: create template for automatically generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,15 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies # dependabot
+      - ignore-for-release # manually excluded
+  categories:
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug Fixes 🛠
+      labels:
+        - bugfix
+    - title: Other Changes
+      labels:
+        - '*'


### PR DESCRIPTION
I was wondering whether it was possibly to configure this in some way. I found this: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configurations

I figured I would give it a try while we figure out what we do with the actual changelog.

My 0.02$: I would remove CHANGELOG.md altogether and just use the release notes on the releases themselves, and allow github to generate them for us.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
