### PR TITLE
fix: ignore empty scoring objects

### DIFF
--- a/interfaces/Portal/src/app/program/program-people-affected/program-people-affected.component.ts
+++ b/interfaces/Portal/src/app/program/program-people-affected/program-people-affected.component.ts
@@ -623,7 +623,10 @@ export class ProgramPeopleAffectedComponent implements OnDestroy {
     let show = false;
     if (this.program?.programQuestions) {
       for (const question of this.program.programQuestions) {
-        if (question['scoring']) {
+        if (
+          question['scoring'] &&
+          Object.keys(question['scoring']).length > 0
+        ) {
           show = true;
           break;
         }


### PR DESCRIPTION
[AB#31513](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/31513) <!--- Replace this with a reference to a devops issue -->

## Describe your changes

Sanne reported that the inclusion score column is always visible. Not sure where/when the bug originated from. This fix ignores the empty scoring objects.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
