### PR TITLE
fix: Use explicit steps to get to a readable label for placeholders

### DIFF
--- a/interfaces/Portal/src/app/shared/message-editor/message-editor.component.ts
+++ b/interfaces/Portal/src/app/shared/message-editor/message-editor.component.ts
@@ -146,14 +146,21 @@ export class MessageEditorComponent implements AfterViewInit, OnInit {
   }
 
   private getLabel(attribute: PaTableAttribute): string {
-    return (
-      // Get label of attributes configured in the program
-      this.translatableString.get(attribute.label) ??
-      // Get label of default attributes
-      this.translate.instant(
-        `page.program.program-people-affected.column.${attribute.name}`,
-      )
-    );
+    let label: string;
+
+    if (attribute.label) {
+      label = this.translatableString.get(attribute.label);
+    }
+
+    if (!label) {
+      const translationKey = `page.program.program-people-affected.column.${attribute.name}`;
+      const translation = this.translate.instant(translationKey);
+
+      // Only use translation if it is actually available, otherwise fall back to the "name" only
+      label = translation !== translationKey ? translation : attribute.name;
+    }
+
+    return label;
   }
 
   public async closeModal() {


### PR DESCRIPTION
See: [AB#29519](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/29519)

The `??` is not doing what was expected, I think.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing#using_the_nullish_coalescing_operator


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
