### PR TITLE
Chore.throw error in mock

### DIFF
--- a/services/mock-service/src/fsp-integration/intersolve-visa/intersolve-visa.mock.service.ts
+++ b/services/mock-service/src/fsp-integration/intersolve-visa/intersolve-visa.mock.service.ts
@@ -711,6 +711,24 @@ export class IntersolveVisaMockService {
         },
       };
     }
+    // Return error if the amount is not an integer
+    // If we post a non interger to the real API, it will return a similair error
+    if (!Number.isInteger(amount)) {
+      return {
+        status: HttpStatus.BAD_REQUEST,
+        statusText: 'Bad Request',
+        data: {
+          success: false,
+          errors: [
+            {
+              code: 'INVALID_PARAMETERS',
+              description:
+                'The JSON value could not be converted to System.Int32',
+            },
+          ],
+        },
+      };
+    }
 
     return {
       status: HttpStatus.OK,

--- a/services/mock-service/src/fsp-integration/intersolve-visa/intersolve-visa.mock.service.ts
+++ b/services/mock-service/src/fsp-integration/intersolve-visa/intersolve-visa.mock.service.ts
@@ -712,7 +712,7 @@ export class IntersolveVisaMockService {
       };
     }
     // Return error if the amount is not an integer
-    // If we post a non interger to the real API, it will return a similair error
+    // If we post a non integer to the real API, it will return a similar error
     if (!Number.isInteger(amount)) {
       return {
         status: HttpStatus.BAD_REQUEST,


### PR DESCRIPTION
[AB#32398](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/32398) <!--- Replace this with a reference to a devops issue -->

## Describe your changes

First merge in #6335 

- We had an error on main where tried to post this transfer amount to intersolve 1626.0000000000002
  - This was caused by a [floating point error](https://ellenaua.medium.com/floating-point-errors-in-javascript-node-js-21aadd897bf8)
  - To fix this I added a math.round() to ensure that we always post an integer
- I want to prevent that we reintroduce this error again in the future
- So I added to our mock service that it throws an error if you call it using a non-integer
  -  Since floating point errors do not appear in a consistent way it's not straight forward to create an automated test for this
  - But I think if we re-introduce this error again it will appear in our k6 tests this way
- I also do not want to spend too much time on this..
- What do you think @reviewer 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines
