### PR TITLE
fix: registration data cache invalidation

### DIFF
--- a/interfaces/Portalicious/src/app/components/registration-page-layout/components/add-note-form/add-note-form.component.ts
+++ b/interfaces/Portalicious/src/app/components/registration-page-layout/components/add-note-form/add-note-form.component.ts
@@ -90,10 +90,10 @@ export class AddNoteFormComponent {
       this.toastService.showToast({
         detail: $localize`Note successfully added.`,
       });
-      void this.registrationApiService.invalidateCache(
-        this.projectId,
-        this.registrationId,
-      );
+      void this.registrationApiService.invalidateCache({
+        projectId: this.projectId,
+        registration: this.registration.data(),
+      });
       this.formVisible.set(false);
     },
   }));

--- a/interfaces/Portalicious/src/app/domains/registration/registration.api.service.ts
+++ b/interfaces/Portalicious/src/app/domains/registration/registration.api.service.ts
@@ -290,18 +290,28 @@ export class RegistrationApiService extends DomainApiService {
     });
   }
 
-  public invalidateCache(
-    projectId: Signal<number | string>,
-    registrationId?: Signal<number | string>,
-  ): Promise<void> {
+  public async invalidateCache({
+    projectId,
+    registration,
+  }: {
+    projectId: Signal<number | string>;
+    registration?: Registration;
+  }): Promise<void> {
     const path = [...BASE_ENDPOINT(projectId)];
 
-    if (registrationId) {
-      path.push(registrationId);
+    if (!registration) {
+      return this.queryClient.invalidateQueries({
+        queryKey: this.pathToQueryKey(path),
+      });
     }
 
-    return this.queryClient.invalidateQueries({
-      queryKey: this.pathToQueryKey(path),
-    });
+    await Promise.all([
+      this.queryClient.invalidateQueries({
+        queryKey: this.pathToQueryKey([...path, registration.id]),
+      }),
+      this.queryClient.invalidateQueries({
+        queryKey: this.pathToQueryKey([...path, registration.referenceId]),
+      }),
+    ]);
   }
 }

--- a/interfaces/Portalicious/src/app/pages/project-registration-personal-information/components/edit-personal-information/edit-personal-information.component.ts
+++ b/interfaces/Portalicious/src/app/pages/project-registration-personal-information/components/edit-personal-information/edit-personal-information.component.ts
@@ -38,6 +38,7 @@ import { ConfirmationDialogComponent } from '~/components/confirmation-dialog/co
 import { FormFieldWrapperComponent } from '~/components/form-field-wrapper/form-field-wrapper.component';
 import { ProjectApiService } from '~/domains/project/project.api.service';
 import { RegistrationApiService } from '~/domains/registration/registration.api.service';
+import { Registration } from '~/domains/registration/registration.model';
 import { ComponentCanDeactivate } from '~/guards/pending-changes.guard';
 import {
   NormalizedRegistrationAttribute,
@@ -75,7 +76,7 @@ export class EditPersonalInformationComponent
   readonly registrationId = input.required<string>();
   readonly attributeList = input.required<NormalizedRegistrationAttribute[]>();
   readonly cancelEditing = output();
-  readonly registrationUpdated = output();
+  readonly registrationUpdated = output<Registration>();
 
   readonly projectApiService = inject(ProjectApiService);
   readonly registrationApiService = inject(RegistrationApiService);
@@ -175,15 +176,15 @@ export class EditPersonalInformationComponent
         reason,
       });
     },
