### PR TITLE
fix: Reduce "layout shifting"/jumpiness of skeletons

### DIFF
--- a/interfaces/Portalicious/src/app/pages/projects-overview/project-metric-container/project-metric-container.component.html
+++ b/interfaces/Portalicious/src/app/pages/projects-overview/project-metric-container/project-metric-container.component.html
@@ -1,12 +1,12 @@
-<dd class="px-2 pt-2">
+<dd class="px-2 pt-2 font-display text-[18px] font-bold">
   @if (pending()) {
     <p-skeleton
-      class="my-1 cursor-progress"
-      height="1.125rem"
+      class="block cursor-progress py-2"
+      height="1em"
       [width]="randomWidth()"
     />
   } @else {
-    <span class="font-display text-[18px] font-bold">{{ value() }}</span>
+    {{ value() }}
   }
 </dd>
 <dt class="px-2 pb-2 pt-1 text-sm">

--- a/interfaces/Portalicious/src/app/pages/projects-overview/project-summary-card/project-summary-card.component.html
+++ b/interfaces/Portalicious/src/app/pages/projects-overview/project-summary-card/project-summary-card.component.html
@@ -8,8 +8,8 @@
     >
       @if (project.isPending()) {
         <p-skeleton
-          class="my-1 cursor-progress text-xl"
-          height="1.25rem"
+          class="my-1 cursor-progress py-1"
+          height="1.5em"
           [width]="randomWidth"
         />
       } @else {
@@ -71,21 +71,21 @@
     </dl>
   </ng-template>
   <ng-template pTemplate="footer">
-    @if (payments.isPending()) {
-      <p-skeleton
-        class="my-1 cursor-progress text-lg"
-        height="1.125rem"
-        [width]="randomWidth"
-      />
-    } @else {
-      <div class="text-end font-display text-sm text-grey-700">
+    <div class="flex justify-end font-display text-sm text-grey-700">
+      @if (payments.isPending()) {
+        <p-skeleton
+          class="cursor-progress text-sm"
+          height="1.25em"
+          [style.flex-basis]="'40%'"
+        />
+      } @else {
         @if (getLastPayment()) {
           <ng-container i18n>Last payment: </ng-container>
           {{ getLastPayment()!.paymentDate | date: 'dd-MM-yyyy' }}
         } @else {
           <ng-container i18n>No payments yet</ng-container>
         }
-      </div>
-    }
+      }
+    </div>
   </ng-template>
 </p-card>


### PR DESCRIPTION
Moving the text-styling to the "container of the data/skeleton", so the font-size can be reused/inherited by the skeleton

See [AB#29814](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/29814)

I don't think this is "the best way forward", but I'd just didn't want to 'waste' my fiddling with the pixels. ;)

---

## Describe your changes

Brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
