### PR TITLE
feat: Reduce churn of Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,12 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
 
   - package-ecosystem: npm
     directory: '/services/121-service'
     schedule:
-      interval: weekly
+      interval: monthly
       day: tuesday
     open-pull-requests-limit: 5
     versioning-strategy: increase
@@ -38,7 +38,7 @@ updates:
   - package-ecosystem: npm
     directory: '/services/mock-service'
     schedule:
-      interval: weekly
+      interval: monthly
       day: tuesday
     open-pull-requests-limit: 5
     versioning-strategy: increase
@@ -113,7 +113,7 @@ updates:
   - package-ecosystem: npm
     directory: '/interfaces/Portalicious'
     schedule:
-      interval: weekly
+      interval: monthly
       day: tuesday
     open-pull-requests-limit: 5
     versioning-strategy: increase
@@ -137,7 +137,7 @@ updates:
   - package-ecosystem: npm
     directory: '/e2e'
     schedule:
-      interval: weekly
+      interval: monthly
       day: tuesday
     open-pull-requests-limit: 5
     versioning-strategy: increase
@@ -153,7 +153,7 @@ updates:
   - package-ecosystem: npm
     directory: '/k6'
     schedule:
-      interval: weekly
+      interval: monthly
       day: tuesday
     open-pull-requests-limit: 5
     versioning-strategy: increase


### PR DESCRIPTION
[AB#31229](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/31229) / [AB#31508](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/31508)

As to reduce the noise in the PRs-list and to reduce the load on the automated-tests-queue, we can reduce the interval of Dependabot checking our dependencies a bit.

This will result in some PRs to check at least every-other-sprint; Instead of 2-times-per-sprint.

We can still trigger checks manually by reopening a Dependabot-PR, or by just running `npm outdated` in some of our sub-folders etc.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