-    onSuccess: () => {
+    onSuccess: (patchedRegistration) => {
       this.toastService.showToast({
         detail: $localize`Personal information edited successfully.`,
       });
-      void this.registrationApiService.invalidateCache(
-        this.projectId,
-        this.registrationId,
-      );
-      this.registrationUpdated.emit();
+      void this.registrationApiService.invalidateCache({
+        projectId: this.projectId,
+        registration: patchedRegistration,
+      });
+      this.registrationUpdated.emit(patchedRegistration);
     },
   }));
   ngOnInit() {

--- a/interfaces/Portalicious/src/app/pages/project-registration-personal-information/project-registration-personal-information.page.html
+++ b/interfaces/Portalicious/src/app/pages/project-registration-personal-information/project-registration-personal-information.page.html
@@ -27,7 +27,7 @@
           [registrationId]="registrationId()"
           [attributeList]="registrationAttributes.data()"
           (cancelEditing)="isEditing.set(false)"
-          (registrationUpdated)="onRegistrationUpdated()"
+          (registrationUpdated)="onRegistrationUpdated($event)"
         />
       }
     }

--- a/interfaces/Portalicious/src/app/pages/project-registration-personal-information/project-registration-personal-information.page.ts
+++ b/interfaces/Portalicious/src/app/pages/project-registration-personal-information/project-registration-personal-information.page.ts
@@ -22,6 +22,7 @@ import {
 } from '~/components/data-list/data-list.component';
 import { RegistrationPageLayoutComponent } from '~/components/registration-page-layout/registration-page-layout.component';
 import { RegistrationApiService } from '~/domains/registration/registration.api.service';
+import { Registration } from '~/domains/registration/registration.model';
 import { ComponentCanDeactivate } from '~/guards/pending-changes.guard';
 import { EditPersonalInformationComponent } from '~/pages/project-registration-personal-information/components/edit-personal-information/edit-personal-information.component';
 import { AuthService } from '~/services/auth.service';
@@ -121,12 +122,12 @@ export class ProjectRegistrationPersonalInformationPageComponent
     ),
   );
 
-  onRegistrationUpdated() {
+  onRegistrationUpdated(registration: Registration) {
     this.isEditing.set(false);
-    void this.registrationApiService.invalidateCache(
-      this.projectId,
-      this.registrationId,
-    );
+    void this.registrationApiService.invalidateCache({
+      projectId: this.projectId,
+      registration,
+    });
     void this.registrationAttributes.refetch();
   }
 

--- a/interfaces/Portalicious/src/app/pages/project-registrations/components/change-status-dialog/change-status-dialog.component.ts
+++ b/interfaces/Portalicious/src/app/pages/project-registrations/components/change-status-dialog/change-status-dialog.component.ts
@@ -206,11 +206,15 @@ export class ChangeStatusDialogComponent
           showSpinner: true,
         });
         this.actionComplete.emit();
-        void this.registrationApiService.invalidateCache(this.projectId);
+        void this.registrationApiService.invalidateCache({
+          projectId: this.projectId,
+        });
 
         setTimeout(() => {
           // invalidate the cache again after a delay to try and make the status change reflected in the UI
-          void this.registrationApiService.invalidateCache(this.projectId);
+          void this.registrationApiService.invalidateCache({
+            projectId: this.projectId,
+          });
         }, 500);
         return;
       }

--- a/interfaces/Portalicious/src/app/pages/project-registrations/components/import-registrations/import-registrations.component.ts
+++ b/interfaces/Portalicious/src/app/pages/project-registrations/components/import-registrations/import-registrations.component.ts
@@ -68,7 +68,9 @@ export class ImportRegistrationsComponent {
       });
     },
     onSuccess: () => {
-      void this.registrationApiService.invalidateCache(this.projectId);
+      void this.registrationApiService.invalidateCache({
+        projectId: this.projectId,
+      });
       this.dialogVisible.set(false);
       this.toastService.showToast({
         summary: $localize`:@@import-registrations-success:Registration(s) imported successfully.`,


### PR DESCRIPTION
[AB#33731](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/33731)

This makes sure that we invalidate cache for registration queries that rely on referenceId, as well as the queries that rely on registration.id

This was causing issues because the new "getDuplicates" endpoint (implemented in #6522) uses referenceId, and the cache for it was not being invalidated after editing personal information.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6530.westeurope.5.azurestaticapps.net
