### PR TITLE
portalicious: remove Dto121Service

### DIFF
--- a/interfaces/Portalicious/src/app/domains/financial-service-provider/financial-service-provider.model.ts
+++ b/interfaces/Portalicious/src/app/domains/financial-service-provider/financial-service-provider.model.ts
@@ -1,8 +1,5 @@
-import { FinancialServiceProvidersController } from '@121-service/src/financial-service-providers/financial-service-provider.controller';
+import { FinancialServiceProviderEntity } from '@121-service/src/financial-service-providers/financial-service-provider.entity';
 
-import { Dto121Service } from '~/utils/dto-type';
-import { ArrayElement } from '~/utils/type-helpers';
+import { Dto } from '~/utils/dto-type';
 
-export type FinancialServiceProvider = ArrayElement<
-  Dto121Service<FinancialServiceProvidersController['getAllFsps']>
->;
+export type FinancialServiceProvider = Dto<FinancialServiceProviderEntity>;

--- a/interfaces/Portalicious/src/app/domains/health/health.model.ts
+++ b/interfaces/Portalicious/src/app/domains/health/health.model.ts
@@ -1,5 +1,5 @@
-import { HealthController } from '@121-service/src/health/health.controller';
+import { GetVersionDto } from '@121-service/src/health/dto/get-version.dto';
 
-import { Dto121Service } from '~/utils/dto-type';
+import { Dto } from '~/utils/dto-type';
 
-export type VersionInfo = Dto121Service<HealthController['version']>;
+export type VersionInfo = Dto<GetVersionDto>;

--- a/interfaces/Portalicious/src/app/domains/metric/metric.model.ts
+++ b/interfaces/Portalicious/src/app/domains/metric/metric.model.ts
@@ -1,5 +1,5 @@
 import { ProgramStats } from '@121-service/src/metrics/dto/program-stats.dto';
 
 import { Dto } from '~/utils/dto-type';
-// TODO: AB#30152 This type should be refactored to use Dto121Service
+
 export type ProjectMetrics = Dto<ProgramStats>;

--- a/interfaces/Portalicious/src/app/domains/notification/notification.model.ts
+++ b/interfaces/Portalicious/src/app/domains/notification/notification.model.ts
@@ -1,11 +1,8 @@
-import { MessageTemplateController } from '@121-service/src/notifications/message-template/message-template.controller';
+import { MessageTemplateEntity } from '@121-service/src/notifications/message-template/message-template.entity';
 
-import { Dto121Service } from '~/utils/dto-type';
-import { ArrayElement } from '~/utils/type-helpers';
+import { Dto } from '~/utils/dto-type';
 
