### PR TITLE
poc: sharing types between BE and FE [simple]

### DIFF
--- a/interfaces/Portal/package-lock.json
+++ b/interfaces/Portal/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "portal",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@angular/animations": "^16.2.12",

--- a/interfaces/Portal/package.json
+++ b/interfaces/Portal/package.json
@@ -26,7 +26,8 @@
     "test:all": "npm run lint && npm test",
     "test:dev": "ng test",
     "test": "ng test --configuration=ci",
-    "upgrade:angular": "ng update @angular/core @angular/cli @angular-eslint/schematics --create-commits"
+    "upgrade:angular": "ng update @angular/core @angular/cli @angular-eslint/schematics --create-commits",
+    "postinstall": "cd ../../services/121-service && npm ci --omit=optional --no-fund --no-audit"
   },
   "private": true,
   "engines": {

--- a/interfaces/Portal/package.json
+++ b/interfaces/Portal/package.json
@@ -27,7 +27,7 @@
     "test:dev": "ng test",
     "test": "ng test --configuration=ci",
     "upgrade:angular": "ng update @angular/core @angular/cli @angular-eslint/schematics --create-commits",
-    "postinstall": "cd ../../services/121-service && npm ci --omit=optional --no-fund --no-audit"
+    "postinstall": "cd ../../services/121-service && npm run install:dependencies-for-portal"
   },
   "private": true,
   "engines": {

--- a/interfaces/Portal/src/app/auth/auth.service.ts
+++ b/interfaces/Portal/src/app/auth/auth.service.ts
@@ -105,7 +105,7 @@ export class AuthService {
   }
 
   private setUserInStorage(user: User): void {
-    const userToStore: User = {
+    const userToStore: Partial<User> = {
       username: user.username,
       permissions: user.permissions,
       isAdmin: user.isAdmin,
@@ -150,6 +150,7 @@ export class AuthService {
     }
 
     return {
+      id: user.id,
       username: user.username,
       permissions: user.permissions,
       expires: user.expires ? user.expires : undefined,

--- a/interfaces/Portal/src/app/components/user-state/user-state.component.spec.ts
+++ b/interfaces/Portal/src/app/components/user-state/user-state.component.spec.ts
@@ -8,6 +8,7 @@ import { User } from 'src/app/models/user.model';
 import { UserStateComponent } from './user-state.component';
 
 const mockUser: User = {
+  id: 42,
   username: 'test@example.org',
   permissions: {
     1: [Permission.ProgramMetricsREAD],

--- a/interfaces/Portal/src/app/models/user.model.ts
+++ b/interfaces/Portal/src/app/models/user.model.ts
@@ -1,14 +1,7 @@
-import Permission from '../auth/permission.enum';
+import { UserController } from '@121-service/src/user/user.controller';
+import { Dto121Service } from '../shared/utils/dto-type';
 
-export class User {
-  username: string;
-  permissions: {
-    [programId: number]: Permission[];
-  };
-  expires?: string;
-  isAdmin?: boolean;
-  isEntraUser?: boolean;
-}
+export type User = Dto121Service<UserController['login']>['user'];
 
 export enum UserType {
   admin = 'admin',

--- a/interfaces/Portal/src/app/shared/utils/dto-type.ts
+++ b/interfaces/Portal/src/app/shared/utils/dto-type.ts
@@ -1,0 +1,73 @@
+/**
+ * This file contains a utility to convert a DTO type from a service controller method
+ * to a type that can be used in the frontend.
+ *
+ * It is based on: https://github.com/tamj0rd2/dto/blob/master/src/dto.ts
+ *
+ * For more info: https://dev.to/tamj0rd2/dto-a-typescript-utility-type-4o3m
+ *
+ * See the bottom of the file for custom utility types.
+ */
+
+type IsOptional<T> = Extract<T, undefined> extends never ? false : true;
+export type Func = (...args: any[]) => any;
+type IsFunction<T> = T extends Func ? true : false;
+type IsValueType<T> = T extends
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Func
+  | Set<any>
+  | Map<any, any>
+  | Date
+  | Array<any>
+  ? true
+  : false;
+
+type ReplaceDate<T> = T extends Date ? string : T;
+type ReplaceSet<T> = T extends Set<infer X> ? X[] : T;
+type ReplaceMap<T> =
+  T extends Map<infer K, infer I>
+    ? Record<
+        K extends string | number | symbol ? K : string,
+        IsValueType<I> extends true
+          ? I
+          : { [K in keyof ExcludeFuncsFromObj<I>]: Dto<I[K]> }
+      >
+    : T;
+type ReplaceArray<T> = T extends Array<infer X> ? Dto<X>[] : T;
+
+type ExcludeFuncsFromObj<T> = Pick<
+  T,
+  { [K in keyof T]: IsFunction<T[K]> extends true ? never : K }[keyof T]
+>;
+
+type Dtoified<T> =
+  IsValueType<T> extends true
+    ? ReplaceDate<ReplaceMap<ReplaceSet<ReplaceArray<T>>>>
+    : { [K in keyof ExcludeFuncsFromObj<T>]: Dto<T[K]> };
+
+export type Dto<T> =
+  IsFunction<T> extends true
+    ? never
+    : IsOptional<T> extends true
+      ? Dtoified<Exclude<T, undefined>> | null
+      : Dtoified<T>;
+
+export type Serializable<T> = T & { serialize(): Dto<T> };
+
+/**
+ * CUSTOM DTO UTILITY TYPES
+ */
+
+// This type is used to convert a DTO type from a service controller method,
+// to a type that can be used in the frontend.
+// Example:
+// import { UserController } from '@121-service/src/user/user.controller';
+// import { Dto121Service } from '../shared/utils/dto-type';
+// export type User = Dto121Service<UserController['login']>['user'];
+export type Dto121Service<
+  ServiceControllerMethod extends (...args: any) => any,
+> = Dto<Awaited<ReturnType<ServiceControllerMethod>>>;

--- a/services/121-service/package.json
+++ b/services/121-service/package.json
@@ -33,7 +33,8 @@
     "migration:run": "npm run typeorm migration:run -- -d ./src/datasource-manage-migrations.ts",
     "migration:revert": "npm run typeorm migration:revert -- -d ./src/datasource-manage-migrations.ts",
     "knip": "knip",
-    "knip:fix": "knip --fix-type files,exports,types"
+    "knip:fix": "knip --fix-type files,exports,types",
+    "install:dependencies-for-portal": "npm ci --omit=dev --no-fund --no-audit"
   },
   "private": true,
   "dependencies": {

--- a/services/121-service/src/config.ts
+++ b/services/121-service/src/config.ts
@@ -1,5 +1,3 @@
-import packageJson = require('../package.json');
-
 export const DEBUG = !['production', 'test'].includes(process.env.NODE_ENV!);
 export const PORT = process.env.PORT_121_SERVICE!;
 
@@ -12,7 +10,7 @@ const rootUrl =
 // ---------------------------------------------------------------------------
 export const APP_VERSION = process.env.GLOBAL_121_VERSION!;
 
-let appTitle = packageJson.name;
+let appTitle = '121-service';
 if (process.env.ENV_NAME) {
   appTitle += ` [${process.env.ENV_NAME}]`;
 }

--- a/services/121-service/src/guards/authenticated-user.guard.ts
+++ b/services/121-service/src/guards/authenticated-user.guard.ts
@@ -13,7 +13,7 @@ export class AuthenticatedUserGuard
     super();
   }
 
-  canActivate(
+  override canActivate(
     context: ExecutionContext,
   ): boolean | Promise<boolean> | Observable<boolean> {
     const endpointParameters = this.reflector.get<AuthenticatedUserParameters>(

--- a/services/121-service/src/registration/registration-data.entity.ts
+++ b/services/121-service/src/registration/registration-data.entity.ts
@@ -69,7 +69,7 @@ export class RegistrationDataEntity extends Base121Entity {
   @Column()
   public value: string;
 
-  public async getDataName(): Promise<string | undefined> {
+  public async getDataName(): Promise<string | void> {
     const repo = AppDataSource.getRepository(RegistrationDataEntity);
     const dataWithRelations = await repo.findOneOrFail({
       where: { id: Equal(this.id) },


### PR DESCRIPTION
If you're interested in digging deeper, the main relevant change is the one called out in the comments. Most of the other changes inside the `121-service` and `Portal` folders were necessary just to get the Portal compiler not to complain about importing complex things from `@121-service`.

## Dom's opinion: ✅ Recommended solution (for Portalicious)

Please look at the comments in the PR for more details.

Find all of the related PRs to this PoC in the related task: [AB#28945](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/28945).