### PR TITLE
portalicious: fix validation on change password page

### DIFF
--- a/interfaces/Portalicious/src/app/services/auth/strategies/basic-auth/basic-auth.change-password.component.html
+++ b/interfaces/Portalicious/src/app/services/auth/strategies/basic-auth/basic-auth.change-password.component.html
@@ -28,6 +28,7 @@
       autocomplete="new-password"
       [toggleMask]="true"
       [feedback]="false"
+      [class.ng-invalid]="formGroup.hasError('newPasswordIsNotDifferent')"
     />
   </app-form-field-wrapper>
   <app-form-field-wrapper
@@ -39,6 +40,7 @@
       formControlName="confirmPassword"
       [toggleMask]="true"
       [feedback]="false"
+      [class.ng-invalid]="formGroup.hasError('confirmPasswordDoesNotMatch')"
     />
   </app-form-field-wrapper>
 </app-form-default>


### PR DESCRIPTION
[AB#30007](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/30007)

I had a look at a lot of forms, and I think with the theming efforts the consistency around validation is there now.

This was the only scenario that was a bit funky, but it's also the only page where we're using ValidatorFn (because of multi-field validation) so it needs this extra nudge.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6449.westeurope.5.azurestaticapps.net
