### PR TITLE
portalicious: fix PR description job

### DIFF
--- a/.github/workflows/deploy_test_portalicious.yml
+++ b/.github/workflows/deploy_test_portalicious.yml
@@ -94,7 +94,7 @@ jobs:
           echo "Preview: <${{ steps.deploy_to_aswa.outputs.static_web_app_url }}>" >> $GITHUB_STEP_SUMMARY
 
   add_staging_comment:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     needs: test
     runs-on: ubuntu-latest
     permissions:
@@ -106,6 +106,7 @@ jobs:
           content: ${{ needs.test.outputs.preview_url }}
           regex: '<!-- start deployment url -->.*?<!-- end deployment url -->'
           regexFlags: ims
+          appendContentOnMatchOnly: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
   close_pull_request_job:


### PR DESCRIPTION
[AB#32463](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/32463)

After merging #6349 I got an error that the job failed on main. I had misconfigured the extra step to _also_ run on pushes on main.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6350.westeurope.5.azurestaticapps.net
https://lively-river-04adce503-6350.westeurope.5.azurestaticapps.net