### PR TITLE
Set focus on the first form-control, but preventing "too soon" validation-errors

### DIFF
--- a/interfaces/Portalicious/src/app/components/form/form-sidebar.component.html
+++ b/interfaces/Portalicious/src/app/components/form/form-sidebar.component.html
@@ -10,6 +10,7 @@
 >
   <ng-template pTemplate="headless">
     <form
+      #sideBarForm
       class="flex max-h-full min-h-full w-full flex-col overflow-y-auto p-4 pb-20"
       [formGroup]="formGroup()"
       (ngSubmit)="onFormSubmit()"
@@ -17,7 +18,6 @@
       (keydown.meta.enter)="onFormSubmit()"
       pFocusTrap
       [pFocusTrapDisabled]="!visible()"
-      [pAutoFocus]="visible()"
     >
       <div class="flex grow flex-col gap-2">
         <h2 class="mb-5">

--- a/interfaces/Portalicious/src/app/components/form/form-sidebar.component.ts
+++ b/interfaces/Portalicious/src/app/components/form/form-sidebar.component.ts
@@ -1,12 +1,13 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   input,
   model,
+  viewChild,
 } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 
-import { AutoFocusModule } from 'primeng/autofocus';
 import { ButtonModule } from 'primeng/button';
 import { DrawerModule } from 'primeng/drawer';
 import { FocusTrapModule } from 'primeng/focustrap';
@@ -17,7 +18,6 @@ import { FormErrorComponent } from '~/components/form-error/form-error.component
 @Component({
   selector: 'app-form-sidebar',
   imports: [
-    AutoFocusModule,
     ButtonModule,
     ReactiveFormsModule,
     FormErrorComponent,
@@ -34,6 +34,8 @@ export class FormSidebarComponent<
   readonly visible = model<boolean>(false);
   readonly formTitle = input.required<string>();
   readonly modal = model<boolean>(true);
+  readonly sideBarForm =
+    viewChild.required<ElementRef<HTMLFormElement>>('sideBarForm');
 
   triggerElement: HTMLElement | null = null;
 
@@ -46,6 +48,9 @@ export class FormSidebarComponent<
 
   onShow() {
     this.rememberTrigger();
+    const firstInput = this.sideBarForm().nativeElement
+      .elements[0] as HTMLElement;
+    firstInput.focus();
   }
 
   onHide() {

--- a/interfaces/Portalicious/src/app/components/page-layout/components/header/header.component.html
+++ b/interfaces/Portalicious/src/app/components/page-layout/components/header/header.component.html
@@ -48,7 +48,6 @@
   [(visible)]="sidebarVisible"
   [closeOnEscape]="true"
   [showCloseIcon]="false"
-  (onShow)="sideBar.el.nativeElement.querySelector('#menu').focus()"
 >
   <ng-template pTemplate="headless">
     <div


### PR DESCRIPTION

[AB#33223](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/33223)
[AB#33599](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/33599)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6516.westeurope.5.azurestaticapps.net
