### PR TITLE
fix: dont return user in 401 azure-ad.strategy

### DIFF
--- a/services/121-service/src/strategies/azure-ad.strategy.ts
+++ b/services/121-service/src/strategies/azure-ad.strategy.ts
@@ -109,7 +109,7 @@ export class AzureAdStrategy
       }
     } catch (error: Error | unknown) {
       throw new HttpException(
-        { message: `User with username ${username} not found`, username },
+        { message: 'Unknown user account or authentication failed.' },
         HttpStatus.UNAUTHORIZED,
       );
     }


### PR DESCRIPTION
[AB#31489](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/31489) <!--- Replace this with a reference to a devops issue -->

## Describe your changes

I've checked the Portal code if it depends on this specific string. It doesn't, so I'm assuming this is fine to change.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
