### PR TITLE
refactor: get balance via fspconfigid of registration AB#32518

### DIFF
--- a/services/121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-voucher.service.ts
+++ b/services/121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-voucher.service.ts
@@ -563,28 +563,25 @@ export class IntersolveVoucherService
     programId: number,
   ): Promise<number> {
     const voucher = await this.getVoucher(referenceId, payment, programId);
-    return await this.getAndStoreBalance(voucher, programId);
+    return await this.getAndStoreBalance(voucher, programId, referenceId);
   }
 
   private async getAndStoreBalance(
     intersolveVoucher: IntersolveVoucherEntity,
     programId: number,
+    referenceId: string,
   ): Promise<number> {
-    const financialServiceProviderName = intersolveVoucher.whatsappPhoneNumber
-      ? FinancialServiceProviders.intersolveVoucherWhatsapp
-      : FinancialServiceProviders.intersolveVoucherPaper;
-    const programFinancialServiceProviderConfiguration =
-      await this.programFspConfigurationRepository.getByProgramIdAndFinancialServiceProviderName(
-        { programId, financialServiceProviderName },
-      );
+    const registration = await this.registrationScopedRepository.findOneOrFail({
+      where: { referenceId: Equal(referenceId) },
+    });
 
     const credentials =
       await this.programFspConfigurationRepository.getUsernamePasswordProperties(
-        programFinancialServiceProviderConfiguration[0].id, // TODO: take the 0-th element, because the above method returns an array of entities as e.g. multiple Excel FSPs can be defined per program. For Intersolve-voucher this is not currently the case, so this is needed and works, but should be improved.
+        registration.programFinancialServiceProviderConfigurationId,
       );
     if (!credentials?.username || !credentials?.password) {
       throw new Error(
-        `Could not retrieve configuration of FSP: "${financialServiceProviderName}", for program: ${programId}. Please contact the 121 platform team.`,
+        `Could not retrieve configuration of FSP Intersolve Voucher for program: ${programId}. Please contact the 121 platform team.`,
       );
     }
 
@@ -686,7 +683,11 @@ export class IntersolveVoucherService
           })
           .getMany();
       for await (const voucher of previouslyUnusedVouchers) {
-        await this.getAndStoreBalance(voucher, programId);
+        await this.getAndStoreBalance(
+          voucher,
+          programId,
+          voucher.image[0].registration.referenceId,
+        );
       }
       id += 1000;
     }
@@ -870,7 +871,11 @@ export class IntersolveVoucherService
         const vouchersToUpdate = await q.getMany();
 
         for await (const voucher of vouchersToUpdate) {
-          await this.getAndStoreBalance(voucher, programId);
+          await this.getAndStoreBalance(
+            voucher,
+            programId,
+            voucher.image[0].registration.referenceId,
+          );
         }
         id += 1000;
       }

--- a/services/121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-voucher.service.ts
+++ b/services/121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-voucher.service.ts
@@ -563,12 +563,9 @@ export class IntersolveVoucherService
     programId: number,
   ): Promise<number> {
     const voucher = await this.getVoucher(referenceId, payment, programId);
-    const registration = await this.registrationScopedRepository.findOneOrFail({
-      where: { referenceId: Equal(referenceId) },
-    });
     const credentials =
-      await this.programFspConfigurationRepository.getUsernamePasswordProperties(
-        registration.programFinancialServiceProviderConfigurationId,
+      await this.programFspConfigurationRepository.getUsernamePasswordPropertiesByVoucherId(
+        voucher.id,
       );
     return await this.getAndStoreBalance(voucher, programId, credentials);
   }
@@ -681,12 +678,9 @@ export class IntersolveVoucherService
             programId,
           })
           .getMany();
-      const programFspConfigId =
-        previouslyUnusedVouchers[0].image[0].registration
-          .programFinancialServiceProviderConfigurationId;
       const credentials =
-        await this.programFspConfigurationRepository.getUsernamePasswordProperties(
-          programFspConfigId,
+        await this.programFspConfigurationRepository.getUsernamePasswordPropertiesByVoucherId(
+          previouslyUnusedVouchers[0].id,
         );
       for await (const voucher of previouslyUnusedVouchers) {
         await this.getAndStoreBalance(voucher, programId, credentials);
@@ -871,12 +865,9 @@ export class IntersolveVoucherService
           });
 
         const vouchersToUpdate = await q.getMany();
-        const programFspConfigId =
-          vouchersToUpdate[0].image[0].registration
-            .programFinancialServiceProviderConfigurationId;
         const credentials =
