### PR TITLE
portalicious: handle mutation errors in confirmation dialog

### DIFF
--- a/interfaces/Portalicious/src/app/components/confirmation-dialog/confirmation-dialog.component.html
+++ b/interfaces/Portalicious/src/app/components/confirmation-dialog/confirmation-dialog.component.html
@@ -1,5 +1,32 @@
-<p-confirmDialog>
+<p-confirmDialog
+  #confirmDialog
+  [header]="header()"
+  closeOnEscape
+>
   <ng-template pTemplate="message">
-    <ng-content></ng-content>
+    <div>
+      <ng-content></ng-content>
+      @if (mutation().isError()) {
+        <div class="mt-4">
+          <app-form-error [error]="mutation().failureReason()?.message" />
+        </div>
+      }
+    </div>
+  </ng-template>
+  <ng-template pTemplate="footer">
+    <p-button
+      label="Cancel"
+      i18n-label="@@generic-cancel"
+      outlined
+      rounded
+      [disabled]="mutation().isPending()"
+      (click)="confirmDialog.reject()"
+    />
+    <p-button
+      [label]="proceedLabel()"
+      rounded
+      [loading]="mutation().isPending()"
+      (click)="onProceed()"
+    />
   </ng-template>
 </p-confirmDialog>

--- a/interfaces/Portalicious/src/app/components/confirmation-dialog/confirmation-dialog.component.ts
+++ b/interfaces/Portalicious/src/app/components/confirmation-dialog/confirmation-dialog.component.ts
@@ -3,40 +3,45 @@ import {
   Component,
   inject,
   input,
+  ViewChild,
 } from '@angular/core';
 
+import { CreateMutationResult } from '@tanstack/angular-query-experimental';
 import { ConfirmationService } from 'primeng/api';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ButtonModule } from 'primeng/button';
