### PR TITLE
fix: Hard-code text+link to prevent translations-loading issue

### DIFF
--- a/interfaces/Portal/src/app/pages/login/login.page.html
+++ b/interfaces/Portal/src/app/pages/login/login.page.html
@@ -247,12 +247,16 @@
             </div>
             <div *ngIf="!isLogoutForced">
               <br />
-              <small
-                [innerHTML]="
-                  'page.login.sso.force-logout-try-again-notice' | translate
-                "
-              >
+              <!-- TODO: Hard-coded in to provide users with a working, clickable link; Without any caching-issues or out-of-date-translations -->
+              <small>
+                If you have trouble logging in,
+                <a href="/logout">try to log-out</a> and try again.
               </small>
+              <!-- TODO: Original code kept, to cache translation for future releases (can be removed for upcoming releases) -->
+              <small
+                hidden
+                innerHTML="'page.login.sso.force-logout-try-again-notice' | translate"
+              ></small>
             </div>
           </form>
         </div>


### PR DESCRIPTION
[AB#30040](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/30040)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- `-`  I have added tests wherever relevant
- `-` I have made sure that all automated checks pass before requesting a review
- `!` I do need some deviation from our PR guidelines  
  The warning-text+link needs to be hard-coded, so users don't run into an issue with outdated/out-of-sync, cached translations-files.
