### PR TITLE
ci: Turn down frequency for Portal dependabot-updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     versioning-strategy: increase
     groups:
       development:
@@ -40,7 +40,7 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     versioning-strategy: increase
     groups:
       development:
@@ -62,9 +62,9 @@ updates:
   - package-ecosystem: npm
     directory: '/interfaces/Portal'
     schedule:
-      interval: weekly
+      interval: monthly
       day: tuesday
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     versioning-strategy: increase
     groups:
       development:


### PR DESCRIPTION
As we're working on "_the new Portal_", we can turn down the 'churn' of updates to the existing Portal.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
