### PR TITLE
chore: add generic to redactSensitiveDataProperties

### DIFF
--- a/services/121-service/src/shared/services/custom-http.service.ts
+++ b/services/121-service/src/shared/services/custom-http.service.ts
@@ -254,7 +254,7 @@ export class CustomHttpService {
    * @param data - Any key-value object
    * @returns - A copy of the input-object with some specific data overwritten/redacted
    */
-  private redactSensitiveDataProperties(data: any) {
+  private redactSensitiveDataProperties<T extends object>(data: T): T {
     if (!isPlainObject(data)) {
       return data;
     }
@@ -274,7 +274,10 @@ export class CustomHttpService {
     }
 
     // Explicitly mask the username/email:
-    if (redactedData.username) {
+    if (
+      'username' in redactedData &&
+      typeof redactedData.username === 'string'
+    ) {
       redactedData.username = maskValueKeepStart(redactedData.username, 3);
     }
 

--- a/services/121-service/src/shared/services/custom-http.service.ts
+++ b/services/121-service/src/shared/services/custom-http.service.ts
@@ -254,7 +254,7 @@ export class CustomHttpService {
    * @param data - Any key-value object
    * @returns - A copy of the input-object with some specific data overwritten/redacted
    */
-  private redactSensitiveDataProperties<T extends object>(data: T): T {
+  private redactSensitiveDataProperties<T>(data: T): T {
     if (!isPlainObject(data)) {
       return data;
     }
@@ -275,6 +275,8 @@ export class CustomHttpService {
 
     // Explicitly mask the username/email:
     if (
+      redactedData &&
+      typeof redactedData === 'object' &&
       'username' in redactedData &&
       typeof redactedData.username === 'string'
     ) {


### PR DESCRIPTION
## Describe your changes

Following up on this discussion: https://github.com/global-121/121-platform/pull/5431#discussion_r1647529254

I wanted to add an example of how to use generics in these circumstances.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
