### PR TITLE
portalicious: default numeric attributes to zero in registrations table

### DIFF
--- a/interfaces/Portalicious/src/app/services/registrations-table-column.service.ts
+++ b/interfaces/Portalicious/src/app/services/registrations-table-column.service.ts
@@ -183,6 +183,13 @@ export class RegistrationsTableColumnService {
               defaultHidden: !DEFAULT_VISIBLE_FIELDS_SORTED.includes(
                 column.field,
               ),
+              getCellText:
+                column.type === QueryTableColumnType.NUMERIC
+                  ? (registration: Registration) =>
+                      registration[column.field]
+                        ? (registration[column.field] as string)
+                        : '0' // default numeric values to 0
+                  : undefined,
             }))
             .sort((a, b) => {
               const aIndex = DEFAULT_VISIBLE_FIELDS_SORTED.indexOf(a.field);


### PR DESCRIPTION
[AB#33036](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/33036)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6451.westeurope.5.azurestaticapps.net
