### PR TITLE
portalicious: add registrations breadcrumb and handle not found

### DIFF
--- a/interfaces/Portalicious/src/locale/messages.nl.xlf
+++ b/interfaces/Portalicious/src/locale/messages.nl.xlf
@@ -839,6 +839,22 @@
         <source>Role description</source>
         <target state="new">Role description</target>
       </trans-unit>
+      <trans-unit id="7739650586737813677" datatype="html">
+        <source>All Registrations</source>
+        <target state="new">All Registrations</target>
+      </trans-unit>
+      <trans-unit id="8040367464671654118" datatype="html">
+        <source>Reg. #</source>
+        <target state="new">Reg. #</target>
+      </trans-unit>
+      <trans-unit id="3284816784388197103" datatype="html">
+        <source>Project not found. Please check the URL and try again.</source>
+        <target state="new">Project not found. Please check the URL and try again.</target>
+      </trans-unit>
+      <trans-unit id="6884725425179376273" datatype="html">
+        <source>Registration not found. Please check the URL and try again.</source>
+        <target state="new">Registration not found. Please check the URL and try again.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/interfaces/Portalicious/src/locale/messages.xlf
+++ b/interfaces/Portalicious/src/locale/messages.xlf
@@ -632,6 +632,18 @@
       <trans-unit id="6751038926528230759" datatype="html">
         <source>Role description</source>
       </trans-unit>
+      <trans-unit id="3284816784388197103" datatype="html">
+        <source>Project not found. Please check the URL and try again.</source>
+      </trans-unit>
+      <trans-unit id="8040367464671654118" datatype="html">
+        <source>Reg. #</source>
+      </trans-unit>
+      <trans-unit id="6884725425179376273" datatype="html">
+        <source>Registration not found. Please check the URL and try again.</source>
+      </trans-unit>
+      <trans-unit id="7739650586737813677" datatype="html">
+        <source>All Registrations</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
[AB#30165](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/30165)
[AB#30395](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/30395)

I combined these two tasks because I found one relying on the other, and figured that they wouldn't be a large set of changes even when combined.

The design of the "registration not found" deviates from what is in Figma based on a convo with Tal.

![image](https://github.com/user-attachments/assets/5c188e60-525d-40f7-93ab-358964255181)

I also took the liberty of adding a "project not found" error.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
