### PR TITLE
fix: reset registration before each test AB#30109

### DIFF
--- a/services/121-service/test/payment/do-payment-fsp-visa-debit/do-payment-fsp-visa-debit-error.test.ts
+++ b/services/121-service/test/payment/do-payment-fsp-visa-debit/do-payment-fsp-visa-debit-error.test.ts
@@ -28,15 +28,16 @@ import {
 import { HttpStatus } from '@nestjs/common';
 
 describe('Do failing payment with FSP Visa Debit', () => {
-  // Set WhatsApp-number for ALL tests in this suite only
-  const registrationVisa = {
-    ...registrationVisaDefault,
-    whatsappPhoneNumber: registrationVisaDefault.phoneNumber,
-  };
+  let registrationVisa;
 
   let accessToken: string;
 
   beforeEach(async () => {
+    // This should be redefined in each test, so that changed values are not carried over to the next test
+    registrationVisa = {
+      ...registrationVisaDefault,
+      whatsappPhoneNumber: registrationVisaDefault.phoneNumber, // Set WhatsApp-number for ALL tests in this suite only
+    };
     await resetDB(SeedScript.nlrcMultiple);
     accessToken = await getAccessToken();
     await waitFor(2_000);


### PR DESCRIPTION
[AB#30109](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/30109)

## Describe your changes

Fix flaky idempotency test, by resetting the registration to use before each test. Otherwise changes to the registration were carried over to the next test.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