-export type MessageTemplate = ArrayElement<
-  Dto121Service<MessageTemplateController['getMessageTemplatesByProgramId']>
->;
+export type MessageTemplate = Dto<MessageTemplateEntity>;
 
 export type MessageTemplateWithTranslatedLabel = {
   label: string;

--- a/interfaces/Portalicious/src/app/domains/payment/payment.model.ts
+++ b/interfaces/Portalicious/src/app/domains/payment/payment.model.ts
@@ -1,14 +1,9 @@
+import { GetPaymentsDto } from '@121-service/src/payments/dto/get-payments.dto';
 import { ProgramPaymentsStatusDto } from '@121-service/src/payments/dto/program-payments-status.dto';
 import { PaymentReturnDto } from '@121-service/src/payments/transactions/dto/get-transaction.dto';
 
 import { Dto } from '~/utils/dto-type';
 
-// TODO: AB#30152 This type should be refactored to use Dto121Service
-export interface Payment {
-  payment: number;
-  paymentDate: string;
-  amount: number;
-}
-
+export type Payment = Dto<GetPaymentsDto>;
 export type PaymentAggregate = Dto<PaymentReturnDto>;
 export type PaymentStatus = Dto<ProgramPaymentsStatusDto>;

--- a/interfaces/Portalicious/src/app/domains/project/project.model.ts
+++ b/interfaces/Portalicious/src/app/domains/project/project.model.ts
@@ -1,29 +1,22 @@
 import { FoundProgramDto } from '@121-service/src/programs/dto/found-program.dto';
-import { ProgramController } from '@121-service/src/programs/programs.controller';
-import { UserController } from '@121-service/src/user/user.controller';
+import { Attribute as AttributeFromBackend } from '@121-service/src/registration/enum/custom-data-attributes';
+import { GetUserReponseDto } from '@121-service/src/user/dto/get-user-response.dto';
+import { AssignmentResponseDTO } from '@121-service/src/user/dto/userrole-response.dto';
 
-import { Dto, Dto121Service } from '~/utils/dto-type';
-import { ArrayElement } from '~/utils/type-helpers';
+import { Dto } from '~/utils/dto-type';
 
-// TODO: AB#30152 This type should be refactored to use Dto121Service
 export type Project = Dto<FoundProgramDto>;
 
-export type ProjectUser = ArrayElement<
-  Dto121Service<UserController['getUsersInProgram']>
->;
+export type ProjectUser = Dto<GetUserReponseDto>;
 
-export type ProjectUserAssignment = Dto121Service<
-  UserController['assignAidworkerToProgram']
->;
+export type ProjectUserAssignment = Dto<AssignmentResponseDTO>;
 
 export type ProjectUserWithRolesLabel = {
   allRolesLabel: string;
   lastLogin?: Date;
 } & Omit<ProjectUser, 'lastLogin'>;
 
-export type Attribute = ArrayElement<
-  Dto121Service<ProgramController['getAttributes']>
->;
+export type Attribute = Dto<AttributeFromBackend>;
 
 export type AttributeWithTranslatedLabel = { label: string } & Omit<
   Attribute,

--- a/interfaces/Portalicious/src/app/domains/registration/registration.model.ts
+++ b/interfaces/Portalicious/src/app/domains/registration/registration.model.ts
@@ -10,9 +10,7 @@ import { MappedPaginatedRegistrationDto } from '@121-service/src/registration/dt
 
 import { Dto } from '~/utils/dto-type';
 
-// TODO: AB#30152 This type should be refactored to use Dto121Service
 export type Registration = Dto<MappedPaginatedRegistrationDto>;
-// TODO: AB#30152 This type should be refactored to use Dto121Service
 export type FindAllRegistrationsResult = Dto<FindAllRegistrationsResultDto>;
 
 // The discriminated union type doesn't play well with our Dto utility type, so we need to define the Activity type manually
@@ -92,7 +90,6 @@ class IntersolveVisaWalletDto {
   public cards: IntersolveVisaCardDto[];
 }
 
-// TODO: AB#30152 This type should be refactored to use Dto121Service
 export type WalletWithCards = Dto<IntersolveVisaWalletDto>;
 
 export type SendMessageData =

--- a/interfaces/Portalicious/src/app/domains/role/role.model.ts
+++ b/interfaces/Portalicious/src/app/domains/role/role.model.ts
@@ -1,5 +1,5 @@
-import { UserController } from '@121-service/src/user/user.controller';
+import { UserRoleResponseDTO } from '@121-service/src/user/dto/userrole-response.dto';
 
-import { Dto121Service } from '~/utils/dto-type';
+import { Dto } from '~/utils/dto-type';
 
-export type Role = Dto121Service<UserController['getUserRoles']>[0];
+export type Role = Dto<UserRoleResponseDTO>;

--- a/interfaces/Portalicious/src/app/domains/user/user.model.ts
+++ b/interfaces/Portalicious/src/app/domains/user/user.model.ts
@@ -1,5 +1,5 @@
-import { UserController } from '@121-service/src/user/user.controller';
+import { UserRO } from '@121-service/src/user/user.interface';
 
-import { Dto121Service } from '~/utils/dto-type';
+import { Dto } from '~/utils/dto-type';
 
-export type User = Dto121Service<UserController['login']>['user'];
+export type User = Dto<UserRO>['user'];

--- a/interfaces/Portalicious/src/app/services/paginate-query.service.ts
+++ b/interfaces/Portalicious/src/app/services/paginate-query.service.ts
@@ -12,8 +12,6 @@ export enum FilterOperator {
   IN = '$in',
 }
 
-// TODO: AB#30152 This type could be taken from the 121-service
-// export type PaginateQuery = Parameters<RegistrationsController['findAll']>[0];
 export interface PaginateQuery {
   page?: number;
   limit?: number;

--- a/interfaces/Portalicious/src/app/utils/dto-type.ts
+++ b/interfaces/Portalicious/src/app/utils/dto-type.ts
@@ -59,17 +59,3 @@ export type Dto<T> =
       : Dtoified<T>;
 
 export type Serializable<T> = { serialize(): Dto<T> } & T;
-
-/**
- * CUSTOM DTO UTILITY TYPES
- */
-
-// This type is used to convert a DTO type from a service controller method,
-// to a type that can be used in the frontend.
-// Example:
-// import { UserController } from '@121-service/src/user/user.controller';
-// import { Dto121Service } from '../shared/utils/dto-type';
-// export type User = Dto121Service<UserController['login']>['user'];
-export type Dto121Service<
-  ServiceControllerMethod extends (...args: any) => any,
-> = Dto<Awaited<ReturnType<ServiceControllerMethod>>>;

--- a/services/121-service/src/health/dto/get-version.dto.ts
+++ b/services/121-service/src/health/dto/get-version.dto.ts
@@ -1,0 +1,6 @@
+export interface GetVersionDto {
+  schemaVersion: number;
+  label: string;
+  message: string;
+  isError?: boolean;
+}

--- a/services/121-service/src/health/health.controller.ts
+++ b/services/121-service/src/health/health.controller.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/terminus';
 
 import { APP_VERSION } from '@121-service/src/config';
+import { GetVersionDto } from '@121-service/src/health/dto/get-version.dto';
 
 @ApiTags('instance')
 // TODO: REFACTOR: rename to instance
@@ -29,12 +30,7 @@ export class HealthController {
 
   @ApiOperation({ summary: 'Get version of instance' })
   @Get('version')
-  public version(): {
-    schemaVersion: number;
-    label: string;
-    message: string;
-    isError?: boolean;
-  } {
+  public version(): GetVersionDto {
     const version = APP_VERSION;
 
     // See: https://shields.io/endpoint

--- a/services/121-service/src/payments/dto/get-payments.dto.ts
+++ b/services/121-service/src/payments/dto/get-payments.dto.ts
@@ -1,0 +1,4 @@
+export interface GetPaymentsDto {
+  payment: number;
+  paymentDate: Date | string;
+}

--- a/services/121-service/src/payments/payments.controller.ts
+++ b/services/121-service/src/payments/payments.controller.ts
@@ -32,6 +32,7 @@ import { AuthenticatedUserGuard } from '@121-service/src/guards/authenticated-us
 import { CreatePaymentDto } from '@121-service/src/payments/dto/create-payment.dto';
 import { FspInstructions } from '@121-service/src/payments/dto/fsp-instructions.dto';
 import { GetPaymentAggregationDto } from '@121-service/src/payments/dto/get-payment-aggregration.dto';
+import { GetPaymentsDto } from '@121-service/src/payments/dto/get-payments.dto';
 import { ProgramPaymentsStatusDto } from '@121-service/src/payments/dto/program-payments-status.dto';
 import { RetryPaymentDto } from '@121-service/src/payments/dto/retry-payment.dto';
 import { PaymentsService } from '@121-service/src/payments/payments.service';
@@ -69,14 +70,7 @@ export class PaymentsController {
   public async getPayments(
     @Param('programId', ParseIntPipe)
     programId: number,
-  ): Promise<
-    {
-      payment: number;
-      paymentDate: Date | string;
-      amount: number;
-    }[]
-  > {
-    // TODO: REFACTOR: use a DTO to define stable structure of result body
+  ): Promise<GetPaymentsDto[]> {
     return await this.paymentsService.getPayments(programId);
   }
 

--- a/services/121-service/src/payments/payments.service.ts
+++ b/services/121-service/src/payments/payments.service.ts
@@ -119,15 +119,12 @@ export class PaymentsService {
     };
   }
 
-  public async getPayments(programId: number): Promise<
-    {
+  public async getPayments(programId: number) {
+    // Use unscoped repository, as you might not be able to select the correct payment in the portal otherwise
+    const payments: {
       payment: number;
       paymentDate: Date | string;
-      amount: number;
-    }[]
-  > {
-    // Use unscoped repository, as you might not be able to select the correct payment in the portal otherwise
-    const payments = await this.transactionRepository
+    }[] = await this.transactionRepository
       .createQueryBuilder('transaction')
       .select('payment')
       .addSelect('MIN(transaction.created)', 'paymentDate')


### PR DESCRIPTION
[AB#31183](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/31183)

The issues we are having on feature branches are related to the use of Dto121Service, where we import directly from the controllers, and end up (for reasons unbeknownst to me) in a situation where TS can't resolve these kinds of imports:

```bash
~/git/121-platform/interfaces/Portalicious ➜ npm run typecheck

> typecheck
> npx tsc --noEmit

../../services/121-service/src/registration/repositories/registration-scoped.repository.ts:14:45 - error TS2307: Cannot find module 'typeorm/query-builder/QueryPartialEntity' or its corresponding type declarations.

14 import { type QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../../services/121-service/src/scoped.repository.ts:16:40 - error TS2307: Cannot find module 'typeorm/query-builder/QueryPartialEntity' or its corresponding type declarations.

16 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Found 2 errors in 2 files.
```

I've decided to remove Dto121Service for now, and consistently rely only on dtos, enums, and entities from the 121-service. These seem to have less issues becuase the dependencies in those files don't trigger these weird warnings.

We can figure out how to introduce it when we pick up [AB#30152](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/30152)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
