### PR TITLE
portalicious: add e2e to validate users in project team table

### DIFF
--- a/e2e/portalicious/pages/BasePage.ts
+++ b/e2e/portalicious/pages/BasePage.ts
@@ -42,6 +42,10 @@ class BasePage {
     await this.projectHeader.getByRole('menuitem', { name: pageName }).click();
   }
 
+  async selectProgram(programName: string) {
+    await this.page.getByRole('link', { name: programName }).click();
+  }
+
   async changeLanguage(language: string) {
     await this.openSidebar();
     await this.languageDropdown.selectOption({ label: language });

--- a/e2e/portalicious/pages/ProjectTeam.ts
+++ b/e2e/portalicious/pages/ProjectTeam.ts
@@ -1,0 +1,33 @@
+import { expect, Locator } from '@playwright/test';
+import { Page } from 'playwright';
+import BasePage from './BasePage';
+
+class ProjectTeam extends BasePage {
+  readonly page: Page;
+  readonly tableRows: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.page = page;
+    this.tableRows = this.page.locator('table tbody tr');
+  }
+
+  async validateAssignedTeamMembers(expectedAssignedUsers: string[]) {
+    const actualAssignedUsers = await this.tableRows.evaluateAll((rows) =>
+      rows.map((row) =>
+        row.querySelector('td:nth-child(1)').textContent.trim(),
+      ),
+    );
+
+    const sortedActualUsers = [...actualAssignedUsers].sort((a, b) =>
+      a.localeCompare(b),
+    );
+    const sortedExpectedUsers = [...expectedAssignedUsers].sort((a, b) =>
+      a.localeCompare(b),
+    );
+
+    expect(sortedActualUsers).toEqual(sortedExpectedUsers);
+  }
+}
+
+export default ProjectTeam;

--- a/e2e/portalicious/tests/ManageTeam/AllUsersAssignedShouldBeVisible.spec.ts
+++ b/e2e/portalicious/tests/ManageTeam/AllUsersAssignedShouldBeVisible.spec.ts
@@ -1,0 +1,47 @@
+import BasePage from '@121-e2e/portalicious/pages/BasePage';
+import LoginPage from '@121-e2e/portalicious/pages/LoginPage';
+import ProjectTeam from '@121-e2e/portalicious/pages/ProjectTeam';
+import { SeedScript } from '@121-service/src/scripts/seed-script.enum';
+import { resetDB } from '@121-service/test/helpers/utility.helper';
+import { test } from '@playwright/test';
+
+const expectedAssignedUsers = [
+  'admin@example.org',
+  'program-admin@example.org',
+  'view-user@example.org',
+  'kobo-user@example.org',
+  'cva-manager@example.org',
+  'cva-officer@example.org',
+  'finance-manager@example.org',
+  'finance-officer@example.org',
+  'view-no-pii@example.org',
+];
+
+test.beforeEach(async ({ page }) => {
+  await resetDB(SeedScript.test);
+
+  // Login
+  const loginPage = new LoginPage(page);
+  await page.goto('/');
+  await loginPage.login(
+    process.env.USERCONFIG_121_SERVICE_EMAIL_ADMIN,
+    process.env.USERCONFIG_121_SERVICE_PASSWORD_ADMIN,
+  );
+});
+
+test('[29748] All users assigned to the project should be visible', async ({
+  page,
+}) => {
+  const basePage = new BasePage(page);
+  const manageTeam = new ProjectTeam(page);
+  const projectTitle = 'Cash program Westeros';
+
+  await test.step('Select program and navigate to Manage team', async () => {
+    await basePage.selectProgram(projectTitle);
+    await basePage.navigateToProgramPage('Team');
+  });
+
+  await test.step('Validate assigned users are visible', async () => {
+    await manageTeam.validateAssignedTeamMembers(expectedAssignedUsers);
+  });
+});


### PR DESCRIPTION
[AB#29863](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/29863)

Wrapping up the work in #5714 so this can be merged as-is without waiting for the other tests.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
