### PR TITLE
fix: unresponsive if no columns selected in table

### DIFF
--- a/interfaces/Portalicious/src/app/components/query-table/components/query-table-column-management/query-table-column-management.component.ts
+++ b/interfaces/Portalicious/src/app/components/query-table/components/query-table-column-management/query-table-column-management.component.ts
@@ -55,8 +55,17 @@ export class QueryTableColumnManagementComponent<
   updateColumnVisibility = injectMutation(() => ({
     // We don't technically need a mutation here, but we're using one
     // so that we can easily reuse the form-sidebar component
-    mutationFn: () =>
-      Promise.resolve(this.formGroup.getRawValue().selectedColumns),
+    mutationFn: () => {
+      const { selectedColumns } = this.formGroup.getRawValue();
+
+      if (selectedColumns.length === 0) {
+        return Promise.reject(
+          new Error($localize`At least one column must be selected`),
+        );
+      }
+
+      return Promise.resolve(selectedColumns);
+    },
     onSuccess: (selectedColumns) => {
       const stateKey = this.selectedColumnsStateKey();
       if (stateKey) {

--- a/interfaces/Portalicious/src/locale/messages.xlf
+++ b/interfaces/Portalicious/src/locale/messages.xlf
@@ -1567,6 +1567,9 @@
       <trans-unit id="registration-duplicates" datatype="html">
         <source>Duplicates</source>
       </trans-unit>
+      <trans-unit id="1160840788795450422" datatype="html">
+        <source>At least one column must be selected</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
[AB#34011](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/34011)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6559.westeurope.5.azurestaticapps.net
