### PR TITLE
feat: enable send message option during decline PAs AB#29108

### DIFF
--- a/interfaces/Portal/src/app/services/bulk-actions.service.ts
+++ b/interfaces/Portal/src/app/services/bulk-actions.service.ts
@@ -88,7 +88,15 @@ export class BulkActionsService {
       tabs: [ProgramTab.peopleAffected, ProgramTab.payment],
       showIfNoValidation: true,
       confirmConditions: {
-        provideInput: false,
+        promptType: PromptType.actionWithMessage,
+        checkbox:
+          'page.program.program-people-affected.action-inputs.message-checkbox',
+        checkboxChecked: false,
+        inputRequired: true,
+        inputConstraint: {
+          length: 1,
+          type: 'min',
+        },
       },
     },
     {
@@ -204,8 +212,10 @@ export class BulkActionsService {
       case BulkActionId.markAsDeclined:
         return await this.programsService.markAsDeclined(
           programId,
+          customBulkActionInput?.message,
           dryRun,
           filters,
+          customBulkActionInput?.messageTemplateKey,
         );
     }
   }

--- a/interfaces/Portal/src/app/services/programs-service-api.service.ts
+++ b/interfaces/Portal/src/app/services/programs-service-api.service.ts
@@ -666,14 +666,18 @@ export class ProgramsServiceApiService {
 
   markAsDeclined(
     programId: number | string,
+    message: string,
     dryRun = false,
     filters?: PaginationFilter[],
+    messageTemplateKey?: string,
   ): Promise<any> {
     return this.updatePaStatus(
       RegistrationStatus.declined,
       programId,
       dryRun,
       filters,
+      message,
+      messageTemplateKey,
     );
   }
 


### PR DESCRIPTION
<!--- [AB#1234](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/1234) Only if relevant, start with a link to an issue on Azure DevOps -->

## Describe your changes

Enable the functionality to decline PAs with message. Also the message should should visible at PAs activity overview.

Task:  [29108](https://dev.azure.com/redcrossnl/121%20Platform/_workitems/edit/28988)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
