### PR TITLE
fix: Cleanup package.json for k6-tests

### DIFF
--- a/k6/package.json
+++ b/k6/package.json
@@ -1,7 +1,5 @@
 {
   "name": "121-service-k6-tests",
-  "version": "1.0.0",
-  "description": "",
   "main": "index.js",
   "directories": {
     "test": "tests"
@@ -11,8 +9,6 @@
     "fix": "npm run lint -- --fix",
     "test": "dotenv -e ../services/.env -- k6 run"
   },
-  "author": "",
-  "license": "ISC",
   "devDependencies": {
     "@eslint/js": "^9.4.0",
     "eslint": "^9.4.0",


### PR DESCRIPTION
We don't need properties that will get out-of-sync.
Also, no need to mix licenses within the repository.

There will be no real 'standalone/distributable' package in the `k6`-folder, so the `package.json`-file is only there to manage dependencies etc.

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
