### PR TITLE
portalicious: consistent "esc" behaviour on dialogs

### DIFF
--- a/interfaces/Portalicious/src/app/components/confirmation-dialog/confirmation-dialog.component.html
+++ b/interfaces/Portalicious/src/app/components/confirmation-dialog/confirmation-dialog.component.html
@@ -1,6 +1,6 @@
 <p-confirmDialog
   #confirmDialog
-  [closeOnEscape]="true"
+  [closeOnEscape]="false"
   [dismissableMask]="true"
   class="[&_.p-dialog-content]:max-w-[632px]"
 >

--- a/interfaces/Portalicious/src/app/pages/project-registration-activity-log/components/activity-log-voucher-dialog/activity-log-voucher-dialog.component.html
+++ b/interfaces/Portalicious/src/app/pages/project-registration-activity-log/components/activity-log-voucher-dialog/activity-log-voucher-dialog.component.html
@@ -10,6 +10,7 @@
   [header]="dialogHeader()"
   [modal]="true"
   [dismissableMask]="true"
+  [closeOnEscape]="false"
   [(visible)]="dialogVisible"
   [style]="{ width: '70rem' }"
 >

--- a/interfaces/Portalicious/src/app/pages/project-registrations/components/change-status-dialog/change-status-dialog.component.html
+++ b/interfaces/Portalicious/src/app/pages/project-registrations/components/change-status-dialog/change-status-dialog.component.html
@@ -1,6 +1,6 @@
 <p-dialog
   #dialog
-  closeOnEscape
+  [closeOnEscape]="false"
   styleClass="md:min-w-[46rem]"
   [(visible)]="dialogVisible"
   [modal]="true"
@@ -189,6 +189,7 @@
   [(visible)]="dryRunFailureDialogVisible"
   [modal]="true"
   [dismissableMask]="true"
+  [closeOnEscape]="false"
 >
   <ng-template pTemplate="header">
     <h3 class="text-red-700">

--- a/interfaces/Portalicious/src/app/pages/project-registrations/components/import-registrations/import-registrations.component.html
+++ b/interfaces/Portalicious/src/app/pages/project-registrations/components/import-registrations/import-registrations.component.html
@@ -10,6 +10,7 @@
 <p-dialog
   [modal]="true"
   [dismissableMask]="true"
+  [closeOnEscape]="false"
   [(visible)]="dialogVisible"
   styleClass="max-w-[46rem]"
 >

--- a/interfaces/Portalicious/src/app/pages/project-registrations/components/send-message-dialog/send-message-dialog.component.html
+++ b/interfaces/Portalicious/src/app/pages/project-registrations/components/send-message-dialog/send-message-dialog.component.html
@@ -4,6 +4,7 @@
   [(visible)]="dialogVisible"
   [modal]="true"
   [dismissableMask]="true"
+  [closeOnEscape]="false"
 >
   <ng-template pTemplate="header">
     <h3>


### PR DESCRIPTION
[AB#31449](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/31449)

Given that sometimes we don't want `esc` to close dialogs, this makes it consistent for all.

I couldn't find a way to set this "globally" for all components - without wrapping the primeng component but IMHO that is overkill for a single attribute.

It would've been nice to enforce this via eslint, but it depnds on this proposal: https://github.com/angular-eslint/angular-eslint/discussions/1800

I tried doing it with the html eslint plugin, but I don't think that can co-exist with the angular-eslint plugin.

For now we'll have to track this manually I suppose.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
