### PR TITLE
Fix Portalicious: show export payment report button

### DIFF
--- a/interfaces/Portalicious/src/app/domains/project/project.helper.ts
+++ b/interfaces/Portalicious/src/app/domains/project/project.helper.ts
@@ -20,10 +20,13 @@ export function projectHasPhysicalCardSupport(project?: Project) {
 }
 
 export function projectHasFspWithExportFileIntegration(project?: Project) {
-  return project?.programFinancialServiceProviderConfigurations.some(
-    (fsp) =>
-      getFinancialServiceProviderSettingByName(fsp.financialServiceProviderName)
-        ?.integrationType === FinancialServiceProviderIntegrationType.csv,
+  return (
+    project?.programFinancialServiceProviderConfigurations.some(
+      (fsp) =>
+        getFinancialServiceProviderSettingByName(
+          fsp.financialServiceProviderName,
+        )?.integrationType === FinancialServiceProviderIntegrationType.csv,
+    ) ?? false
   );
 }
 

--- a/interfaces/Portalicious/src/app/pages/project-payment/components/single-payment-export/single-payment-export.component.ts
+++ b/interfaces/Portalicious/src/app/pages/project-payment/components/single-payment-export/single-payment-export.component.ts
@@ -35,6 +35,7 @@ import { ToastService } from '~/services/toast.service';
 export class SinglePaymentExportComponent {
   projectId = input.required<string>();
   paymentId = input.required<string>();
+  hasExportFileIntegration = input<boolean | undefined>(false);
 
   private authService = inject(AuthService);
   private exportService = inject(ExportService);
@@ -96,7 +97,8 @@ export class SinglePaymentExportComponent {
   exportOptions = computed<MenuItem[]>(() => [
     {
       label: this.fspPaymentListLabel(),
-      visible: this.canExportPaymentInstructions(),
+      visible:
+        this.canExportPaymentInstructions() && this.hasExportFileIntegration(),
       command: () => {
         this.exportFspPaymentListDialog().askForConfirmation();
       },

--- a/interfaces/Portalicious/src/app/pages/project-payment/components/single-payment-export/single-payment-export.component.ts
+++ b/interfaces/Portalicious/src/app/pages/project-payment/components/single-payment-export/single-payment-export.component.ts
@@ -35,7 +35,7 @@ import { ToastService } from '~/services/toast.service';
 export class SinglePaymentExportComponent {
   projectId = input.required<string>();
   paymentId = input.required<string>();
-  hasExportFileIntegration = input<boolean | undefined>(false);
+  hasExportFileIntegration = input<boolean>(false);
 
   private authService = inject(AuthService);
   private exportService = inject(ExportService);

--- a/interfaces/Portalicious/src/app/pages/project-payment/project-payment.page.html
+++ b/interfaces/Portalicious/src/app/pages/project-payment/project-payment.page.html
@@ -15,11 +15,12 @@
         [paymentId]="paymentId()"
         [projectId]="projectId()"
       />
-      <app-single-payment-export
-        [projectId]="projectId()"
-        [paymentId]="paymentId()"
-      />
     }
+    <app-single-payment-export
+      [projectId]="projectId()"
+      [paymentId]="paymentId()"
+      [hasExportFileIntegration]="hasFspWithExportFileIntegration()"
+    />
   </div>
   <div
     class="grid gap-5 grid-areas-project-payment md:grid-cols-project-payment-wide md:grid-areas-project-payment-wide"


### PR DESCRIPTION
[AB#32740](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/32740) <!--- Replace this with a reference to a devops issue -->

## Describe your changes

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6466.westeurope.5.azurestaticapps.net
