### PR TITLE
portalicious: fix change status "cancel" button

### DIFF
--- a/interfaces/Portalicious/src/app/pages/project-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.html
+++ b/interfaces/Portalicious/src/app/pages/project-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.html
@@ -57,6 +57,6 @@
 } @else {
   <app-change-status-submit-buttons
     [isMutating]="isMutating()"
-    (cancelClick)="previewData.set(undefined)"
+    (cancelClick)="cancelClick()"
   />
 }

--- a/interfaces/Portalicious/src/app/pages/project-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.html
+++ b/interfaces/Portalicious/src/app/pages/project-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.html
@@ -1,9 +1,10 @@
 <div class="mt-6 flex justify-end space-x-2">
   <p-button
-    label="Go back"
-    i18n-label="@@generic-go-back"
+    label="Cancel"
+    i18n-label="@@generic-cancel"
     outlined
     rounded
+    severity="contrast"
     [disabled]="isMutating()"
     (click)="cancelClick.emit()"
   />


### PR DESCRIPTION
[AB#33160](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/33160)

I checked out the original commit where these modals were added: 49d028e4a4e38c008c2d9c6ca82fd48939fca6ff

And it seems this was always broken. I remember that, when we built this originally, me and Peter went through several refactors. I suppose this slipped through the cracks at the time.

The fix is mainly the `(cancelClick)="cancelClick()"` change. The other change is a design fix related to the same buttons.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6448.westeurope.5.azurestaticapps.net
