### PR TITLE
chore: address (one of the) flaky test(s)

### DIFF
--- a/services/121-service/test/helpers/assert.helper.ts
+++ b/services/121-service/test/helpers/assert.helper.ts
@@ -24,8 +24,12 @@ export const assertArraysAreEqual = (
   }
 };
 
-export function sortByFspName(array: { fsp: string }[]): any[] {
+export function sortByFspName(array: any[]): any[] {
   return array.slice().sort((a, b) => {
+    if (typeof a === 'string' && typeof b === 'string') {
+      return a.localeCompare(b);
+    }
+
     const nameA = a.fsp;
     const nameB = b.fsp;
 


### PR DESCRIPTION
Lots of tests are failing like such:
https://github.com/global-121/121-platform/actions/runs/9713211869/job/26809966484

Apparently sometimes we are comparing strings, when we assume that we are always comparing objects. This can cause the order of the arrays to sometimes change, which I believe to be the source of the flakiness (for this particular test).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
