### PR TITLE
feat: Add change-password redirect to help Password-managers

### DIFF
--- a/e2e/portalicious/tests/ChangePassword/ChangePasswordRedirect.spec.ts
+++ b/e2e/portalicious/tests/ChangePassword/ChangePasswordRedirect.spec.ts
@@ -1,0 +1,27 @@
+import LoginPage from '@121-e2e/pages/Login/LoginPage';
+import ChangePasswordPage from '@121-e2e/portalicious/pages/ChangePasswordPage';
+import { SeedScript } from '@121-service/src/scripts/seed-script.enum';
+import { resetDB } from '@121-service/test/helpers/utility.helper';
+import { test } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await resetDB(SeedScript.test);
+
+  // Login
+  const loginPage = new LoginPage(page);
+  await page.goto('/');
+  await loginPage.login(
+    process.env.USERCONFIG_121_SERVICE_EMAIL_ADMIN,
+    process.env.USERCONFIG_121_SERVICE_PASSWORD_ADMIN,
+  );
+});
+
+test('Change password redirect', async ({ page }) => {
+  const changePasswordPage = new ChangePasswordPage(page);
+
+  await test.step('Should bring the user to the Change-Password-page from a well-known URL', async () => {
+    await page.goto('/.well-known/change-password');
+
+    await changePasswordPage.changePasswordButton.isVisible();
+  });
+});

--- a/e2e/portalicious/tests/ChangePassword/ChangePasswordRedirect.spec.ts
+++ b/e2e/portalicious/tests/ChangePassword/ChangePasswordRedirect.spec.ts
@@ -1,5 +1,5 @@
-import LoginPage from '@121-e2e/pages/Login/LoginPage';
 import ChangePasswordPage from '@121-e2e/portalicious/pages/ChangePasswordPage';
+import LoginPage from '@121-e2e/portalicious/pages/LoginPage';
 import { SeedScript } from '@121-service/src/scripts/seed-script.enum';
 import { resetDB } from '@121-service/test/helpers/utility.helper';
 import { test } from '@playwright/test';

--- a/interfaces/Portalicious/staticwebapp.config.json
+++ b/interfaces/Portalicious/staticwebapp.config.json
@@ -8,6 +8,11 @@
       }
     },
     {
+      "route": "/.well-known/change-password",
+      "redirect": "/en/change-password",
+      "statusCode": 302
+    },
+    {
       "route": "*.{js,json,css,jpg,jpeg,png,ico,webmanifest,tff,woff,woff2}",
       "headers": {
         "Cache-Control": "immutable, no-transform, max-age=31536000"


### PR DESCRIPTION
Original task: [AB#29275](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/29275)

[AB#30179](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/30179)

Password-managers can use this URL to help users to change their password (to a more secure one) when the password-manager detects a re-used or easily-guessed password, or it was found in a data-leak, etc.)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
