### PR TITLE
Fix allow empty string values for nonRequired dropdows

### DIFF
--- a/services/121-service/src/registration/validators/registrations-input-validator.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.ts
@@ -260,7 +260,7 @@ export class RegistrationsInputValidator {
             if (row[att.name] === undefined) {
               return;
             }
-            if (row[att.name] == null) {
+            if (row[att.name] == null || row[att.name] === '') {
               validatedRegistrationInput.data[att.name] = null;
               return;
             }

--- a/services/121-service/test/helpers/assert.helper.ts
+++ b/services/121-service/test/helpers/assert.helper.ts
@@ -1,7 +1,6 @@
 import { MessageTemplateEntity } from '@121-service/src/notifications/message-template/message-template.entity';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { RegistrationEntity } from '@121-service/src/registration/registration.entity';
-import { LocalizedString } from '@121-service/src/shared/types/localized-string.type';
 
 export function processMessagePlaceholders(
   messageTemplates: MessageTemplateEntity[],
@@ -20,30 +19,4 @@ export function processMessagePlaceholders(
   );
 
   return processedTemplate;
-}
-
-export function assertRegistrationBulkUpdate(
-  patchData: Record<
-    string,
-    string | undefined | boolean | number | null | LocalizedString
-  >,
-  updatedRegistration: Record<
-    string,
-    string | undefined | boolean | number | null
-  >,
-  originalRegistration: Record<
-    string,
-    string | undefined | boolean | number | null
-  >,
-): void {
-  for (const key in patchData) {
-    expect(JSON.stringify(updatedRegistration[key])).toBe(
-      JSON.stringify(patchData[key]),
-    );
-  }
-  for (const key in originalRegistration) {
-    if (patchData[key] === undefined && key !== 'name') {
-      expect(updatedRegistration[key]).toStrictEqual(originalRegistration[key]);
-    }
-  }
 }

--- a/services/121-service/test/registrations/bulk-update-registration.test.ts
+++ b/services/121-service/test/registrations/bulk-update-registration.test.ts
@@ -1,6 +1,5 @@
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { waitFor } from '@121-service/src/utils/waitFor.helper';
-import { assertRegistrationBulkUpdate } from '@121-service/test/helpers/assert.helper';
 import { patchProgram } from '@121-service/test/helpers/program.helper';
 import {
   bulkUpdateRegistrationsCSV,
@@ -11,6 +10,22 @@ import {
   getAccessToken,
   resetDB,
 } from '@121-service/test/helpers/utility.helper';
+
+function filterUnchangedProperties(
+  originalData: Record<string, unknown>,
+  patchData: Record<string, unknown>,
+): Record<string, any> {
+  const unchangedProperties: Record<string, unknown> = {};
+
+  for (const key of Object.keys(originalData)) {
+    // registration.name is a special case as it is a derived property so it cannot be patched
+    if (!(key in patchData) && key !== 'name') {
+      unchangedProperties[key] = originalData[key];
+    }
+  }
+
+  return unchangedProperties;
+}
 
 describe('Update attribute of multiple PAs via Bulk update', () => {
   const programIdOcw = 3;
@@ -34,7 +49,7 @@ describe('Update attribute of multiple PAs via Bulk update', () => {
       fullName: 'updated name1',
       addressStreet: 'newStreet1',
       addressHouseNumber: '2',
-      addressHouseNumberAddition: '',
+      addressHouseNumberAddition: null,
       preferredLanguage: 'ar',
       paymentAmountMultiplier: 2,
       whatsappPhoneNumber: '14155238880',
@@ -96,16 +111,25 @@ describe('Update attribute of multiple PAs via Bulk update', () => {
     const pa2AfterPatch = searchByReferenceIdAfterPatchPa2.body.data[0];
 
     // Assert
-    assertRegistrationBulkUpdate(
-      registrationDataThatWillChangePa1,
-      pa1AfterPatch,
+    // Explicit assertions for pa1 using patch data
+    expect(pa1AfterPatch).toMatchObject(registrationDataThatWillChangePa1);
+
+    // Explicit assertions for pa2 using patch data
+    expect(pa2AfterPatch).toMatchObject(registrationDataThatWillChangePa2);
+
+    // Ensure unchanged fields remain the same
+    const dataThatStaysTheSamePa1 = filterUnchangedProperties(
       pa1BeforePatch,
+      registrationDataThatWillChangePa1,
     );
-    assertRegistrationBulkUpdate(
-      registrationDataThatWillChangePa2,
-      pa2AfterPatch,
+
+    const dataThatStaysTheSamePa2 = filterUnchangedProperties(
       pa2BeforePatch,
+      registrationDataThatWillChangePa2,
     );
+
+    expect(pa1AfterPatch).toMatchObject(dataThatStaysTheSamePa1);
+    expect(pa2AfterPatch).toMatchObject(dataThatStaysTheSamePa2);
   });
 
   it('Should bulk update chosen FSP and validate changed records', async () => {
@@ -173,16 +197,25 @@ describe('Update attribute of multiple PAs via Bulk update', () => {
     const pa2AfterPatch = searchByReferenceIdAfterPatchPa2.body.data[0];
 
     // Assert
-    assertRegistrationBulkUpdate(
-      registrationDataThatWillChangePa1,
-      pa1AfterPatch,
+    // Explicit assertions for pa1 using patch data
+    expect(pa1AfterPatch).toMatchObject(registrationDataThatWillChangePa1);
+
+    // Explicit assertions for pa2 using patch data
+    expect(pa2AfterPatch).toMatchObject(registrationDataThatWillChangePa2);
+
+    // Ensure unchanged fields remain the same
+    const dataThatStaysTheSamePa1 = filterUnchangedProperties(
       pa1BeforePatch,
+      registrationDataThatWillChangePa1,
     );
-    assertRegistrationBulkUpdate(
-      registrationDataThatWillChangePa2,
-      pa2AfterPatch,
+
+    const dataThatStaysTheSamePa2 = filterUnchangedProperties(
       pa2BeforePatch,
+      registrationDataThatWillChangePa2,
     );
+
+    expect(pa1AfterPatch).toMatchObject(dataThatStaysTheSamePa1);
+    expect(pa2AfterPatch).toMatchObject(dataThatStaysTheSamePa2);
   });
 
   it('Should bulk update if phoneNumber column is empty and program is configured as allowing empty phone number', async () => {
@@ -190,7 +223,7 @@ describe('Update attribute of multiple PAs via Bulk update', () => {
       fullName: 'updated name1',
       addressStreet: 'newStreet1',
       addressHouseNumber: '2',
-      addressHouseNumberAddition: '',
+      addressHouseNumberAddition: null,
       preferredLanguage: 'ar',
       paymentAmountMultiplier: 2,
       phoneNumber: '14155238880',
@@ -255,15 +288,24 @@ describe('Update attribute of multiple PAs via Bulk update', () => {
     const pa2AfterPatch = searchByReferenceIdAfterPatchPa2.body.data[0];
 
     // Assert
-    assertRegistrationBulkUpdate(
-      registrationDataThatWillChangePa1,
-      pa1AfterPatch,
+    // Explicit assertions for pa1 using patch data
+    expect(pa1AfterPatch).toMatchObject(registrationDataThatWillChangePa1);
+
+    // Explicit assertions for pa2 using patch data
+    expect(pa2AfterPatch).toMatchObject(registrationDataThatWillChangePa2);
+
+    const dataThatStaysTheSamePa1 = filterUnchangedProperties(
       pa1BeforePatch,
+      registrationDataThatWillChangePa1,
     );
-    assertRegistrationBulkUpdate(
-      registrationDataThatWillChangePa2,
-      pa2AfterPatch,
+
+    const dataThatStaysTheSamePa2 = filterUnchangedProperties(
       pa2BeforePatch,
+      registrationDataThatWillChangePa2,
     );
+
+    // Ensure unchanged fields remain the same
+    expect(pa1AfterPatch).toMatchObject(dataThatStaysTheSamePa1);
+    expect(pa2AfterPatch).toMatchObject(dataThatStaysTheSamePa2);
   });
 });


### PR DESCRIPTION
[AB#33084](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/33084) [AB#33082](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/33082) <!--- Replace this with a reference to a devops issue -->

## Describe your changes

See github comments in the code 


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
