### PR TITLE
Fix store failure of empty phonenumber

### DIFF
--- a/services/121-service/src/notifications/sms/sms.service.ts
+++ b/services/121-service/src/notifications/sms/sms.service.ts
@@ -27,7 +27,9 @@ export class SmsService {
     messageContentType?: MessageContentType,
     messageProcessType?: MessageProcessType,
   ): Promise<void> {
-    const to = recipientPhoneNr ? formatPhoneNumber(recipientPhoneNr) : null;
+    const to = recipientPhoneNr
+      ? formatPhoneNumber(recipientPhoneNr)
+      : 'not available'; // When allowEmptyPhoneNumber is true in a program, the to number can be empty and an error will be stored
 
     let messageToStore;
     try {


### PR DESCRIPTION
[AB#29583](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/29583) 

## Describe your changes

- Explicitly store that phonenumber is not available when attempting to send a message to people without phonenumber
- Another solution is to make the to column nullable... I though this was more explicit as it cannot be empty for whatsapp


