### PR TITLE
feat: refactor FSPInstructions and add payment status endpoint

### DIFF
--- a/interfaces/Portal/src/app/program/export-fsp-instructions/export-fsp-instructions.component.ts
+++ b/interfaces/Portal/src/app/program/export-fsp-instructions/export-fsp-instructions.component.ts
@@ -1,4 +1,3 @@
-import { ExportFileType } from '@121-service/src/payments/dto/fsp-instructions.dto';
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { AlertController } from '@ionic/angular';
 import { TranslateService } from '@ngx-translate/core';
@@ -9,7 +8,6 @@ import { ActionType } from '../../models/actions.model';
 import { ErrorHandlerService } from '../../services/error-handler.service';
 import { LatestActionService } from '../../services/latest-action.service';
 import { actionResult } from '../../shared/action-result';
-import { downloadAsCsv } from '../../shared/array-to-csv';
 import { arrayToXlsx as downloadAsXlsx } from '../../shared/array-to-xlsx';
 
 @Component({
@@ -119,12 +117,7 @@ export class ExportFspInstructionsComponent implements OnChanges, OnInit {
           }
           const exportFileName = `payment#${this.payment}-fsp-instructions`;
 
-          if (res.fileType === ExportFileType.csv) {
-            downloadAsCsv(res.data, exportFileName);
-          }
-          if (res.fileType === ExportFileType.excel) {
-            downloadAsXlsx(res.data, exportFileName);
-          }
+          downloadAsXlsx(res.data, exportFileName);
 
           this.updateSubHeader();
         },

--- a/services/121-service/src/payments/dto/fsp-instructions.dto.ts
+++ b/services/121-service/src/payments/dto/fsp-instructions.dto.ts
@@ -1,13 +1,5 @@
 import { ExcelFspInstructions } from '@121-service/src/payments/fsp-integration/excel/dto/excel-fsp-instructions.dto';
 
-export type CsvInstructions = ExcelFspInstructions[];
-
 export class FspInstructions {
-  public data?: CsvInstructions | string;
-  public fileType?: ExportFileType;
-}
-
-export enum ExportFileType {
-  csv = 'csv',
-  excel = 'excel',
+  public data: ExcelFspInstructions[];
 }

--- a/services/121-service/src/payments/payments.controller.ts
+++ b/services/121-service/src/payments/payments.controller.ts
@@ -89,6 +89,31 @@ export class PaymentsController {
     return await this.paymentsService.getProgramPaymentsStatus(programId);
   }
 
+  @AuthenticatedUser({ permissions: [PermissionEnum.PaymentREAD] })
+  @ApiOperation({ summary: 'Get status of a specific payment.' })
+  @ApiParam({ name: 'programId', required: true, type: 'integer' })
+  @ApiParam({
+    name: 'payment',
+    required: true,
+    type: 'integer',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Status of the specific payment',
+  })
+  @Get('programs/:programId/payments/:payment/status')
+  public async getPaymentStatusForPayment(
+    @Param('programId', ParseIntPipe)
+    programId: number,
+    @Param('payment', ParseIntPipe)
+    payment: number,
+  ): Promise<ProgramPaymentsStatusDto> {
+    return await this.paymentsService.getProgramPaymentsStatus(
+      programId,
+      payment,
+    );
+  }
+
   @AuthenticatedUser({ permissions: [PermissionEnum.PaymentTransactionREAD] })
   @ApiOperation({ summary: '[SCOPED] Get payment aggregate results' })
   @ApiParam({ name: 'programId', required: true, type: 'integer' })


### PR DESCRIPTION
[AB#31608](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/31608) [AB#31609](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/31609)

While working on Portalicious, I realised there was logic in the Portal and the backend that isn't being used anywhere.

- removes unused ExportFileType
- removes unnecessary CsvInstructions
- updates the Portal and service code accordingly

Also adding a new endpoint that makes polling for this specific information easier

- adds programs/:programId/payments/:payment/status

I combined the above into a single PR because they are both small changes, and they are already sharded off of #6154, but I can split into two separate PRs if necessary / useful.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
