### PR TITLE
portalicious: registrations are not deselected after performing an action

### DIFF
--- a/e2e/portalicious/components/TableComponent.ts
+++ b/e2e/portalicious/components/TableComponent.ts
@@ -202,6 +202,17 @@ class TableComponent {
     textFromColumn = await this.getTextArrayFromColumn(columnIndex);
     expect(textFromColumn).toEqual(descendingExpected);
   }
+
+  async validateSelectionCount(expectedCount: number) {
+    if (expectedCount === 0) {
+      await expect(this.page.getByText('selected)')).not.toBeVisible();
+      return;
+    }
+
+    await expect(
+      this.page.getByText(`(${expectedCount} selected)`),
+    ).toBeVisible();
+  }
 }
 
 export default TableComponent;

--- a/e2e/portalicious/components/TableComponent.ts
+++ b/e2e/portalicious/components/TableComponent.ts
@@ -205,7 +205,7 @@ class TableComponent {
 
   async validateSelectionCount(expectedCount: number) {
     if (expectedCount === 0) {
-      await expect(this.page.getByText('selected)')).not.toBeVisible();
+      await expect(this.page.getByText('selected')).not.toBeVisible();
       return;
     }
 

--- a/e2e/portalicious/pages/RegistrationsPage.ts
+++ b/e2e/portalicious/pages/RegistrationsPage.ts
@@ -162,6 +162,7 @@ class RegistrationsPage extends BasePage {
 
   async sendMessage() {
     await this.page.getByRole('button', { name: 'Send message' }).click();
+    await this.table.validateSelectionCount(0);
   }
 
   async getFirstRegistrationNameFromTable() {
@@ -260,6 +261,7 @@ class RegistrationsPage extends BasePage {
       const rowCheckbox = await this.table.getCell(i, 0);
       await rowCheckbox.click();
     }
+    await this.table.validateSelectionCount(selectionCount);
   }
 
   async performActionWithRightClick(action: string, row = 0) {

--- a/interfaces/Portalicious/src/app/pages/project-registrations/project-registrations.page.html
+++ b/interfaces/Portalicious/src/app/pages/project-registrations/project-registrations.page.html
@@ -106,11 +106,11 @@
 <app-send-message-dialog
   #sendMessageDialog
   [projectId]="projectId()"
-  (onActionComplete)="onActionComplete()"
+  (actionComplete)="onActionComplete()"
 />
 
 <app-change-status-dialog
   #changeStatusDialog
   [projectId]="projectId()"
-  (onActionComplete)="onActionComplete()"
+  (actionComplete)="onActionComplete()"
 />


### PR DESCRIPTION
[AB#33151](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/33151)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6438.westeurope.5.azurestaticapps.net
