### PR TITLE
fix: rename query attribute

### DIFF
--- a/interfaces/Portal/src/app/services/programs-service-api.service.ts
+++ b/interfaces/Portal/src/app/services/programs-service-api.service.ts
@@ -130,14 +130,14 @@ export class ProgramsServiceApiService {
     options?: {
       includeProgramRegistrationAttributes?: boolean;
       includeTemplateDefaultAttributes?: boolean;
-      filterShowInPeopleAffectedTable?: boolean;
+      filterShowInRegistrationsTable?: boolean;
     },
   ): Promise<PaTableAttribute[]> {
     let params = new HttpParams();
     const defaultOptions = {
       includeProgramRegistrationAttributes: true,
       includeTemplateDefaultAttributes: false,
-      filterShowInPeopleAffectedTable: true,
+      filterShowInRegistrationsTable: true,
     };
     params = params.appendAll(Object.assign(defaultOptions, options));
 

--- a/interfaces/Portal/src/app/shared/message-editor/message-editor.component.ts
+++ b/interfaces/Portal/src/app/shared/message-editor/message-editor.component.ts
@@ -121,7 +121,7 @@ export class MessageEditorComponent implements AfterViewInit, OnInit {
       this.inputProps.programId,
       {
         includeTemplateDefaultAttributes: true,
-        filterShowInPeopleAffectedTable: false,
+        filterShowInRegistrationsTable: false,
       },
     );
 


### PR DESCRIPTION
[AB#34272](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/34272) <!--- Replace this with a reference to a devops issue -->

## Describe your changes

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

Bug introduced by PR #6475 

A query parameter used in the /attributes endpoint wasn't renamed in the Portal

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
