### PR TITLE
chore: run Jest with colors

### DIFF
--- a/services/.env.example
+++ b/services/.env.example
@@ -22,6 +22,9 @@ NODE_ENV=development
 # Uncomment when starting from a clean slate only.
 #COMPOSE_PROJECT_NAME=global-121-platform
 
+# (Optional) Make Jest use all the colors.
+#FORCE_COLOR=true
+
 # (Optional) Flag to indicate operating system in local development.
 # Set to `:windows` if on windows, otherwise leave empty/undefined
 WINDOWS_DEV_STARTUP_SUFFIX=

--- a/services/121-service/README.md
+++ b/services/121-service/README.md
@@ -88,6 +88,10 @@ To update snapshots, amend the `-- -u` option, for example:
 
     docker exec 121-service  npm run test:integration:all -- -u
 
+If you want all the color output Jest can give set the
+[`FORCE_COLOR`](https://force-color.org/) environment variable to `true` in your
+local development environment via the [`services/.env`](../.env.example)-file.
+
 ### Debugging
 
 To enter the 121-service in the terminal use: (Or use the "Exec"-tab inside Docker Desktop)


### PR DESCRIPTION
[AB#34160](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/34160) <!--- Replace this with a reference to a devops issue -->

## Describe your changes

Docker Compose will read the `FORCE_COLOR` environment variable from the host which Jest will use to color the test

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
