### PR TITLE
portalicious: retry transfers

### DIFF
--- a/interfaces/Portalicious/src/app/components/registrations-table/registrations-table.component.html
+++ b/interfaces/Portalicious/src/app/components/registrations-table/registrations-table.component.html
@@ -8,7 +8,6 @@
   [serverSideTotalRecords]="totalRegistrations()"
   (onUpdatePaginateQuery)="paginateQuery.set($event)"
   [enableSelection]="true"
-  (onUpdateSelection)="tableSelection.set($event)"
   [contextMenuItems]="contextMenuItems()"
   (onUpdateContextMenuItem)="contextMenuRegistration.set($event)"
   [enableColumnManagement]="true"

--- a/interfaces/Portalicious/src/app/domains/metric/metric.api.service.ts
+++ b/interfaces/Portalicious/src/app/domains/metric/metric.api.service.ts
@@ -2,6 +2,7 @@ import { HttpParamsOptions } from '@angular/common/http';
 import { Injectable, Signal } from '@angular/core';
 
 import { ExportType } from '@121-service/src/metrics/enum/export-type.enum';
+import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 
 import { DomainApiService } from '~/domains/domain-api.service';
 import {
@@ -49,11 +50,21 @@ export class MetricApiService extends DomainApiService {
     projectId: Signal<number>;
     payment: Signal<number>;
   }) {
-    return this.generateQueryOptions<{ data: PaymentMetricDetails[] }>({
+    return this.generateQueryOptions<
+      { data: PaymentMetricDetails[] },
+      PaymentMetricDetails[]
+    >({
       path: [...BASE_ENDPOINT(projectId), 'export-list', ExportType.payment],
       params: {
         minPayment: payment,
         maxPayment: payment,
+      },
+      processResponse: (response) => {
+        // TODO: AB#32158 - Should we filter out deleted transactions here?
+        return response.data.filter(
+          (transaction) =>
+            transaction.registrationStatus !== RegistrationStatusEnum.deleted,
+        );
       },
     });
   }

--- a/interfaces/Portalicious/src/app/domains/metric/metric.model.ts
+++ b/interfaces/Portalicious/src/app/domains/metric/metric.model.ts
@@ -1,6 +1,7 @@
 import { FinancialServiceProviders } from '@121-service/src/financial-service-providers/enum/financial-service-provider-name.enum';
 import { ProgramStats } from '@121-service/src/metrics/dto/program-stats.dto';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
+import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 
 import { Dto } from '~/utils/dto-type';
 
@@ -23,4 +24,5 @@ export interface PaymentMetricDetails {
   amount: number;
   financialserviceprovider: FinancialServiceProviders;
   fullName: string;
+  registrationStatus: RegistrationStatusEnum;
 }

--- a/interfaces/Portalicious/src/app/domains/payment/payment.api.service.ts
+++ b/interfaces/Portalicious/src/app/domains/payment/payment.api.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Signal } from '@angular/core';
 
 import { CreatePaymentDto } from '@121-service/src/payments/dto/create-payment.dto';
 import { FspInstructions } from '@121-service/src/payments/dto/fsp-instructions.dto';
+import { RetryPaymentDto } from '@121-service/src/payments/dto/retry-payment.dto';
 import { BulkActionResultPaymentDto } from '@121-service/src/registration/dto/bulk-action-result.dto';
 
 import { DomainApiService } from '~/domains/domain-api.service';
@@ -69,6 +70,31 @@ export class PaymentApiService extends DomainApiService {
         ),
         dryRun,
       },
+    });
+  }
+
+  retryFailedTransfers({
+    projectId,
+    paymentId,
+    referenceIds,
+  }: {
+    projectId: Signal<number>;
+    paymentId: number;
+    referenceIds: string[];
+  }) {
+    const body: Dto<RetryPaymentDto> = {
+      payment: paymentId,
+      referenceIds: {
+        referenceIds,
+      },
+    };
+
+    return this.httpWrapperService.perform121ServiceRequest<
+      Dto<BulkActionResultPaymentDto>
+    >({
+      method: 'PATCH',
+      endpoint: this.pathToQueryKey([...BASE_ENDPOINT(projectId)]).join('/'),
+      body,
     });
   }
 

