### PR TITLE
chore: add PR metadata checker

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,9 +2,7 @@ changelog:
   exclude:
     labels:
       - dependencies # dependabot
-      - chore # manually excluded
       - ignore-for-release # manually excluded
-      - portalicious # manually excluded
   categories:
     - title: New Features 🎉
       labels:
@@ -12,6 +10,12 @@ changelog:
     - title: Bug Fixes 🛠
       labels:
         - bugfix
+    - title: Chores 🧹
+      labels:
+        - chore
+    - title: Portalicious 🚀
+      labels:
+        - portalicious
     - title: Other Changes
       labels:
         - '*'

--- a/.github/workflows/test_pull_request_formatting.yml
+++ b/.github/workflows/test_pull_request_formatting.yml
@@ -1,0 +1,45 @@
+name: PR linter
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check_pr_description:
+    name: Check PR metadata
+    runs-on: ubuntu-latest
+    # Don't run this check on dependabot PRs
+    if: contains(github.actor, 'dependabot') == false
+
+    steps:
+      - name: Check PR description and labels
+        id: fetch_pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            core.startGroup('Received PR Data')
+            core.info(JSON.stringify(pr.data, null, 4));
+            core.endGroup()
+
+            const prDescription = pr.data.body;
+            if (!/AB#\d{5}/.test(prDescription)) {
+              core.setFailed('Please make sure you have replaced AB#XXXX with a valid DevOps ID in your PR description');
+            } else {
+              core.notice('✅ PR description contains a DevOps ID');
+            }
+
+            const validLabels = ['enhancement', 'bugfix', 'dependencies', 'chore', 'ignore-for-release', 'portalicious'];
+            const prLabels = pr.data.labels.map(label => label.name);
+            if (!prLabels.some(label => validLabels.includes(label))) {
+              core.setFailed('Add one of the following labels to your PR: enhancement, bugfix, chore, ignore-for-release, portalicious');
+            } else {
+              core.notice('✅ PR has at least one valid label');
+            }
+
+            return pr.data;

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,8 +1,8 @@
-<!--- AB#1234 Only if relevant, start with a link to an issue on Azure DevOps -->
+AB#XXXX <!--- Replace this with a reference to a devops issue -->
 
 ## Describe your changes
 
-Brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps.
+<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->
 
 ## Checklist before requesting a review
 


### PR DESCRIPTION
[AB#29882](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/29882)

## Describe your changes

This adds a CI job to all PRs on main that checks two things:
1. The PR should have a valid DevOps ID in the description
1. The PR should have one of the valid labels we use for auto-generating release notes.

If a PR is missing either (or both) of these things, it fails, with an error message such as this:
https://github.com/global-121/121-platform/actions/runs/10525330926?pr=5725

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
