### PR TITLE
portalicious: open registration in new tab

### DIFF
--- a/e2e/portalicious/pages/RegistrationsPage.ts
+++ b/e2e/portalicious/pages/RegistrationsPage.ts
@@ -266,7 +266,7 @@ class RegistrationsPage extends BasePage {
     await this.table.tableRows.nth(row).click({ button: 'right' });
     await this.page.getByLabel(action).click();
 
-    if (action !== 'Message') {
+    if (action !== 'Message' && action !== 'Open in new tab') {
       await this.page.getByRole('button', { name: 'Approve' }).click();
     }
   }

--- a/e2e/portalicious/tests/ViewAndManagePeopleAffected/OpenRegistrationInNewTab.spec.ts
+++ b/e2e/portalicious/tests/ViewAndManagePeopleAffected/OpenRegistrationInNewTab.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+
+import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
+import { seedIncludedRegistrations } from '@121-service/test/helpers/registration.helper';
+import {
+  getAccessToken,
+  resetDB,
+} from '@121-service/test/helpers/utility.helper';
+import {
+  programIdPV,
+  registrationsPV,
+} from '@121-service/test/registrations/pagination/pagination-data';
+
+import BasePage from '@121-e2e/portalicious/pages/BasePage';
+import LoginPage from '@121-e2e/portalicious/pages/LoginPage';
+import RegistrationsPage from '@121-e2e/portalicious/pages/RegistrationsPage';
+
+test.beforeEach(async ({ page }) => {
+  await resetDB(SeedScript.nlrcMultiple);
+
+  const accessToken = await getAccessToken();
+  await seedIncludedRegistrations(registrationsPV, programIdPV, accessToken);
+
+  // Login
+  const loginPage = new LoginPage(page);
+  await page.goto('/');
+  await loginPage.login(
+    process.env.USERCONFIG_121_SERVICE_EMAIL_ADMIN,
+    process.env.USERCONFIG_121_SERVICE_PASSWORD_ADMIN,
+  );
+});
+
+const chosenRegistration = registrationsPV[registrationsPV.length - 1];
+
+test('Open registration in new tab and verify new tab', async ({ page }) => {
+  const basePage = new BasePage(page);
+  const registrations = new RegistrationsPage(page);
+
+  const projectTitle = 'NLRC Direct Digital Aid Program (PV)';
+
+  await test.step('Select program', async () => {
+    await basePage.selectProgram(projectTitle);
+  });
+
+  await test.step('Open registration in new tab', async () => {
+    // Count all registrations
+    const allRegistrationsCount = registrationsPV.length;
+
+    // Wait for page to load
+    await registrations.waitForLoaded(allRegistrationsCount);
+
+    // Get the first registration's full name from the table
+    const registrationName = chosenRegistration.fullName;
+
+    await registrations.performActionOnRegistrationByName({
+      registrationName,
+      action: 'Open in new tab',
+    });
+  });
+
+  await test.step('Verify new tab is opened', async () => {
+    await page.waitForTimeout(2000); //waitForNavigation and waitForLoadState do not work in this case
+
+    const pages = await page.context().pages();
+
+    await expect(pages).toHaveLength(2);
+
+    expect(await pages[1].title()).toEqual(
+      'Activity log | Registration details | 121 Portal',
+    );
+
+    const pageHeader = await pages[1].$('h1');
+
+    expect(await pageHeader?.textContent()).toContain(
+      chosenRegistration.fullName,
+    );
+  });
+});

--- a/interfaces/Portalicious/src/app/pages/project-payment/project-payment.page.ts
+++ b/interfaces/Portalicious/src/app/pages/project-payment/project-payment.page.ts
@@ -51,6 +51,7 @@ import { SinglePaymentExportComponent } from '~/pages/project-payment/components
 import { AuthService } from '~/services/auth.service';
 import { ToastService } from '~/services/toast.service';
 import { TranslatableStringService } from '~/services/translatable-string.service';
+import { getOriginUrl } from '~/utils/url-helper';
 
 export interface TransactionsTableCellContext {
   projectId: Signal<string>;
@@ -276,7 +277,7 @@ export class ProjectPaymentPageComponent {
               }),
             ),
           );
-          window.open(url, '_blank');
+          window.open(getOriginUrl() + url, '_blank');
         },
       },
       {

--- a/interfaces/Portalicious/src/app/pages/project-registrations/project-registrations.page.ts
+++ b/interfaces/Portalicious/src/app/pages/project-registrations/project-registrations.page.ts
@@ -27,6 +27,7 @@ import { ImportRegistrationsComponent } from '~/pages/project-registrations/comp
 import { SendMessageDialogComponent } from '~/pages/project-registrations/components/send-message-dialog/send-message-dialog.component';
 import { AuthService } from '~/services/auth.service';
 import { ToastService } from '~/services/toast.service';
+import { getOriginUrl } from '~/utils/url-helper';
 
 @Component({
   selector: 'app-project-registrations',
@@ -183,7 +184,7 @@ export class ProjectRegistrationsPageComponent {
               }),
             ),
           );
-          window.open(url, '_blank');
+          window.open(getOriginUrl() + url, '_blank');
         },
       },
       {


### PR DESCRIPTION
[AB#32871](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/32871)

This is broken on test/production:
<img width="776" alt="image" src="https://github.com/user-attachments/assets/184b8541-a003-406e-a5dc-ac9bc4e9b01b" />

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6411.westeurope.5.azurestaticapps.net
