### PR TITLE
chore: portalicious CI not failing with broken translations

### DIFF
--- a/.github/workflows/test_interface_portalicious.yml
+++ b/.github/workflows/test_interface_portalicious.yml
@@ -48,3 +48,8 @@ jobs:
       - name: 'Test: Code'
         working-directory: ${{ env.interfacePath }}
         run: 'npm run test:ci'
+
+      - name: 'Check translations'
+        uses: nickcharlton/diff-check@main
+        with:
+          command: cd ${{ env.interfacePath }} && npm run set-env-variables -- env=development && npm run extract-i18n


### PR DESCRIPTION
[AB#33602](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/33602)

In [this PR](https://github.com/global-121/121-platform/pull/6397/files#diff-6bdb3cad870fa068cdf8a3f152c8bb8f3170e8c8921b35e481ca6e42a6bb7a86R1369-R1370) we were able to merge a broken xlf file. This means that then the locale extractor script is broken (and potentially also the download translations flow?).

This shouldn't happen.

I think this broke in this PR https://github.com/global-121/121-platform/pull/6482 and more specifically, [this change](https://github.com/global-121/121-platform/pull/6482/files#diff-e13b3ee3c88f64c4a2ef68d917f7f97731b3f425ebed0cfbf8d08b037bf3ee3dL35-R47).

(Meanwhile the broken xlf file was fixed in https://github.com/global-121/121-platform/pull/6517)

---

[Example of the new CI test failing](https://github.com/global-121/121-platform/actions/runs/13327176895/job/37222928741?pr=6518) before fixing `messages.xlf`.

[Example of the new CI test failing](https://github.com/global-121/121-platform/actions/runs/13326994819/job/37222364140?pr=6518) when there is an unexpected diff in translations (ie. the developer has not run extract-i18n on their machine).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6518.westeurope.5.azurestaticapps.net
