### PR TITLE
fix: update payment count AB#30500

### DIFF
--- a/services/121-service/src/payments/transactions/repositories/latest-transaction.repository.ts
+++ b/services/121-service/src/payments/transactions/repositories/latest-transaction.repository.ts
@@ -45,4 +45,14 @@ export class LatestTransactionRepository extends Repository<LatestTransactionEnt
       }
     }
   }
+
+  public async getPaymentCount(registrationId: number): Promise<number> {
+    const distinctPayments = await this.baseRepository
+      .createQueryBuilder('transaction')
+      .select('DISTINCT transaction.payment')
+      .where('transaction.registrationId = :registrationId', { registrationId })
+      .getRawMany();
+
+    return distinctPayments.length;
+  }
 }

--- a/services/121-service/src/transaction-job-processors/transaction-job-processors.service.ts
+++ b/services/121-service/src/transaction-job-processors/transaction-job-processors.service.ts
@@ -451,7 +451,9 @@ export class TransactionJobProcessorsService {
   ): Promise<void> {
     const program = await this.programRepository.findByIdOrFail(programId);
 
-    const paymentCount = (registration.paymentCount || 0) + 1;
+    const paymentCount = await this.latestTransactionRepository.getPaymentCount(
+      registration.id,
+    );
 
     let updateData: {
       paymentCount: number;


### PR DESCRIPTION
AB#30500

## Describe your changes

This fix makes sure always the correct paymentCount is calculated by counting the distinct 'payments' in latestTransaction table (by registrationId), instead of doing +1, which would fail in case of job retry.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines
