### PR TITLE
portalicious: fix navigation post create-payment

### DIFF
--- a/interfaces/Portalicious/src/app/pages/project-payments/components/create-payment/create-payment.component.ts
+++ b/interfaces/Portalicious/src/app/pages/project-payments/components/create-payment/create-payment.component.ts
@@ -177,7 +177,14 @@ export class CreatePaymentComponent {
         return;
       }
 
-      this.dialogVisible.set(false);
+      // Do not set dialogVisible to false here, otherwise the addCurrentStepToQueryParams
+      // effect will be triggered, blocking the user from navigating away
+      // this.dialogVisible.set(false);
+
+      await this.paymentApiService.invalidateCache(
+        this.projectId,
+        signal(paymentId),
+      );
 
       await this.router.navigate([
         '/',
@@ -190,8 +197,6 @@ export class CreatePaymentComponent {
       this.toastService.showToast({
         detail: $localize`Payment created.`,
       });
-
-      void this.paymentApiService.invalidateCache(this.projectId);
     },
     onError: (error) => {
       this.toastService.showToast({


### PR DESCRIPTION
[AB#32308](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/32308)

After creating a new payment, the user should be redirected to the payment page. This was not working.

This does not address the originally reported bug in the linked bug item, but that is because the bug is _actually_ expected behaviour.

PS I also disabled the very annoying HTTP request logs

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
