### PR TITLE
Allow non required boolean values to be empty

### DIFF
--- a/e2e/portalicious/tests/ChangeRegistrationStatus/MovePasFromCompletedToIncluded.spec.ts
+++ b/e2e/portalicious/tests/ChangeRegistrationStatus/MovePasFromCompletedToIncluded.spec.ts
@@ -1,11 +1,8 @@
 import test from '@playwright/test';
 
-import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
-import { doPayment } from '@121-service/test/helpers/program.helper';
 import {
-  changeBulkRegistrationStatus,
-  seedRegistrations,
+  seedPaidRegistrations,
   updateRegistration,
 } from '@121-service/test/helpers/registration.helper';
 import {
@@ -28,7 +25,7 @@ const toastMessage =
 test.beforeEach(async ({ page }) => {
   await resetDB(SeedScript.nlrcMultiple);
 
-  await seedRegistrations([registrationPvMaxPayment], programIdPV);
+  await seedPaidRegistrations([registrationPvMaxPayment], programIdPV);
   // Login
   const loginPage = new LoginPage(page);
   await page.goto('/');
@@ -48,27 +45,9 @@ test('[31214] Move PA(s) from status "Completed" to "Included"', async ({
   const registrations = new RegistrationsPage(page);
   const tableComponent = new TableComponent(page);
   // Act
-  await test.step('Change status of registration to "Included"', async () => {
-    await changeBulkRegistrationStatus({
-      programId: 2,
-      status: RegistrationStatusEnum.included,
-      accessToken,
-    });
-  });
-
   await test.step('Validate the status of the registration', async () => {
     await registrations.validateStatusOfFirstRegistration({
-      status: 'Included',
-    });
-  });
-
-  await test.step('Change status of registration to "Completed" with doing a payment', async () => {
-    await doPayment({
-      programId: 2,
-      paymentNr: 1,
-      amount: 25,
-      referenceIds: [],
-      accessToken,
+      status: 'Completed',
     });
   });
 

--- a/services/121-service/src/registration/services/registrations-import.service.ts
+++ b/services/121-service/src/registration/services/registrations-import.service.ts
@@ -208,7 +208,6 @@ export class RegistrationsImportService {
           customData[att.name] =
             RegistrationsInputValidatorHelpers.inputToBoolean(
               record.data[att.name],
-              false,
             );
         } else {
           customData[att.name] = record.data[att.name];
@@ -357,7 +356,6 @@ export class RegistrationsImportService {
         values.push(
           RegistrationsInputValidatorHelpers.inputToBoolean(
             customData[att.name],
-            false,
           ),
         );
       } else if (att.type === RegistrationAttributeTypes.text) {

--- a/services/121-service/src/registration/validators/registrations-input.validator.helper.spec.ts
+++ b/services/121-service/src/registration/validators/registrations-input.validator.helper.spec.ts
@@ -2,7 +2,7 @@ import { RegistrationsInputValidatorHelpers } from '@121-service/src/registratio
 
 describe('RegistrationsInputValidatorHelpers', () => {
   describe('inputToBoolean', () => {
-    it.concurrent.each([['true'], ['yes'], ['1'], [true]])(
+    it.concurrent.each([['true'], ['yes'], ['1'], [1], [true]])(
       'should return true for input "%s"',
       async (input) => {
         expect(RegistrationsInputValidatorHelpers.inputToBoolean(input)).toBe(
@@ -16,6 +16,8 @@ describe('RegistrationsInputValidatorHelpers', () => {
       ['no'],
       ['0'],
       [''],
+      [0],
+      [2],
       ['unrecognized'],
       [false],
     ])('should return false for input "%s"', async (input) => {

--- a/services/121-service/src/registration/validators/registrations-input.validator.helper.spec.ts
+++ b/services/121-service/src/registration/validators/registrations-input.validator.helper.spec.ts
@@ -1,73 +1,36 @@
 import { RegistrationsInputValidatorHelpers } from '@121-service/src/registration/validators/registrations-input.validator.helper';
 
 describe('RegistrationsInputValidatorHelpers', () => {
-  describe('stringToBoolean', () => {
-    it('should convert "true", "yes", and "1" to true', () => {
-      expect(RegistrationsInputValidatorHelpers.inputToBoolean('true')).toBe(
-        true,
-      );
-      expect(RegistrationsInputValidatorHelpers.inputToBoolean('yes')).toBe(
-        true,
-      );
-      expect(RegistrationsInputValidatorHelpers.inputToBoolean('1')).toBe(true);
-    });
+  describe('inputToBoolean', () => {
+    it.concurrent.each([['true'], ['yes'], ['1'], [true]])(
+      'should return true for input "%s"',
+      async (input) => {
+        expect(RegistrationsInputValidatorHelpers.inputToBoolean(input)).toBe(
+          true,
+        );
+      },
+    );
 
-    it('should convert "false", "no", "0", "", and null to false', () => {
-      expect(RegistrationsInputValidatorHelpers.inputToBoolean('false')).toBe(
-        false,
-      );
-      expect(RegistrationsInputValidatorHelpers.inputToBoolean('no')).toBe(
-        false,
-      );
-      expect(RegistrationsInputValidatorHelpers.inputToBoolean('0')).toBe(
-        false,
-      );
-      expect(RegistrationsInputValidatorHelpers.inputToBoolean('')).toBe(false);
-      expect(RegistrationsInputValidatorHelpers.inputToBoolean(null)).toBe(
+    it.concurrent.each([
+      ['false'],
+      ['no'],
+      ['0'],
+      [''],
+      ['unrecognized'],
+      [false],
+    ])('should return false for input "%s"', async (input) => {
+      expect(RegistrationsInputValidatorHelpers.inputToBoolean(input)).toBe(
         false,
       );
     });
 
-    it('should return undefined for unrecognized strings if no default value is provided', () => {
-      expect(
-        RegistrationsInputValidatorHelpers.inputToBoolean('unrecognized'),
-      ).toBeUndefined();
-    });
-
-    it('should return the default value for unrecognized strings if provided', () => {
-      expect(
-        RegistrationsInputValidatorHelpers.inputToBoolean('unrecognized', true),
-      ).toBe(true);
-      expect(
-        RegistrationsInputValidatorHelpers.inputToBoolean(
-          'unrecognized',
-          false,
-        ),
-      ).toBe(false);
-    });
-
-    it('should return the default value for undefined input if provided', () => {
-      expect(
-        RegistrationsInputValidatorHelpers.inputToBoolean(undefined, true),
-      ).toBe(true);
-      expect(
-        RegistrationsInputValidatorHelpers.inputToBoolean(undefined, false),
-      ).toBe(false);
-    });
-
-    it('should return undefined for undefined input if no default value is provided', () => {
-      expect(
-        RegistrationsInputValidatorHelpers.inputToBoolean(undefined),
-      ).toBeUndefined();
-    });
-
-    it('should handle boolean input by returning it directly', () => {
-      expect(RegistrationsInputValidatorHelpers.inputToBoolean('true')).toBe(
-        true,
-      );
-      expect(RegistrationsInputValidatorHelpers.inputToBoolean('false')).toBe(
-        false,
-      );
-    });
+    it.concurrent.each([[null], [undefined]])(
+      'should return undefined for input %s',
+      async (input) => {
+        expect(
+          RegistrationsInputValidatorHelpers.inputToBoolean(input),
+        ).toBeUndefined();
+      },
+    );
   });
 });

--- a/services/121-service/src/registration/validators/registrations-input.validator.helper.ts
+++ b/services/121-service/src/registration/validators/registrations-input.validator.helper.ts
@@ -1,7 +1,6 @@
 export class RegistrationsInputValidatorHelpers {
   static inputToBoolean(
     input: string | null | undefined | number | boolean,
-    defaultValue?: boolean,
   ): boolean | undefined {
     if (typeof input === 'boolean') {
       return input;
@@ -12,13 +11,11 @@ export class RegistrationsInputValidatorHelpers {
     }
 
     if (input === null) {
-      return false;
+      return undefined;
     }
 
     if (input === undefined) {
-      return this.isValueUndefinedOrNull(defaultValue)
-        ? undefined
-        : defaultValue;
+      return undefined;
     }
 
     switch (input.toLowerCase().trim()) {
@@ -32,13 +29,7 @@ export class RegistrationsInputValidatorHelpers {
       case '':
         return false;
       default:
-        return this.isValueUndefinedOrNull(defaultValue)
-          ? undefined
-          : defaultValue;
+        return false;
     }
-  }
-
-  static isValueUndefinedOrNull(value: any): boolean {
-    return value === undefined || value === null;
   }
 }


### PR DESCRIPTION
[AB#34340](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/34340) <!--- Replace this with a reference to a devops issue -->



## Describe your changes

Registration data has been refactor to allow non required values (see isRequired in ProgramRegistrationAttributeEntity)

However for registration data of type boolean we would always revert to a default value 'false' if a registration was imported with the value not set. 


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
