### PR TITLE
portalicious: edit user on teams page

### DIFF
--- a/interfaces/Portalicious/src/app/components/query-table/query-table.component.html
+++ b/interfaces/Portalicious/src/app/components/query-table/query-table.component.html
@@ -53,14 +53,14 @@
             [pSortableColumn]="column.field"
             style="min-width: 14rem"
           >
-            <div class="justify-content-between align-items-center flex">
+            <div class="flex items-center">
               <ng-container>{{ column.header }}</ng-container>
               <p-sortIcon [field]="column.field" />
               <p-columnFilter
                 [type]="column.type ?? 'text'"
                 [field]="column.field"
                 display="menu"
-                class="ms-2"
+                class="ms-1"
               />
             </div>
           </th>

--- a/interfaces/Portalicious/src/app/domains/project/project.api.service.ts
+++ b/interfaces/Portalicious/src/app/domains/project/project.api.service.ts
@@ -92,6 +92,30 @@ export class ProjectApiService extends DomainApiService {
     );
   }
 
+  updateProjectUserAssignment(
+    projectId: Signal<number>,
+    {
+      userId,
+      roles,
+      scope,
+    }: {
+      userId: number;
+      roles: Role['role'][];
+      scope: string;
+    },
+  ) {
+    return this.httpWrapperService.perform121ServiceRequest<ProjectUserAssignment>(
+      {
+        method: 'PATCH',
+        endpoint: `${BASE_ENDPOINT}/${projectId().toString()}/users/${userId.toString()}`,
+        body: {
+          rolesToAdd: roles,
+          scope,
+        },
+      },
+    );
+  }
+
   removeProjectUser(projectId: Signal<number>, userId: number) {
     return this.httpWrapperService.perform121ServiceRequest<Project>({
       method: 'DELETE',

--- a/interfaces/Portalicious/src/app/pages/project/project-team/add-user-form/add-user-form.component.html
+++ b/interfaces/Portalicious/src/app/pages/project/project-team/add-user-form/add-user-form.component.html
@@ -1,11 +1,3 @@
-<p-button
-  label="Add team member"
-  i18n-label="@@add-team-member"
-  rounded
-  icon="pi pi-plus"
-  (click)="formVisible.set(true)"
-/>
-
 <app-form-sidebar
   [(visible)]="formVisible"
   [formGroup]="formGroup"

--- a/interfaces/Portalicious/src/app/pages/project/project-team/project-team.component.html
+++ b/interfaces/Portalicious/src/app/pages/project/project-team/project-team.component.html
@@ -5,9 +5,18 @@
 >
   <div header-actions>
     @if (canManageAidworkers()) {
-      <app-add-user-button
+      <p-button
+        label="Add team member"
+        i18n-label="@@add-team-member"
+        rounded
+        icon="pi pi-plus"
+        (click)="openForm('add')"
+      />
+      <app-add-user-form
         [projectId]="projectId()"
         [enableScope]="enableScope()"
+        [(formVisible)]="formVisible"
+        [userToEdit]="formMode() === 'edit' ? selectedUser() : undefined"
       />
     }
   </div>

--- a/interfaces/Portalicious/src/app/pages/projects-overview/create-project-form/create-project-form.component.html
+++ b/interfaces/Portalicious/src/app/pages/projects-overview/create-project-form/create-project-form.component.html
@@ -1,11 +1,3 @@
-<p-button
-  label="Add project"
-  i18n-label="@@add-project-label"
-  outlined
-  rounded
-  icon="pi pi-plus"
-  (click)="formVisible.set(true)"
-/>
 <app-form-sidebar
   [(visible)]="formVisible"
   [formGroup]="formGroup"

--- a/interfaces/Portalicious/src/app/pages/projects-overview/create-project-form/create-project-form.component.ts
+++ b/interfaces/Portalicious/src/app/pages/projects-overview/create-project-form/create-project-form.component.ts
@@ -2,7 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   inject,
-  signal,
+  model,
 } from '@angular/core';
 import {
   FormControl,
@@ -28,10 +28,10 @@ import {
 } from '~/utils/form-validation';
 
 type CreateProjectFormGroup =
-  (typeof CreateProjectButtonComponent)['prototype']['formGroup'];
+  (typeof CreateProjectFormComponent)['prototype']['formGroup'];
 
 @Component({
-  selector: 'app-create-project-button',
+  selector: 'app-create-project-form',
   standalone: true,
   imports: [
     InputTextModule,
@@ -43,16 +43,16 @@ type CreateProjectFormGroup =
     FormFieldWrapperComponent,
   ],
   providers: [ToastService],
-  templateUrl: './create-project-button.component.html',
+  templateUrl: './create-project-form.component.html',
   styles: ``,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CreateProjectButtonComponent {
+export class CreateProjectFormComponent {
   private projectApiService = inject(ProjectApiService);
   private router = inject(Router);
   private toastService = inject(ToastService);
 
-  formVisible = signal(false);
+  formVisible = model.required<boolean>();
 
   formGroup = new FormGroup({
     token: new FormControl('', {

--- a/interfaces/Portalicious/src/app/pages/projects-overview/projects-overview.component.html
+++ b/interfaces/Portalicious/src/app/pages/projects-overview/projects-overview.component.html
@@ -4,7 +4,15 @@
 >
   <div header-actions>
     @if (canCreateProjects) {
-      <app-create-project-button />
+      <p-button
+        label="Add project"
+        i18n-label="@@add-project-label"
+        outlined
+        rounded
+        icon="pi pi-plus"
+        (click)="formVisible.set(true)"
+      />
+      <app-create-project-form [(formVisible)]="formVisible" />
     }
   </div>
 

--- a/interfaces/Portalicious/src/app/pages/projects-overview/projects-overview.component.ts
+++ b/interfaces/Portalicious/src/app/pages/projects-overview/projects-overview.component.ts
@@ -1,9 +1,14 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
 import { PageLayoutComponent } from '~/components/page-layout/page-layout.component';
-import { CreateProjectButtonComponent } from '~/pages/projects-overview/create-project-button/create-project-button.component';
+import { CreateProjectFormComponent } from '~/pages/projects-overview/create-project-form/create-project-form.component';
 import { ProjectSummaryCardComponent } from '~/pages/projects-overview/project-summary-card/project-summary-card.component';
 import { AuthService } from '~/services/auth.service';
 
@@ -16,7 +21,7 @@ import { AuthService } from '~/services/auth.service';
     PageLayoutComponent,
     RouterLink,
     ProjectSummaryCardComponent,
-    CreateProjectButtonComponent,
+    CreateProjectFormComponent,
   ],
   templateUrl: './projects-overview.component.html',
   styles: ``,
@@ -28,4 +33,6 @@ export class ProjectsOverviewComponent {
   public canCreateProjects = this.authService.isAdmin;
 
   public assignedProjects = this.authService.getAssignedProjectIds();
+
+  formVisible = signal(false);
 }

--- a/interfaces/Portalicious/src/locale/messages.nl.xlf
+++ b/interfaces/Portalicious/src/locale/messages.nl.xlf
@@ -515,6 +515,10 @@
         <source>The base transfer value is multiplied by a set factor for each registration. For example, if the base value is $50 and the multiplier is based on household size, a 3-person household would receive $150 per payment.</source>
         <target state="new">The base transfer value is multiplied by a set factor for each registration. For example, if the base value is $50 and the multiplier is based on household size, a 3-person household would receive $150 per payment.</target>
       </trans-unit>
+      <trans-unit id="1755386264837692034" datatype="html">
+        <source>User updated</source>
+        <target state="new">User updated</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/interfaces/Portalicious/src/locale/messages.xlf
+++ b/interfaces/Portalicious/src/locale/messages.xlf
@@ -389,6 +389,9 @@
       <trans-unit id="generic-not-available" datatype="html">
         <source>Not available</source>
       </trans-unit>
+      <trans-unit id="1755386264837692034" datatype="html">
+        <source>User updated</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/interfaces/Portalicious/src/styles.scss
+++ b/interfaces/Portalicious/src/styles.scss
@@ -19,6 +19,12 @@ body {
   overflow-y: scroll; /* Always show scrollbars to avoid page skipping about */
 }
 
+:root {
+  // primeng uses this variable on all of its components by default
+  // and it does not work if we set it within the 'primeng' layer
+  --font-family: theme(fontFamily.body);
+}
+
 @layer tailwind-base {
   h1 {
     @apply font-bold txt-h-1;
@@ -64,11 +70,6 @@ body {
 // So there will only be ONE section/grouping per PrimeNG component.
 //
 @layer primeng {
-  :root {
-    // primeng uses this variable on all of its components by default
-    --font-family: theme(fontFamily.body);
-  }
-
   $toolbar-height: calc(48 / 14 * 1rem);
 
   .p-button {
@@ -189,6 +190,13 @@ body {
     // Prevent contents being cut off, always wrap and align checkboxes to the top
     .p-multiselect-item {
       @apply items-start text-wrap;
+    }
+  }
+
+  .p-element.ng-touched.ng-invalid {
+    .p-inputwrapper,
+    .p-inputtext {
+      border-color: theme('colors.red.500') !important;
     }
   }
 }


### PR DESCRIPTION
[AB#29744](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/29744)

When discussing with Elwin, we had settled on a different approach: The idea was to get rid of the separate component for managing the form and moving everything into the page.

When I started doing this, though, I realised that maybe there wasn't a need for it, and instead the only logic that needed to be moved to the page was whether to show the form or not.

So, I've also edited the "create-project-button" component accordingly so that they both follow the same pattern.

Still not sure if this is the wisest approach but it works.

EDIT: I also sneaked a couple of design fixes in there too.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
