### PR TITLE
Refactor move logic to registration action menu service

### DIFF
--- a/interfaces/Portalicious/src/app/domains/registration/registration.model.ts
+++ b/interfaces/Portalicious/src/app/domains/registration/registration.model.ts
@@ -9,6 +9,7 @@ import { IntersolveVisaWalletDto } from '@121-service/src/payments/fsp-integrati
 import { BulkActionResultDto } from '@121-service/src/registration/dto/bulk-action-result.dto';
 import { FindAllRegistrationsResultDto } from '@121-service/src/registration/dto/find-all-registrations-result.dto';
 import { MappedPaginatedRegistrationDto } from '@121-service/src/registration/dto/mapped-paginated-registration.dto';
+import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 
 import { Dto } from '~/utils/dto-type';
 
@@ -39,3 +40,8 @@ export type WalletWithCards = Dto<IntersolveVisaWalletDto>;
 export type SendMessageData =
   | { customMessage: string }
   | { messageTemplateKey: string };
+
+export type RegistrationStatusChangeTarget = Exclude<
+  RegistrationStatusEnum,
+  RegistrationStatusEnum.completed | RegistrationStatusEnum.registered
+>;

--- a/interfaces/Portalicious/src/app/pages/project-registrations/project-registrations.page.ts
+++ b/interfaces/Portalicious/src/app/pages/project-registrations/project-registrations.page.ts
@@ -61,7 +61,7 @@ export class ProjectRegistrationsPageComponent {
   private router = inject(Router);
   private projectApiService = inject(ProjectApiService);
   private toastService = inject(ToastService);
-  private registrationMenuService = inject(RegistrationActionMenuService);
+  readonly registrationMenuService = inject(RegistrationActionMenuService);
 
   readonly registrationsTable =
     viewChild.required<RegistrationsTableComponent>('registrationsTable');
@@ -76,23 +76,18 @@ export class ProjectRegistrationsPageComponent {
 
   project = injectQuery(this.projectApiService.getProject(this.projectId));
 
-  readonly canChangeStatus = computed(() => {
-    const project = this.project.data();
-    if (!project) {
-      return () => false;
-    }
-
-    return (status: RegistrationStatusChangeTarget) =>
-      this.registrationMenuService.canChangeStatus()({
+  readonly canChangeStatus = computed(
+    () => (status: RegistrationStatusChangeTarget) =>
+      this.registrationMenuService.canChangeStatus({
         status,
         projectId: this.projectId(),
-        hasValidation: !!project.validation,
-      });
-  });
+        hasValidation: !!this.project.data()?.validation,
+      }),
+  );
 
   readonly canSendMessage = computed(
     () => () =>
-      this.registrationMenuService.canSendMessage()({
+      this.registrationMenuService.canSendMessage({
         projectId: this.projectId(),
       }),
   );
@@ -157,6 +152,7 @@ export class ProjectRegistrationsPageComponent {
       RegistrationStatusEnum.deleted,
     ),
   ]);
+
   sendMessage({
     triggeredFromContextMenu = false,
   }: {
@@ -201,7 +197,7 @@ export class ProjectRegistrationsPageComponent {
     return this.registrationMenuService.createContextItemForRegistrationStatus({
       status,
       projectId: this.projectId(),
-      hasValidation: this.project.data()?.validation ?? false,
+      hasValidation: !!this.project.data()?.validation,
       command: () => {
         this.changeStatus({
           status,

--- a/interfaces/Portalicious/src/app/pages/project-registrations/project-registrations.page.ts
+++ b/interfaces/Portalicious/src/app/pages/project-registrations/project-registrations.page.ts
@@ -85,11 +85,10 @@ export class ProjectRegistrationsPageComponent {
       }),
   );
 
-  readonly canSendMessage = computed(
-    () => () =>
-      this.registrationMenuService.canSendMessage({
-        projectId: this.projectId(),
-      }),
+  readonly canSendMessage = computed(() =>
+    this.registrationMenuService.canSendMessage({
+      projectId: this.projectId(),
+    }),
   );
   readonly canImport = computed(() =>
     this.authService.hasAllPermissions({
@@ -136,19 +135,22 @@ export class ProjectRegistrationsPageComponent {
         });
       },
     }),
-    this.createContextMenuItemForRegistrationStatus(
+    {
+      separator: true,
+    },
+    this.createContextItemForRegistrationStatusChange(
       RegistrationStatusEnum.validated,
     ),
-    this.createContextMenuItemForRegistrationStatus(
+    this.createContextItemForRegistrationStatusChange(
       RegistrationStatusEnum.included,
     ),
-    this.createContextMenuItemForRegistrationStatus(
+    this.createContextItemForRegistrationStatusChange(
       RegistrationStatusEnum.declined,
     ),
-    this.createContextMenuItemForRegistrationStatus(
+    this.createContextItemForRegistrationStatusChange(
       RegistrationStatusEnum.paused,
     ),
-    this.createContextMenuItemForRegistrationStatus(
+    this.createContextItemForRegistrationStatusChange(
       RegistrationStatusEnum.deleted,
     ),
   ]);
@@ -191,19 +193,21 @@ export class ProjectRegistrationsPageComponent {
     this.registrationsTable().resetSelection();
   }
 
-  private createContextMenuItemForRegistrationStatus(
+  private createContextItemForRegistrationStatusChange(
     status: RegistrationStatusChangeTarget,
   ) {
-    return this.registrationMenuService.createContextItemForRegistrationStatus({
-      status,
-      projectId: this.projectId(),
-      hasValidation: !!this.project.data()?.validation,
-      command: () => {
-        this.changeStatus({
-          status,
-          triggeredFromContextMenu: true,
-        });
+    return this.registrationMenuService.createContextItemForRegistrationStatusChange(
+      {
+        status,
+        projectId: this.projectId(),
+        hasValidation: !!this.project.data()?.validation,
+        command: () => {
+          this.changeStatus({
+            status,
+            triggeredFromContextMenu: true,
+          });
+        },
       },
-    });
+    );
   }
 }

--- a/interfaces/Portalicious/src/app/services/registration-action-menu.service.ts
+++ b/interfaces/Portalicious/src/app/services/registration-action-menu.service.ts
@@ -1,0 +1,95 @@
+import { computed, inject, Injectable } from '@angular/core';
+
+import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
+import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
+
+import {
+  REGISTRATION_STATUS_ICON,
+  REGISTRATION_STATUS_VERB,
+} from '~/domains/registration/registration.helper';
+import { RegistrationStatusChangeTarget } from '~/domains/registration/registration.model';
+import { AuthService } from '~/services/auth.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RegistrationActionMenuService {
+  private readonly authService = inject(AuthService);
+
+  readonly canChangeStatus = computed(
+    () =>
+      ({
+        status,
+        projectId,
+        hasValidation,
+      }: {
+        status: RegistrationStatusChangeTarget;
+        projectId: string;
+        hasValidation: boolean;
+      }) => {
+        if (status === RegistrationStatusEnum.validated && !hasValidation) {
+          return false;
+        }
+
+        const statusToPermissionMap = {
+          [RegistrationStatusEnum.validated]:
+            PermissionEnum.RegistrationStatusMarkAsValidatedUPDATE,
+          [RegistrationStatusEnum.included]:
+            PermissionEnum.RegistrationStatusIncludedUPDATE,
+          [RegistrationStatusEnum.declined]:
+            PermissionEnum.RegistrationStatusMarkAsDeclinedUPDATE,
+          [RegistrationStatusEnum.deleted]: PermissionEnum.RegistrationDELETE,
+          [RegistrationStatusEnum.paused]:
+            PermissionEnum.RegistrationStatusPausedUPDATE,
+        };
+
+        return this.authService.hasPermission({
+          projectId,
+          requiredPermission: statusToPermissionMap[status],
+        });
+      },
+  );
+
+  readonly canSendMessage = computed(
+    () =>
+      ({ projectId }: { projectId: string }) =>
+        this.authService.hasPermission({
+          projectId,
+          requiredPermission: PermissionEnum.RegistrationNotificationCREATE,
+        }),
+  );
+
+  createContextItemForRegistrationStatus({
+    status,
+    projectId,
+    hasValidation,
+    command,
+  }: {
+    status: RegistrationStatusChangeTarget;
+    projectId: string;
+    hasValidation: boolean;
+    command: () => void;
+  }) {
+    return {
+      label: REGISTRATION_STATUS_VERB[status],
+      icon: REGISTRATION_STATUS_ICON[status],
+      visible: this.canChangeStatus()({ status, projectId, hasValidation }),
+      command,
+    };
+  }
+
+  createContextItemForMessage({
+    projectId,
+    command,
+  }: {
+    projectId: string;
+    command: () => void;
+  }) {
+    return {
+      label: $localize`Message`,
+      icon: 'pi pi-envelope',
+      visible: this.canSendMessage()({ projectId }),
+      command,
+    };
+  }
+}

--- a/interfaces/Portalicious/src/app/services/registration-action-menu.service.ts
+++ b/interfaces/Portalicious/src/app/services/registration-action-menu.service.ts
@@ -1,4 +1,4 @@
-import { computed, inject, Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
@@ -16,50 +16,45 @@ import { AuthService } from '~/services/auth.service';
 export class RegistrationActionMenuService {
   private readonly authService = inject(AuthService);
 
-  readonly canChangeStatus = computed(
-    () =>
-      ({
-        status,
-        projectId,
-        hasValidation,
-      }: {
-        status: RegistrationStatusChangeTarget;
-        projectId: string;
-        hasValidation: boolean;
-      }) => {
-        if (status === RegistrationStatusEnum.validated && !hasValidation) {
-          return false;
-        }
+  public canChangeStatus({
+    status,
+    projectId,
+    hasValidation,
+  }: {
+    status: RegistrationStatusChangeTarget;
+    projectId: string;
+    hasValidation: boolean;
+  }): boolean {
+    if (status === RegistrationStatusEnum.validated && !hasValidation) {
+      return false;
+    }
 
-        const statusToPermissionMap = {
-          [RegistrationStatusEnum.validated]:
-            PermissionEnum.RegistrationStatusMarkAsValidatedUPDATE,
-          [RegistrationStatusEnum.included]:
-            PermissionEnum.RegistrationStatusIncludedUPDATE,
-          [RegistrationStatusEnum.declined]:
-            PermissionEnum.RegistrationStatusMarkAsDeclinedUPDATE,
-          [RegistrationStatusEnum.deleted]: PermissionEnum.RegistrationDELETE,
-          [RegistrationStatusEnum.paused]:
-            PermissionEnum.RegistrationStatusPausedUPDATE,
-        };
+    const statusToPermissionMap = {
+      [RegistrationStatusEnum.validated]:
+        PermissionEnum.RegistrationStatusMarkAsValidatedUPDATE,
+      [RegistrationStatusEnum.included]:
+        PermissionEnum.RegistrationStatusIncludedUPDATE,
+      [RegistrationStatusEnum.declined]:
+        PermissionEnum.RegistrationStatusMarkAsDeclinedUPDATE,
+      [RegistrationStatusEnum.deleted]: PermissionEnum.RegistrationDELETE,
+      [RegistrationStatusEnum.paused]:
+        PermissionEnum.RegistrationStatusPausedUPDATE,
+    };
 
-        return this.authService.hasPermission({
-          projectId,
-          requiredPermission: statusToPermissionMap[status],
-        });
-      },
-  );
+    return this.authService.hasPermission({
+      projectId,
+      requiredPermission: statusToPermissionMap[status],
+    });
+  }
 
-  readonly canSendMessage = computed(
-    () =>
-      ({ projectId }: { projectId: string }) =>
-        this.authService.hasPermission({
-          projectId,
-          requiredPermission: PermissionEnum.RegistrationNotificationCREATE,
-        }),
-  );
+  public canSendMessage({ projectId }: { projectId: string }): boolean {
+    return this.authService.hasPermission({
+      projectId,
+      requiredPermission: PermissionEnum.RegistrationNotificationCREATE,
+    });
+  }
 
-  createContextItemForRegistrationStatus({
+  public createContextItemForRegistrationStatus({
     status,
     projectId,
     hasValidation,
@@ -73,12 +68,12 @@ export class RegistrationActionMenuService {
     return {
       label: REGISTRATION_STATUS_VERB[status],
       icon: REGISTRATION_STATUS_ICON[status],
-      visible: this.canChangeStatus()({ status, projectId, hasValidation }),
+      visible: this.canChangeStatus({ status, projectId, hasValidation }),
       command,
     };
   }
 
-  createContextItemForMessage({
+  public createContextItemForMessage({
     projectId,
     command,
   }: {
@@ -88,7 +83,7 @@ export class RegistrationActionMenuService {
     return {
       label: $localize`Message`,
       icon: 'pi pi-envelope',
-      visible: this.canSendMessage()({ projectId }),
+      visible: this.canSendMessage({ projectId }),
       command,
     };
   }

--- a/interfaces/Portalicious/src/app/services/registration-action-menu.service.ts
+++ b/interfaces/Portalicious/src/app/services/registration-action-menu.service.ts
@@ -54,7 +54,7 @@ export class RegistrationActionMenuService {
     });
   }
 
-  public createContextItemForRegistrationStatus({
+  public createContextItemForRegistrationStatusChange({
     status,
     projectId,
     hasValidation,


### PR DESCRIPTION
[AB#33898](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/33898) <!--- Replace this with a reference to a devops issue -->

Moved logic from to project-registrations.page to seperate service. Refactor to prepare for the introcution of an actions menu on the profile page

## Describe your changes

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6538.westeurope.5.azurestaticapps.net
