### PR TITLE
portalicious: fix request caching

### DIFF
--- a/interfaces/Portalicious/src/app/domains/metric/metric.api.service.ts
+++ b/interfaces/Portalicious/src/app/domains/metric/metric.api.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, Signal } from '@angular/core';
+
+import { DomainApiService } from '~/domains/domain-api.service';
+import { ProjectMetrics } from '~/domains/metric/metric.model';
+
+const BASE_ENDPOINT = (projectId: Signal<number>) => [
+  'programs',
+  projectId,
+  'metrics',
+];
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MetricApiService extends DomainApiService {
+  getProjectSummaryMetrics(projectId: Signal<number>) {
+    return this.generateQueryOptions<ProjectMetrics>({
+      path: [...BASE_ENDPOINT(projectId), 'program-stats-summary'],
+    });
+  }
+
+  public invalidateCache(projectId: Signal<number>): Promise<void> {
+    return this.queryClient.invalidateQueries({
+      queryKey: this.pathToQueryKey(BASE_ENDPOINT(projectId)),
+    });
+  }
+}

--- a/interfaces/Portalicious/src/app/domains/metric/metric.model.ts
+++ b/interfaces/Portalicious/src/app/domains/metric/metric.model.ts
@@ -1,0 +1,5 @@
+import { ProgramStats } from '@121-service/src/metrics/dto/program-stats.dto';
+
+import { Dto } from '~/utils/dto-type';
+// TODO: AB#30152 This type should be refactored to use Dto121Service
+export type ProjectMetrics = Dto<ProgramStats>;

--- a/interfaces/Portalicious/src/app/domains/project/project.api.service.ts
+++ b/interfaces/Portalicious/src/app/domains/project/project.api.service.ts
@@ -1,4 +1,3 @@
-import { HttpParams } from '@angular/common/http';
 import { inject, Injectable, Signal } from '@angular/core';
 
 import { uniqBy } from 'lodash';
@@ -9,7 +8,6 @@ import {
   Attribute,
   AttributeWithTranslatedLabel,
   Project,
-  ProjectMetrics,
   ProjectUser,
   ProjectUserAssignment,
   ProjectUserWithRolesLabel,
@@ -54,12 +52,6 @@ export class ProjectApiService extends DomainApiService {
     });
   }
 