-          await this.programFspConfigurationRepository.getUsernamePasswordProperties(
-            programFspConfigId,
+          await this.programFspConfigurationRepository.getUsernamePasswordPropertiesByVoucherId(
+            vouchersToUpdate[0].id,
           );
         for await (const voucher of vouchersToUpdate) {
           await this.getAndStoreBalance(voucher, programId, credentials);

--- a/services/121-service/src/program-financial-service-provider-configurations/program-financial-service-provider-configurations.repository.ts
+++ b/services/121-service/src/program-financial-service-provider-configurations/program-financial-service-provider-configurations.repository.ts
@@ -80,7 +80,7 @@ export class ProgramFinancialServiceProviderConfigurationRepository extends Repo
       })
       .andWhere('voucher.payment = transactions.payment') // TODO: REFACTOR: this filter is needed as it is not taken care of by the joins above. Better to refactor the entity relations here, probably together with whole Voucher refactor. Also look at module responsiblity then.
       .select('configuration.id AS id')
-      .getRawOne();
+      .getRawOne(); // use getRawOne (+select) instead of getOne for performance reasons
 
     if (!programFspConfig) {
       throw new Error(

--- a/services/121-service/src/program-financial-service-provider-configurations/program-financial-service-provider-configurations.repository.ts
+++ b/services/121-service/src/program-financial-service-provider-configurations/program-financial-service-provider-configurations.repository.ts
@@ -71,14 +71,16 @@ export class ProgramFinancialServiceProviderConfigurationRepository extends Repo
     const programFspConfig = await this.baseRepository
       .createQueryBuilder('configuration')
       .leftJoin('configuration.transactions', 'transactions')
-      .leftJoin('transactions.registration', 'registration')
+      .innerJoin('transactions.latestTransaction', 'latestTransaction')
+      .leftJoin('latestTransaction.registration', 'registration')
       .leftJoin('registration.images', 'images')
       .leftJoin('images.voucher', 'voucher')
       .where('voucher.id = :intersolveVoucherId', {
         intersolveVoucherId,
       })
-      .andWhere('voucher.payment = transactions.payment') // REFACTOR: this filter is needed, as it is not taken care of by the joins above. Better refactor the entity relations here.
-      .getOne(); // the above can still return multiple transaction (steps/attempts) for the same voucher, but they will always have the same fspConfig, so take one
+      .andWhere('voucher.payment = transactions.payment') // TODO: REFACTOR: this filter is needed as it is not taken care of by the joins above. Better to refactor the entity relations here, probably together with whole Voucher refactor. Also look at module responsiblity then.
+      .select('configuration.id AS id')
+      .getRawOne();
 
     if (!programFspConfig) {
       throw new Error(

--- a/services/121-service/test/helpers/intersolve-voucher.helper.ts
+++ b/services/121-service/test/helpers/intersolve-voucher.helper.ts
@@ -1,0 +1,46 @@
+import * as request from 'supertest';
+
+import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
+import { waitFor } from '@121-service/src/utils/waitFor.helper';
+import { getTransactions } from '@121-service/test/helpers/program.helper';
+import { getServer } from '@121-service/test/helpers/utility.helper';
+
+export async function getTransactionsIntersolveVoucher(
+  programId: number,
+  payment: number,
+  referenceId: string,
+  accessToken: string,
+): Promise<any[]> {
+  let getTransactionsBody: any[] = [];
+  let attempts = 0;
+  while (attempts <= 10) {
+    attempts++;
+    getTransactionsBody = (
+      await getTransactions(programId, payment, referenceId, accessToken)
+    ).body;
+
+    if (
+      getTransactionsBody.length > 0 &&
+      getTransactionsBody[0].status === TransactionStatusEnum.success
+    ) {
+      break;
+    }
+
+    await waitFor(2_000);
+  }
+  return getTransactionsBody;
+}
+
+export async function getVoucherBalance(
+  programId: number,
+  payment: number,
+  referenceId: string | null,
+  accessToken: string,
+): Promise<request.Response> {
+  return await getServer()
+    .get(
+      `/programs/${programId}/financial-service-providers/intersolve-voucher/vouchers/balance`,
+    )
+    .set('Cookie', [accessToken])
+    .query({ payment, referenceId });
+}

--- a/services/121-service/test/payment/do-payment-fsp-voucher.test.ts
+++ b/services/121-service/test/payment/do-payment-fsp-voucher.test.ts
@@ -5,11 +5,10 @@ import { TransactionStatusEnum } from '@121-service/src/payments/transactions/en
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { SeedScript } from '@121-service/src/scripts/seed-script.enum';
 import { LanguageEnum } from '@121-service/src/shared/enum/language.enums';
-import { waitFor } from '@121-service/src/utils/waitFor.helper';
 import { adminOwnerDto } from '@121-service/test/fixtures/user-owner';
+import { getTransactionsIntersolveVoucher } from '@121-service/test/helpers/intersolve-voucher.helper';
 import {
   doPayment,
-  getTransactions,
   waitForMessagesToComplete,
 } from '@121-service/test/helpers/program.helper';
 import {
@@ -67,30 +66,14 @@ describe('Do payment to 1 PA', () => {
         accessToken,
       );
 
+      const getTransactionsBody = await getTransactionsIntersolveVoucher(
+        programId,
+        payment,
+        registrationAh.referenceId,
+        accessToken,
+      );
+
       // Assert
-      let getTransactionsBody: any[] = [];
-      let attempts = 0;
-      while (attempts <= 10) {
-        attempts++;
-        getTransactionsBody = (
-          await getTransactions(
-            programId,
-            payment,
-            registrationAh.referenceId,
-            accessToken,
-          )
-        ).body;
-
-        if (
-          getTransactionsBody.length > 0 &&
-          getTransactionsBody[0].status === TransactionStatusEnum.success
-        ) {
-          break;
-        }
-
-        await waitFor(2_000);
-      }
-
       expect(doPaymentResponse.status).toBe(HttpStatus.ACCEPTED);
       expect(doPaymentResponse.body.applicableCount).toBe(
         paymentReferenceIds.length,

--- a/services/121-service/test/voucher/get-balance.test.ts
+++ b/services/121-service/test/voucher/get-balance.test.ts
@@ -1,0 +1,75 @@
+import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
+import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
+import { SeedScript } from '@121-service/src/scripts/seed-script.enum';
+import { waitFor } from '@121-service/src/utils/waitFor.helper';
+import {
+  getTransactionsIntersolveVoucher,
+  getVoucherBalance,
+} from '@121-service/test/helpers/intersolve-voucher.helper';
+import { doPayment } from '@121-service/test/helpers/program.helper';
+import {
+  awaitChangePaStatus,
+  importRegistrations,
+} from '@121-service/test/helpers/registration.helper';
+import {
+  getAccessToken,
+  resetDB,
+} from '@121-service/test/helpers/utility.helper';
+import {
+  programIdPV,
+  registrationPV5,
+} from '@121-service/test/registrations/pagination/pagination-data';
+
+describe('Get Intersolve voucher balance', () => {
+  let accessToken: string;
+
+  const payment = 1;
+  const amount = 22;
+
+  beforeEach(async () => {
+    await waitFor(1_000);
+    await resetDB(SeedScript.nlrcMultiple);
+    accessToken = await getAccessToken();
+    await waitFor(3_000);
+  });
+
+  it('should succesfully get balance', async () => {
+    // Arrange
+    await importRegistrations(programIdPV, [registrationPV5], accessToken);
+    await awaitChangePaStatus(
+      programIdPV,
+      [registrationPV5.referenceId],
+      RegistrationStatusEnum.included,
+      accessToken,
+    );
+    const paymentReferenceIds = [registrationPV5.referenceId];
+    await doPayment(
+      programIdPV,
+      payment,
+      amount,
+      paymentReferenceIds,
+      accessToken,
+    );
+
+    // make sure to wait for the transaction to be completed
+    const getTransactionsBody = await getTransactionsIntersolveVoucher(
+      programIdPV,
+      payment,
+      registrationPV5.referenceId,
+      accessToken,
+    );
+
+    // Act
+    const getVoucherBalanceResponse = await getVoucherBalance(
+      programIdPV,
+      payment,
+      registrationPV5.referenceId,
+      accessToken,
+    );
+
+    // Assert
+    expect(getTransactionsBody[0].status).toBe(TransactionStatusEnum.success);
+    expect(getVoucherBalanceResponse.status).toBe(200);
+    expect(getVoucherBalanceResponse.text).toBe('12.5'); // This is the number our mock gives back
+  });
+});


### PR DESCRIPTION
[AB#32518](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/32518)

## Describe your changes

3 commits build on each other
1. first got fspConfigId via registration (also in both bulk methods)
2. then optimized by not repeating queries in bulk methods unnecessarily
3. then realized, getting fspConfigId via registration may be incorrect if FSP changed along the way, so instead got via transaction.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
