### PR TITLE
fix: referenceId mistakenly cast to number

### DIFF
--- a/services/121-service/src/registration/services/registrations-pagination.service.ts
+++ b/services/121-service/src/registration/services/registrations-pagination.service.ts
@@ -164,14 +164,28 @@ export class RegistrationsPaginationService {
 
     queryBuilder = this.addPaymentFilter(queryBuilder, query);
 
-    // Replacing the filter on referenceId is needed in specific cases where the referenceId only consists of numbers.
-    // The !query.filter.referenceId.includes('$') is needed to check if the query doesn't contain an operator like '$ilike'.
-    // If the filter has a '$' we don't need to replace the filter
-    if (query?.filter?.referenceId && !query.filter.referenceId.includes('$')) {
-      queryBuilder.andWhere('CAST("referenceId" AS TEXT) = :referenceId', {
-        referenceId: query.filter.referenceId,
-      });
-      delete query.filter.referenceId;
+    // Replacing the filter on referenceId is needed in specific cases where the referenceId only consists of numbers
+    // or a string that javascript could mistakenly interpret as a number (ie. "651581942751358e5")
+    if (
+      query?.filter?.referenceId &&
+      typeof query.filter.referenceId === 'string'
+    ) {
+      if (!query.filter.referenceId.includes('$')) {
+        // The !query.filter.referenceId.includes('$') is needed to check if the query doesn't contain an operator like '$ilike'.
+        // If the filter has a '$' we don't need to replace the filter
+        queryBuilder.andWhere('CAST("referenceId" AS TEXT) = :referenceId', {
+          referenceId: query.filter.referenceId,
+        });
+        delete query.filter.referenceId;
+      } else if (query.filter.referenceId.includes('$eq')) {
+        // Weird edge case
+        // See this for more info: https://dev.azure.com/redcrossnl/121%20Platform/_workitems/edit/30713
+        // If we don't do this, nestjs-paginate could try to convert referenceId to a number and fail.
+        queryBuilder.andWhere('"referenceId" = :referenceId', {
+          referenceId: query.filter.referenceId.split('$eq:')[1],
+        });
+        delete query.filter.referenceId;
+      }
     }
 
     // PaginateConfig.select and PaginateConfig.relations cannot be used in combi with each other


### PR DESCRIPTION
[AB#30719](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/30719)

Regression introduced in nestjs-paginate:
https://github.com/ppetzold/nestjs-paginate/commit/25739bda711c98f7de673a049da1cdf55c8a96f6#diff-87404c91a22dbabcc334f9a5288341281cb2b6625533e1207efcac16dc1e2ffdR279

This is a temporary fix to solve the regression introduced above. TBD whether we need to adjust this code, adjust our code further, or submit a PR to nestjs-paginate.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
