### PR TITLE
portalicious: refactor hasPermission

### DIFF
--- a/interfaces/Portalicious/src/app/auth.guard.ts
+++ b/interfaces/Portalicious/src/app/auth.guard.ts
@@ -34,7 +34,9 @@ export const projectPermissionsGuard: (
       throw new Error('projectId is not a number');
     }
 
-    if (authService.hasPermission(projectId, permission)) {
+    if (
+      authService.hasPermission({ projectId, requiredPermission: permission })
+    ) {
       return true;
     }
 

--- a/interfaces/Portalicious/src/app/components/page-layout/components/project-header/project-header.component.ts
+++ b/interfaces/Portalicious/src/app/components/page-layout/components/project-header/project-header.component.ts
@@ -37,20 +37,20 @@ export class ProjectHeaderComponent {
       label: $localize`:@@page-title-project-monitoring:Monitoring`,
       routerLink: `/${AppRoutes.project}/${this.projectId().toString()}/${AppRoutes.projectMonitoring}`,
       icon: 'pi pi-chart-bar',
-      visible: this.authService.hasPermission(
-        this.projectId(),
-        PermissionEnum.ProgramMetricsREAD,
-      ),
+      visible: this.authService.hasPermission({
+        projectId: this.projectId(),
+        requiredPermission: PermissionEnum.ProgramMetricsREAD,
+      }),
     },
     {
       label: $localize`:@@page-title-project-team:Team`,
       routerLink: `/${AppRoutes.project}/${this.projectId().toString()}/${AppRoutes.projectTeam}`,
       styleClass: 'ms-auto',
       icon: 'pi pi-users',
-      visible: this.authService.hasPermission(
-        this.projectId(),
-        PermissionEnum.AidWorkerProgramREAD,
-      ),
+      visible: this.authService.hasPermission({
+        projectId: this.projectId(),
+        requiredPermission: PermissionEnum.AidWorkerProgramREAD,
+      }),
     },
   ]);
 }

--- a/interfaces/Portalicious/src/app/pages/project/project-team/project-team.component.ts
+++ b/interfaces/Portalicious/src/app/pages/project/project-team/project-team.component.ts
@@ -97,10 +97,10 @@ export class ProjectTeamComponent {
   ]);
 
   canManageAidworkers = computed(() =>
-    this.authService.hasPermission(
-      this.projectId(),
-      PermissionEnum.AidWorkerProgramUPDATE,
-    ),
+    this.authService.hasPermission({
+      projectId: this.projectId(),
+      requiredPermission: PermissionEnum.AidWorkerProgramUPDATE,
+    }),
   );
 
   enableScope = computed(() => this.project.data()?.enableScope ?? false);

--- a/interfaces/Portalicious/src/app/services/auth.service.ts
+++ b/interfaces/Portalicious/src/app/services/auth.service.ts
@@ -148,32 +148,55 @@ export class AuthService {
     });
   }
 
-  private isAssignedToProgram(
-    programId: number,
-    user?: LocalStorageUser | null,
-  ): boolean {
+  private isAssignedToProject({
+    projectId,
+    user,
+  }: {
+    projectId: number;
+    user?: LocalStorageUser | null;
+  }): boolean {
     user = user ?? this.user;
     return (
       !!user?.permissions &&
-      Object.keys(user.permissions).includes(String(programId))
+      Object.keys(user.permissions).includes(String(projectId))
     );
   }
 
-  public hasPermission(
-    programId: number,
-    requiredPermission: PermissionEnum,
-    user?: LocalStorageUser | null,
-  ): boolean {
+  public hasPermission({
+    projectId,
+    requiredPermission,
+    user,
+  }: {
+    projectId: number;
+    requiredPermission: PermissionEnum;
+    user?: LocalStorageUser | null;
+  }): boolean {
     user = user ?? this.user;
     // During development: Use this to simulate a user not having a certain permission
-    // user.permissions[programId] = user.permissions[programId].filter(
+    // user.permissions[projectId] = user.permissions[projectId].filter(
     //   (p) => p !== Permission.FspDebitCardBLOCK,
     // );
 
     return (
       !!user?.permissions &&
-      this.isAssignedToProgram(programId, user) &&
-      user.permissions[programId].includes(requiredPermission)
+      this.isAssignedToProject({ projectId, user }) &&
+      user.permissions[projectId].includes(requiredPermission)
+    );
+  }
+
+  public hasAllPermissions({
+    projectId,
+    requiredPermissions,
+  }: {
+    projectId: number;
+    requiredPermissions: PermissionEnum[];
+  }): boolean {
+    return requiredPermissions.every((permissionName) =>
+      this.hasPermission({
+        projectId,
+        requiredPermission: permissionName,
+        user: this.user,
+      }),
     );
   }
 }


### PR DESCRIPTION
[AB#30228](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/30228)

- hasPermission now uses an object param
- added hasAllPermissions (will be used in activity log)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
