### PR TITLE
fix: mock message should fail without phonenumber

### DIFF
--- a/services/mock-service/src/twilio/twilio.service.ts
+++ b/services/mock-service/src/twilio/twilio.service.ts
@@ -85,6 +85,7 @@ export class TwilioService {
     // 1. First loop through different error rseponses and return early
     if (
       !twilioMessagesCreateDto.To ||
+      twilioMessagesCreateDto.To === 'not available' || // this relates to 'to' being set to 'not available' in the sms.service > send Sms()
       twilioMessagesCreateDto.To.includes(MockPhoneNumbers.FailGeneric)
     ) {
       response.status = TwilioStatus.failed;


### PR DESCRIPTION
[AB#31500](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/31500)

## Describe your changes

Let's mock send message fail when no phonenumber again.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