-  getProjectSummaryMetrics(projectId: Signal<number>) {
-    return this.generateQueryOptions<ProjectMetrics>({
-      path: [BASE_ENDPOINT, projectId, 'metrics/program-stats-summary'],
-    });
-  }
-
   getProjectUsers(projectId: Signal<number>) {
     return this.generateQueryOptions<
       ProjectUser[],
@@ -95,23 +87,19 @@ export class ProjectApiService extends DomainApiService {
     includeTemplateDefaultAttributes?: boolean;
     filterShowInPeopleAffectedTable?: boolean;
   }) {
-    const params = new HttpParams({
-      fromObject: {
-        includeCustomAttributes,
-        includeProgramQuestions,
-        includeFspQuestions,
-        includeTemplateDefaultAttributes,
-        filterShowInPeopleAffectedTable,
-      },
-    });
-
     return this.generateQueryOptions<
       Attribute[],
       AttributeWithTranslatedLabel[]
     >({
       path: [BASE_ENDPOINT, projectId, 'attributes'],
       requestOptions: {
-        params,
+        params: {
+          includeCustomAttributes,
+          includeProgramQuestions,
+          includeFspQuestions,
+          includeTemplateDefaultAttributes,
+          filterShowInPeopleAffectedTable,
+        },
       },
       processResponse: (attributes) => {
         return uniqBy(attributes, 'name').map((attribute) => {
@@ -224,12 +212,10 @@ export class ProjectApiService extends DomainApiService {
         'financial-service-providers/intersolve-voucher/vouchers',
       ],
       requestOptions: {
-        params: new HttpParams({
-          fromObject: {
-            referenceId: voucherReferenceId,
-            payment: paymentId.toString(),
-          },
-        }),
+        params: {
+          referenceId: voucherReferenceId,
+          payment: paymentId.toString(),
+        },
         responseAsBlob: true,
       },
     });
@@ -244,10 +230,6 @@ export class ProjectApiService extends DomainApiService {
     registrationReferenceId: string;
     paymentId: number;
   }) {
-    let params = new HttpParams();
-    params = params.append('referenceId', registrationReferenceId);
-    params = params.append('payment', paymentId);
-
     return this.generateQueryOptions<number>({
       path: [
         BASE_ENDPOINT,
@@ -255,7 +237,10 @@ export class ProjectApiService extends DomainApiService {
         'financial-service-providers/intersolve-voucher/vouchers/balance',
       ],
       requestOptions: {
-        params,
+        params: {
+          referenceId: registrationReferenceId,
+          payment: paymentId,
+        },
       },
     });
   }

--- a/interfaces/Portalicious/src/app/domains/project/project.model.ts
+++ b/interfaces/Portalicious/src/app/domains/project/project.model.ts
@@ -1,4 +1,3 @@
-import { ProgramStats } from '@121-service/src/metrics/dto/program-stats.dto';
 import { FoundProgramDto } from '@121-service/src/programs/dto/found-program.dto';
 import { ProgramController } from '@121-service/src/programs/programs.controller';
 import { UserController } from '@121-service/src/user/user.controller';
@@ -8,9 +7,6 @@ import { ArrayElement } from '~/utils/type-helpers';
 
 // TODO: AB#30152 This type should be refactored to use Dto121Service
 export type Project = Dto<FoundProgramDto>;
-
-// TODO: AB#30152 This type should be refactored to use Dto121Service
-export type ProjectMetrics = Dto<ProgramStats>;
 
 export type ProjectUser = ArrayElement<
   Dto121Service<UserController['getUsersInProgram']>

--- a/interfaces/Portalicious/src/app/domains/registration/registration.api.service.ts
+++ b/interfaces/Portalicious/src/app/domains/registration/registration.api.service.ts
@@ -1,5 +1,4 @@
-import { HttpParams } from '@angular/common/http';
-import { inject, Injectable, Signal } from '@angular/core';
+import { Injectable, Signal } from '@angular/core';
 
 import { queryOptions } from '@tanstack/angular-query-experimental';
 
@@ -17,10 +16,7 @@ import {
   VisaCardAction,
   WalletWithCards,
 } from '~/domains/registration/registration.model';
-import {
-  PaginateQuery,
-  PaginateQueryService,
-} from '~/services/paginate-query.service';
+import { PaginateQuery } from '~/services/paginate-query.service';
 
 const BASE_ENDPOINT = (projectId: Signal<number>) => [
   'programs',
@@ -32,31 +28,14 @@ const BASE_ENDPOINT = (projectId: Signal<number>) => [
   providedIn: 'root',
 })
 export class RegistrationApiService extends DomainApiService {
-  paginateQueryService = inject(PaginateQueryService);
-
   getManyByQuery(
     projectId: Signal<number>,
     paginateQuery: Signal<PaginateQuery | undefined>,
   ) {
-    return () => {
-      const path = [...BASE_ENDPOINT(projectId)];
-
-      return queryOptions({
-        queryKey: [path, paginateQuery()],
-        queryFn: async () =>
-          this.httpWrapperService.perform121ServiceRequest<FindAllRegistrationsResult>(
-            {
-              method: 'GET',
-              endpoint: this.pathToQueryKey(path).join('/'),
-              params:
-                this.paginateQueryService.paginateQueryToHttpParams(
-                  paginateQuery(),
-                ),
-            },
-          ),
-        enabled: () => !!paginateQuery(),
-      });
-    };
+    return this.generateQueryOptions<FindAllRegistrationsResult>({
+      path: [...BASE_ENDPOINT(projectId)],
+      paginateQuery,
+    });
   }
 
   getRegistrationById(
@@ -100,7 +79,9 @@ export class RegistrationApiService extends DomainApiService {
       ]).join('/'),
       body,
       params:
-        this.paginateQueryService.paginateQueryToHttpParams(paginateQuery),
+        this.paginateQueryService.paginateQueryToHttpParamsObject(
+          paginateQuery,
+        ),
     });
   }
 
@@ -223,11 +204,9 @@ export class RegistrationApiService extends DomainApiService {
     return this.httpWrapperService.perform121ServiceRequest({
       method: 'PATCH',
       endpoint,
-      params: new HttpParams({
-        fromObject: {
-          pause: pauseStatus,
-        },
-      }),
+      params: {
+        pause: pauseStatus,
+      },
     });
   }
 

--- a/interfaces/Portalicious/src/app/pages/project-monitoring/project-monitoring.page.ts
+++ b/interfaces/Portalicious/src/app/pages/project-monitoring/project-monitoring.page.ts
@@ -19,6 +19,7 @@ import {
 import { InfoTooltipComponent } from '~/components/info-tooltip/info-tooltip.component';
 import { PageLayoutComponent } from '~/components/page-layout/page-layout.component';
 import { SkeletonInlineComponent } from '~/components/skeleton-inline/skeleton-inline.component';
+import { MetricApiService } from '~/domains/metric/metric.api.service';
 import { PaymentApiService } from '~/domains/payment/payment.api.service';
 import { ProjectApiService } from '~/domains/project/project.api.service';
 import { MetricTileComponent } from '~/pages/project-monitoring/components/metric-tile/metric-tile.component';
@@ -52,13 +53,14 @@ export class ProjectMonitoringPageComponent {
   projectId = input.required<number>();
 
   readonly locale = inject(LOCALE_ID);
+  readonly metricApiService = inject(MetricApiService);
   readonly projectApiService = inject(ProjectApiService);
   readonly paymentApiService = inject(PaymentApiService);
   readonly translatableStringService = inject(TranslatableStringService);
 
   project = injectQuery(this.projectApiService.getProject(this.projectId));
   metrics = injectQuery(() => ({
-    ...this.projectApiService.getProjectSummaryMetrics(this.projectId)(),
+    ...this.metricApiService.getProjectSummaryMetrics(this.projectId)(),
     enabled: !!this.project.data()?.id,
   }));
   payments = injectQuery(() => ({

--- a/interfaces/Portalicious/src/app/pages/project-registrations/components/custom-message-preview/custom-message-preview.component.ts
+++ b/interfaces/Portalicious/src/app/pages/project-registrations/components/custom-message-preview/custom-message-preview.component.ts
@@ -32,7 +32,11 @@ export class CustomMessagePreviewComponent {
   private messagingService = inject(MessagingService);
 
   messagePreview = injectQuery(() => ({
-    queryKey: [this.messageData(), this.projectId, this.previewRegistration],
+    queryKey: [
+      this.messageData(),
+      this.projectId(),
+      this.previewRegistration(),
+    ],
     queryFn: () =>
       this.messagingService.getMessagePreview(
         this.messageData(),

--- a/interfaces/Portalicious/src/app/pages/projects-overview/components/project-summary-card/project-summary-card.component.ts
+++ b/interfaces/Portalicious/src/app/pages/projects-overview/components/project-summary-card/project-summary-card.component.ts
@@ -14,6 +14,7 @@ import { SkeletonModule } from 'primeng/skeleton';
 
 import { AppRoutes } from '~/app.routes';
 import { SkeletonInlineComponent } from '~/components/skeleton-inline/skeleton-inline.component';
+import { MetricApiService } from '~/domains/metric/metric.api.service';
 import { PaymentApiService } from '~/domains/payment/payment.api.service';
 import { ProjectApiService } from '~/domains/project/project.api.service';
 import { ProjectMetricContainerComponent } from '~/pages/projects-overview/components/project-metric-container/project-metric-container.component';
@@ -37,6 +38,7 @@ import { TranslatableStringPipe } from '~/pipes/translatable-string.pipe';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProjectSummaryCardComponent {
+  private metricApiService = inject(MetricApiService);
   private projectApiService = inject(ProjectApiService);
   private paymentApiService = inject(PaymentApiService);
 
@@ -44,7 +46,7 @@ export class ProjectSummaryCardComponent {
 
   public project = injectQuery(this.projectApiService.getProject(this.id));
   public metrics = injectQuery(() => ({
-    ...this.projectApiService.getProjectSummaryMetrics(this.id)(),
+    ...this.metricApiService.getProjectSummaryMetrics(this.id)(),
     enabled: !!this.project.data()?.id,
   }));
   public payments = injectQuery(() => ({

--- a/interfaces/Portalicious/src/app/services/http-wrapper.service.ts
+++ b/interfaces/Portalicious/src/app/services/http-wrapper.service.ts
@@ -3,6 +3,7 @@ import {
   HttpErrorResponse,
   HttpHeaders,
   HttpParams,
+  HttpParamsOptions,
   HttpStatusCode,
 } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
@@ -22,12 +23,7 @@ interface PerformRequestParams {
   body?: unknown;
   responseAsBlob?: boolean;
   isUpload?: boolean;
-  params?:
-    | HttpParams
-    | Record<
-        string,
-        boolean | number | readonly (boolean | number | string)[] | string
-      >;
+  params?: HttpParamsOptions['fromObject'];
 }
 
 export type Perform121ServiceRequestParams = { endpoint: string } & Omit<
@@ -158,7 +154,7 @@ export class HttpWrapperService {
             headers: this.createHeaders(isUpload),
             responseType: responseAsBlob ? 'blob' : undefined,
             withCredentials: true,
-            params,
+            params: new HttpParams({ fromObject: params }),
             body,
           })
           .pipe(

--- a/interfaces/Portalicious/src/app/services/paginate-query.service.spec.ts
+++ b/interfaces/Portalicious/src/app/services/paginate-query.service.spec.ts
@@ -1,3 +1,4 @@
+import { HttpParams } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 
 import { FilterMatchMode, FilterMetadata } from 'primeng/api';
@@ -128,56 +129,62 @@ describe('PaginateQueryService', () => {
     });
   });
 
-  describe('paginateQueryToHttpParams', () => {
-    it('should convert an empty query to HttpParams', () => {
-      const result = service.paginateQueryToHttpParams();
-      expect(result.toString()).toBe('');
+  describe('paginateQueryToHttpParamsObject', () => {
+    it('should convert an empty query to HttpParamsObject', () => {
+      const result = service.paginateQueryToHttpParamsObject();
+      const params = new HttpParams({ fromObject: result });
+      expect(params.toString()).toBe('');
     });
 
-    it('should convert a query with page and limit to HttpParams', () => {
+    it('should convert a query with page and limit to HttpParamsObject', () => {
       const query: PaginateQuery = {
         page: 1,
         limit: 10,
       };
-      const result = service.paginateQueryToHttpParams(query);
-      expect(result.toString()).toBe('page=1&limit=10');
+      const result = service.paginateQueryToHttpParamsObject(query);
+      const params = new HttpParams({ fromObject: result });
+      expect(params.toString()).toBe('page=1&limit=10');
     });
 
-    it('should convert a query with sortBy to HttpParams', () => {
+    it('should convert a query with sortBy to HttpParamsObject', () => {
       const query: PaginateQuery = {
         sortBy: [['name', 'ASC']],
       };
-      const result = service.paginateQueryToHttpParams(query);
-      expect(result.toString()).toBe('sortBy=name:ASC');
+      const result = service.paginateQueryToHttpParamsObject(query);
+      const params = new HttpParams({ fromObject: result });
+      expect(params.toString()).toBe('sortBy=name:ASC');
     });
 
-    it('should convert a query with search to HttpParams', () => {
+    it('should convert a query with search to HttpParamsObject', () => {
       const query: PaginateQuery = {
         search: 'test',
       };
-      const result = service.paginateQueryToHttpParams(query);
-      expect(result.toString()).toBe('search=test');
+      const result = service.paginateQueryToHttpParamsObject(query);
+      const params = new HttpParams({ fromObject: result });
+      expect(params.toString()).toBe('search=test');
     });
 
-    it('should convert a query with filter to HttpParams', () => {
+    it('should convert a query with filter to HttpParamsObject', () => {
       const query: PaginateQuery = {
         filter: {
           name: '$ilike:test',
         },
       };
-      const result = service.paginateQueryToHttpParams(query);
-      expect(result.toString()).toBe('filter.name=$ilike:test');
+      const result = service.paginateQueryToHttpParamsObject(query);
+      const params = new HttpParams({ fromObject: result });
+      expect(params.toString()).toBe('filter.name=$ilike:test');
     });
 
-    it('should convert a query with select to HttpParams', () => {
+    it('should convert a query with select to HttpParamsObject', () => {
       const query: PaginateQuery = {
         select: ['name', 'age'],
       };
-      const result = service.paginateQueryToHttpParams(query);
-      expect(result.toString()).toBe('select=name&select=age');
+      const result = service.paginateQueryToHttpParamsObject(query);
+      const params = new HttpParams({ fromObject: result });
+      expect(params.toString()).toBe('select=name,age');
     });
 
-    it('should convert a complex query to HttpParams', () => {
+    it('should convert a complex query to HttpParamsObject', () => {
       const query: PaginateQuery = {
         page: 1,
         limit: 10,
@@ -188,9 +195,10 @@ describe('PaginateQueryService', () => {
         },
         select: ['name', 'age'],
       };
-      const result = service.paginateQueryToHttpParams(query);
-      expect(result.toString()).toBe(
-        'page=1&limit=10&sortBy=name:ASC&search=test&filter.name=$ilike:test&select=name&select=age',
+      const result = service.paginateQueryToHttpParamsObject(query);
+      const params = new HttpParams({ fromObject: result });
+      expect(params.toString()).toBe(
+        'page=1&limit=10&sortBy=name:ASC&search=test&filter.name=$ilike:test&select=name,age',
       );
     });
 
@@ -200,10 +208,9 @@ describe('PaginateQueryService', () => {
           name: ['$ilike:test1', '$ilike:test2'],
         },
       };
-      const result = service.paginateQueryToHttpParams(query);
-      expect(result.toString()).toBe(
-        'filter.name=$ilike:test1&filter.name=$ilike:test2',
-      );
+      const result = service.paginateQueryToHttpParamsObject(query);
+      const params = new HttpParams({ fromObject: result });
+      expect(params.toString()).toBe('filter.name=$ilike:test1,$ilike:test2');
     });
   });
 });

--- a/interfaces/Portalicious/src/app/services/paginate-query.service.ts
+++ b/interfaces/Portalicious/src/app/services/paginate-query.service.ts
@@ -1,4 +1,4 @@
-import { HttpParams } from '@angular/common/http';
+import { HttpParamsOptions } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import { FilterMatchMode, FilterMetadata } from 'primeng/api';
@@ -156,47 +156,45 @@ export class PaginateQueryService {
     };
   }
 
-  public paginateQueryToHttpParams(query?: PaginateQuery) {
-    let params = new HttpParams();
+  public paginateQueryToHttpParamsObject(
+    query?: PaginateQuery,
+  ): Exclude<HttpParamsOptions['fromObject'], undefined> {
+    const params: HttpParamsOptions['fromObject'] = {};
 
     if (!query) {
       return params;
     }
 
     if (query.page) {
-      params = params.set('page', query.page);
+      params.page = query.page.toString();
     }
 
     if (query.limit) {
-      params = params.set('limit', query.limit);
+      params.limit = query.limit.toString();
     }
 
     if (query.sortBy) {
-      query.sortBy.forEach(([column, direction]) => {
-        params = params.set(`sortBy`, `${column}:${direction}`);
-      });
+      params.sortBy = query.sortBy.map(
+        ([column, direction]) => `${column}:${direction}`,
+      );
     }
 
     if (query.search) {
-      params = params.set('search', query.search);
+      params.search = query.search;
     }
 
     if (query.filter) {
       Object.entries(query.filter).forEach(([column, value]) => {
         if (Array.isArray(value)) {
-          value.forEach((v) => {
-            params = params.append(`filter.${column}`, v);
-          });
+          params[`filter.${column}`] = value.join(',');
         } else {
-          params = params.set(`filter.${column}`, value);
+          params[`filter.${column}`] = value;
         }
       });
     }
 
     if (query.select) {
-      query.select.forEach((column) => {
-        params = params.append('select', column);
-      });
+      params.select = query.select.join(',');
     }
 
     return params;


### PR DESCRIPTION
[AB#31036](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/31036)

## Describe your changes

On some requests in the export functionality, the same request + http parameters were being sent to the backend, even when the http parameters being used to make the request in the service were different.

I started by changing the `generateQueryOptions` function to have an exhaustive list of query keys, thinking that the lack of `requestOptions` in this array was the culprit.

It was not.

So then I refactored the `HttpWrapper.performRequest` to only accept HttpParam _objects_ instead of HttpParam _class instances_. My thinking here was that tanstack-query was struggling to serialize class instances as opposed to objects.

This was partially true, but did not solve the problem entirely.

I ultimately added the `paginateQuery` option to the `generateQueryOptions`, because I realised that the issue was that the call to the Signal `paginateQuery` needed to happen _inside_ the `queryFn` in order to allow the "signals to signal".

I'm not sure any of my thought process actually makes any sense, but hopefully you find the resulting code cleaner either way, given that now we don't have to worry about creating HttpParams anywhere anymore, and we just deal with objects.

## Testing

There is nothing to test in the UI - as in, everything should work like before because the original buggy behaviour was only encountered in #6000 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