+import { ConfirmDialog, ConfirmDialogModule } from 'primeng/confirmdialog';
+
+import { FormErrorComponent } from '~/components/form-error/form-error.component';
 
 @Component({
   selector: 'app-confirmation-dialog',
   standalone: true,
-  imports: [ConfirmDialogModule],
+  imports: [ConfirmDialogModule, ButtonModule, FormErrorComponent],
   providers: [ConfirmationService],
   templateUrl: './confirmation-dialog.component.html',
   styles: ``,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ConfirmationDialogComponent {
+export class ConfirmationDialogComponent<TMutationData = unknown> {
   private confirmationService = inject(ConfirmationService);
 
+  mutation =
+    input.required<CreateMutationResult<unknown, Error, TMutationData>>();
+  mutationData = input.required<TMutationData>();
   header = input($localize`:@@confirmation-dialog-header:Are you sure?`);
-  acceptLabel = input($localize`:@@generic-proceed:Proceed`);
-  rejectLabel = input($localize`:@@generic-cancel:Cancel`);
-  acceptIcon = input('none');
-  rejectIcon = input('none');
+  proceedLabel = input($localize`:@@generic-proceed:Proceed`);
 
-  confirm({ accept, reject }: { accept: () => void; reject?: () => void }) {
-    this.confirmationService.confirm({
-      accept,
-      reject,
-      header: this.header(),
-      acceptLabel: this.acceptLabel(),
-      rejectLabel: this.rejectLabel(),
-      acceptIcon: this.acceptIcon(),
-      rejectIcon: this.rejectIcon(),
-      rejectButtonStyleClass: 'p-button-rounded p-button-outlined',
-      acceptButtonStyleClass: 'p-button-rounded',
+  @ViewChild('confirmDialog') confirmDialog: ConfirmDialog;
+
+  askForConfirmation() {
+    this.confirmationService.confirm({});
+  }
+
+  onProceed() {
+    this.mutation().mutate(this.mutationData(), {
+      onSuccess: () => {
+        this.confirmDialog.accept();
+      },
     });
   }
 }

--- a/interfaces/Portalicious/src/app/components/form/form-sidebar.component.html
+++ b/interfaces/Portalicious/src/app/components/form/form-sidebar.component.html
@@ -29,7 +29,7 @@
       <div class="flex justify-end gap-2">
         <p-button
           label="Cancel"
-          i18n-label
+          i18n-label="@@generic-cancel"
           type="button"
           rounded
           outlined

--- a/interfaces/Portalicious/src/app/domains/project/project.api.service.ts
+++ b/interfaces/Portalicious/src/app/domains/project/project.api.service.ts
@@ -157,7 +157,11 @@ export class ProjectApiService extends DomainApiService {
     );
   }
 
-  removeProjectUser(projectId: Signal<number>, userId: number) {
+  removeProjectUser(projectId: Signal<number>, userId?: number) {
+    if (!userId) {
+      return Promise.reject(new Error('User ID is required'));
+    }
+
     return this.httpWrapperService.perform121ServiceRequest<Project>({
       method: 'DELETE',
       endpoint: `${BASE_ENDPOINT}/${projectId().toString()}/users/${userId.toString()}`,

--- a/interfaces/Portalicious/src/app/pages/project/project-team/project-team.page.html
+++ b/interfaces/Portalicious/src/app/pages/project/project-team/project-team.page.html
@@ -33,11 +33,13 @@
   </p-card>
 </app-page-layout>
 <app-confirmation-dialog
-  #confirmationDialog
+  #removeUserConfirmationDialog
   header="Remove user from team"
   i18n-header
-  acceptLabel="Remove user"
-  i18n-acceptLabel="@@remove-user-button"
+  proceedLabel="Remove user"
+  i18n-proceedLabel="@@remove-user-button"
+  [mutation]="removeUserMutation"
+  [mutationData]="{ userId: selectedUser()?.id }"
 >
   <p i18n>
     You're about to remove

--- a/interfaces/Portalicious/src/locale/messages.nl.xlf
+++ b/interfaces/Portalicious/src/locale/messages.nl.xlf
@@ -266,7 +266,7 @@
         <source>Submit</source>
         <target state="new">Submit</target>
       </trans-unit>
-      <trans-unit id="2159130950882492111" datatype="html">
+      <trans-unit id="generic-cancel" datatype="html">
         <source>Cancel</source>
         <target state="new">Cancel</target>
       </trans-unit>
@@ -349,10 +349,6 @@
       <trans-unit id="4533999713544924009" datatype="html">
         <source>Remove user from team</source>
         <target state="new">Remove user from team</target>
-      </trans-unit>
-      <trans-unit id="generic-cancel" datatype="html">
-        <source>Cancel</source>
-        <target state="new">Cancel</target>
       </trans-unit>
       <trans-unit id="8875170340911342447" datatype="html">
         <source>You&apos;re about to remove <x ctype="x-b" equiv-text="&lt;b&gt;" id="START_BOLD_TEXT"/><x equiv-text="{{ selectedUser()?.username }}" id="INTERPOLATION"/><x ctype="x-b" equiv-text="&lt;/b&gt;" id="CLOSE_BOLD_TEXT"/> (<x equiv-text="{{ selectedUser()?.allRolesLabel }}" id="INTERPOLATION_1"/>) from your team.<x ctype="lb" equiv-text="&lt;br /&gt;" id="LINE_BREAK"/>They will not have access to the project anymore.</source>

--- a/interfaces/Portalicious/src/locale/messages.xlf
+++ b/interfaces/Portalicious/src/locale/messages.xlf
@@ -199,7 +199,7 @@
       <trans-unit id="1887371025019909976" datatype="html">
         <source>Kobo Asset ID</source>
       </trans-unit>
-      <trans-unit id="2159130950882492111" datatype="html">
+      <trans-unit id="generic-cancel" datatype="html">
         <source>Cancel</source>
       </trans-unit>
       <trans-unit id="7750664097458673871" datatype="html">
@@ -267,9 +267,6 @@
       </trans-unit>
       <trans-unit id="8875170340911342447" datatype="html">
         <source>You&apos;re about to remove <x ctype="x-b" equiv-text="&lt;b&gt;" id="START_BOLD_TEXT"/><x equiv-text="{{ selectedUser()?.username }}" id="INTERPOLATION"/><x ctype="x-b" equiv-text="&lt;/b&gt;" id="CLOSE_BOLD_TEXT"/> (<x equiv-text="{{ selectedUser()?.allRolesLabel }}" id="INTERPOLATION_1"/>) from your team.<x ctype="lb" equiv-text="&lt;br /&gt;" id="LINE_BREAK"/>They will not have access to the project anymore.</source>
-      </trans-unit>
-      <trans-unit id="generic-cancel" datatype="html">
-        <source>Cancel</source>
       </trans-unit>
       <trans-unit id="generic-success" datatype="html">
         <source>Success</source>


### PR DESCRIPTION
[AB#30503](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/30503)

This refactor makes the assumption that confirmation dialogs will always be used with mutations, which I think is a fair assumption.

If we find a scenario where this isn't true, we can refactor / create an abstraction later.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