--- a/interfaces/Portalicious/src/app/pages/project-payment/components/retry-transfers-dialog/retry-transfers-dialog.component.html
+++ b/interfaces/Portalicious/src/app/pages/project-payment/components/retry-transfers-dialog/retry-transfers-dialog.component.html
@@ -1,0 +1,16 @@
+<app-confirmation-dialog
+  #retryTransfersConfirmationDialog
+  header="Retry failed transfers"
+  i18n-header="@@retry-failed-transfers"
+  headerIcon="pi pi-refresh"
+  proceedLabel="Retry transfers"
+  i18n-proceedLabel
+  [mutation]="retryFailedTransfersMutation"
+  [mutationData]="referenceIdsForRetryTransfers()"
+>
+  <p i18n>
+    You are about to retry
+    {{ referenceIdsForRetryTransfers().length }} payment(s). The transfer status
+    will change to Pending until received by the registration.
+  </p>
+</app-confirmation-dialog>

--- a/interfaces/Portalicious/src/app/pages/project-payment/components/retry-transfers-dialog/retry-transfers-dialog.component.ts
+++ b/interfaces/Portalicious/src/app/pages/project-payment/components/retry-transfers-dialog/retry-transfers-dialog.component.ts
@@ -1,0 +1,90 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  input,
+  signal,
+  ViewChild,
+} from '@angular/core';
+
+import { injectMutation } from '@tanstack/angular-query-experimental';
+
+import { ConfirmationDialogComponent } from '~/components/confirmation-dialog/confirmation-dialog.component';
+import { QueryTableComponent } from '~/components/query-table/query-table.component';
+import { PaymentMetricDetails } from '~/domains/metric/metric.model';
+import { PaymentApiService } from '~/domains/payment/payment.api.service';
+import { ToastService } from '~/services/toast.service';
+
+@Component({
+  selector: 'app-retry-transfers-dialog',
+  standalone: true,
+  imports: [ConfirmationDialogComponent],
+  templateUrl: './retry-transfers-dialog.component.html',
+  styles: ``,
+  providers: [ToastService],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RetryTransfersDialogComponent {
+  readonly projectId = input.required<number>();
+  readonly paymentId = input.required<number>();
+
+  private paymentApiService = inject(PaymentApiService);
+  private toastService = inject(ToastService);
+
+  referenceIdsForRetryTransfers = signal<string[]>([]);
+
+  @ViewChild('retryTransfersConfirmationDialog')
+  private retryTransfersConfirmationDialog: ConfirmationDialogComponent;
+
+  retryFailedTransfersMutation = injectMutation(() => ({
+    mutationFn: (referenceIds: string[]) =>
+      this.paymentApiService.retryFailedTransfers({
+        projectId: this.projectId,
+        paymentId: this.paymentId(),
+        referenceIds,
+      }),
+    onSuccess: () =>
+      this.paymentApiService.invalidateCache(this.projectId, this.paymentId),
+    onError: (error) => {
+      this.toastService.showToast({
+        severity: 'error',
+        detail: error.message,
+      });
+    },
+  }));
+
+  public retryFailedTransfers({
+    table,
+    triggeredFromContextMenu,
+    contextMenuItem,
+  }: {
+    table: QueryTableComponent<PaymentMetricDetails, never>;
+    triggeredFromContextMenu: boolean;
+    contextMenuItem?: PaymentMetricDetails;
+  }) {
+    const actionData = table.getActionData({
+      triggeredFromContextMenu,
+      contextMenuItem,
+      fieldForFilter: 'referenceId',
+      noSelectionToastMessage: $localize`:@@no-registrations-selected:Select one or more registrations and try again.`,
+    });
+
+    if (!actionData) {
+      return;
+    }
+
+    const selection = actionData.selection;
+
+    if (!Array.isArray(selection) || selection.length === 0) {
+      this.toastService.showGenericError(); // Should never happen
+      return;
+    }
+
+    const referenceIds = selection.map(
+      (transaction) => transaction.referenceId,
+    );
+
+    this.referenceIdsForRetryTransfers.set(referenceIds);
+    this.retryTransfersConfirmationDialog.askForConfirmation();
+  }
+}

--- a/interfaces/Portalicious/src/app/pages/project-payment/project-payment.page.html
+++ b/interfaces/Portalicious/src/app/pages/project-payment/project-payment.page.html
@@ -23,7 +23,7 @@
       <app-metric-tile
         class="grid-in-metric1"
         [pending]="paymentStatus.isPending() || transactions.isPending()"
-        [metricValue]="transactions.data()?.data?.length"
+        [metricValue]="transactions.data()?.length"
         metricLabel="Transfers sent"
         i18n-metricLabel
         chipLabel="In progress"
@@ -35,7 +35,7 @@
       <app-metric-tile
         class="grid-in-metric1"
         [pending]="false"
-        [metricValue]="transactions.data()?.data?.length"
+        [metricValue]="transactions.data()?.length"
         metricLabel="Registrations included"
         i18n-metricLabel
       />
@@ -49,6 +49,8 @@
       [chipLabel]="successfulPaymentsAmount()"
       chipIcon="pi pi-check-circle"
       chipVariant="green"
+      metricTooltip="The total payment amount is calculated by summing up the transfer values of each included registration added to the payment."
+      i18n-metricTooltip
     />
 
     @let paymentDetails = this.payment.data();
@@ -74,13 +76,15 @@
 
     <p-card class="grid-in-table">
       <app-query-table
-        [items]="transactions.data()?.data ?? []"
+        #table
+        [items]="transactions.data() ?? []"
         [isPending]="transactions.isPending()"
         [columns]="columns()"
         [localStorageKey]="localStorageKey()"
         [enableColumnManagement]="true"
         [contextMenuItems]="contextMenuItems()"
         (onUpdateContextMenuItem)="contextMenuSelection.set($event)"
+        [enableSelection]="true"
         [globalFilterFields]="[
           'id',
           'fullName',
@@ -100,7 +104,7 @@
           @if (canRetryTransfers()) {
             <p-button
               label="Retry failed transfers"
-              i18n-label
+              i18n-label="@@retry-failed-transfers"
               rounded
               outlined
               icon="pi pi-refresh"
@@ -112,3 +116,9 @@
     </p-card>
   </div>
 </app-page-layout>
+
+<app-retry-transfers-dialog
+  #retryTransfersDialog
+  [projectId]="projectId()"
+  [paymentId]="paymentId()"
+/>

--- a/interfaces/Portalicious/src/app/services/paginate-query.service.ts
+++ b/interfaces/Portalicious/src/app/services/paginate-query.service.ts
@@ -24,6 +24,7 @@ export interface PaginateQuery {
 export interface ActionDataWithPaginateQuery<T> {
   query: PaginateQuery;
   count: number;
+  selection: QueryTableSelectionEvent<T>;
   selectAll: boolean;
   previewItem: T;
 }
@@ -229,6 +230,7 @@ export class PaginateQueryService {
           limit: undefined,
         },
         count: totalCount,
+        selection,
         selectAll: true,
         previewItem: previewItemForSelectAll,
       };
@@ -241,6 +243,7 @@ export class PaginateQueryService {
         },
       },
       count: selection.length,
+      selection,
       selectAll: false,
       previewItem: selection[0],
     };

--- a/interfaces/Portalicious/src/locale/messages.nl.xlf
+++ b/interfaces/Portalicious/src/locale/messages.nl.xlf
@@ -1584,6 +1584,18 @@
         <source>Registrations included</source>
         <target state="new">Registrations included</target>
       </trans-unit>
+      <trans-unit id="retry-failed-transfers" datatype="html">
+        <source>Retry failed transfers</source>
+        <target state="new">Retry failed transfers</target>
+      </trans-unit>
+      <trans-unit id="3971565293367630153" datatype="html">
+        <source>Retry transfers</source>
+        <target state="new">Retry transfers</target>
+      </trans-unit>
+      <trans-unit id="7113199794780283377" datatype="html">
+        <source>You are about to retry <x equiv-text="{{ referenceIdsForRetryTransfers().length }}" id="INTERPOLATION"/> payment(s). The transfer status will change to Pending until received by the registration.</source>
+        <target state="new">You are about to retry <x equiv-text="{{ referenceIdsForRetryTransfers().length }}" id="INTERPOLATION"/> payment(s). The transfer status will change to Pending until received by the registration.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/interfaces/Portalicious/src/locale/messages.xlf
+++ b/interfaces/Portalicious/src/locale/messages.xlf
@@ -1190,6 +1190,15 @@
       <trans-unit id="4585448172507601196" datatype="html">
         <source>Registrations included</source>
       </trans-unit>
+      <trans-unit id="3971565293367630153" datatype="html">
+        <source>Retry transfers</source>
+      </trans-unit>
+      <trans-unit id="7113199794780283377" datatype="html">
+        <source>You are about to retry <x equiv-text="{{ referenceIdsForRetryTransfers().length }}" id="INTERPOLATION"/> payment(s). The transfer status will change to Pending until received by the registration.</source>
+      </trans-unit>
+      <trans-unit id="retry-failed-transfers" datatype="html">
+        <source>Retry failed transfers</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
[AB#31728](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/31728)

To implement the retry transfers feature, I had to do a few other things: 

- Remove the deleted registrations from the payment details table. TBD whether this will be permanent.
- Refactor query-table to include "getActionData" (which was previously only used on the registrations table)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
