### PR TITLE
portalicious: add support for tailwind on primeng styleClass

### DIFF
--- a/interfaces/Portalicious/.prettierrc.yml
+++ b/interfaces/Portalicious/.prettierrc.yml
@@ -9,6 +9,8 @@ plugins:
   - prettier-plugin-organize-imports
   - prettier-plugin-tailwindcss
   - '@prettier/plugin-xml'
+tailwindAttributes:
+  - styleClass
 overrides:
   - files: '*.xlf'
     options:

--- a/interfaces/Portalicious/.vscode/settings.json
+++ b/interfaces/Portalicious/.vscode/settings.json
@@ -8,6 +8,12 @@
   "prettier.configPath": ".prettierrc.yml",
   "tailwindCSS.rootFontSize": 14,
   "tailwindCSS.showPixelEquivalents": false,
+  "tailwindCSS.classAttributes": [
+    "class",
+    "styleClass",
+    "ngClass",
+    "class:list"
+  ],
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "typescript.tsdk": "node_modules/typescript/lib",
   "XLF: State": true,

--- a/interfaces/Portalicious/src/app/pages/change-password/change-password.component.html
+++ b/interfaces/Portalicious/src/app/pages/change-password/change-password.component.html
@@ -24,7 +24,7 @@
             [toggleMask]="true"
             [feedback]="false"
             autocomplete="current-password"
-            styleClass="w-full [&_input]:w-full mt-2"
+            styleClass="mt-2 w-full [&_input]:w-full"
           />
         </label>
         <app-form-error
@@ -44,7 +44,7 @@
             [toggleMask]="true"
             [feedback]="false"
             autocomplete="new-password"
-            styleClass="w-full [&_input]:w-full mt-2"
+            styleClass="mt-2 w-full [&_input]:w-full"
           />
         </label>
         @if (
@@ -80,7 +80,7 @@
             formControlName="confirmPassword"
             [toggleMask]="true"
             [feedback]="false"
-            styleClass="w-full [&_input]:w-full mt-2"
+            styleClass="mt-2 w-full [&_input]:w-full"
           />
         </label>
         @if (

--- a/interfaces/Portalicious/src/app/pages/login/login.component.html
+++ b/interfaces/Portalicious/src/app/pages/login/login.component.html
@@ -52,7 +52,7 @@
               [toggleMask]="true"
               [feedback]="false"
               autocomplete="current-password"
-              styleClass="w-full [&_input]:w-full mt-2"
+              styleClass="mt-2 w-full [&_input]:w-full"
             />
           </label>
           <app-form-error

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,33 @@
       "name": "121-platform",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@prettier/plugin-xml": "^3.4.1",
         "husky": "^9.0.11",
         "lint-staged": "^15.2.2",
         "prettier": "3.3.3",
         "prettier-plugin-organize-imports": "^4.0.0",
         "prettier-plugin-tailwindcss": "^0.6.5"
+      }
+    },
+    "node_modules/@prettier/plugin-xml": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.4.1.tgz",
+      "integrity": "sha512-Uf/6/+9ez6z/IvZErgobZ2G9n1ybxF5BhCd7eMcKqfoWuOzzNUxBipNo3QAP8kRC1VD18TIo84no7LhqtyDcTg==",
+      "dev": true,
+      "dependencies": {
+        "@xml-tools/parser": "^1.0.11"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0"
+      }
+    },
+    "node_modules/@xml-tools/parser": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
+      "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
+      "dev": true,
+      "dependencies": {
+        "chevrotain": "7.1.1"
       }
     },
     "node_modules/ansi-escapes": {
@@ -72,6 +94,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chevrotain": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
+      "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
+      "dev": true,
+      "dependencies": {
+        "regexp-to-ast": "0.5.0"
       }
     },
     "node_modules/cli-cursor": {
@@ -608,6 +639,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/regexp-to-ast": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
+      "dev": true
     },
     "node_modules/restore-cursor": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
+    "@prettier/plugin-xml": "^3.4.1",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.2",
     "prettier": "3.3.3",


### PR DESCRIPTION
- Tailwind CSS extension in VSCode now has autocomplete on `styleClass` attributes (but, sadly, only when opening the `Portalicious` directory directly)
- Prettier also auto-sorts the `styleClass` attribute

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
