### PR TITLE
Fix: remove image codes after a day instead of immidiately

### DIFF
--- a/services/.env.example
+++ b/services/.env.example
@@ -168,6 +168,8 @@ CRON_INTERSOLVE_VOUCHER_CANCEL_FAILED_CARDS=
 CRON_INTERSOLVE_VOUCHER_CACHE_UNUSED_VOUCHERS=
 # (Optional) Send WhatsApp reminders
 CRON_INTERSOLVE_VOUCHER_SEND_WHATSAPP_REMINDERS=
+# (Optional) Remove deprecated image-codes
+CRON_INTERSOLVE_VOUCHER_REMOVE_DEPRECATED_IMAGE_CODES=
 
 # FSP-Specific: Intersolve-VISA
 # (All Require Admin-account credentials to be set!)

--- a/services/121-service/src/cronjob/cronjob.service.ts
+++ b/services/121-service/src/cronjob/cronjob.service.ts
@@ -161,6 +161,23 @@ export class CronjobService {
     return { url, responseStatus: response.status }; // Only used for testing purposes; this method is then called from the controller
   }
 
+  @Cron(CronExpression.EVERY_DAY_AT_1AM, {
+    disabled: !shouldBeEnabled(
+      process.env.CRON_INTERSOLVE_VOUCHER_REMOVE_DEPRECATED_IMAGE_CODES,
+    ),
+  })
+  public async cronRemoveDeprecatedImageCodes(): Promise<{
+    url: string;
+    responseStatus: number;
+  }> {
+    // Removes image codes older than one day as they're no longer needed after Twilio has downloaded them
+    const accessToken = await this.axiosCallsService.getAccessToken();
+    const url = `${this.axiosCallsService.getBaseUrl()}/financial-service-providers/intersolve-voucher/deprecated-image-codes`;
+    const headers = this.axiosCallsService.accesTokenToHeaders(accessToken);
+    const response: AxiosResponse = await this.httpService.delete(url, headers);
+    return { url, responseStatus: response.status }; // Only used for testing purposes; this method is then called from the controller
+  }
+
   public getAllMethods(): {
     methodNames: string[];
     url: string;

--- a/services/121-service/src/payments/fsp-integration/intersolve-voucher/dto/remove-deprecated-image-codes-dto.ts
+++ b/services/121-service/src/payments/fsp-integration/intersolve-voucher/dto/remove-deprecated-image-codes-dto.ts
@@ -3,12 +3,13 @@ import { IsDateString, IsOptional } from 'class-validator';
 
 export class RemoveDeprecatedImageCodesDto {
   @ApiPropertyOptional({
-    description:
-      'TESTING ONLY: Allows overriding the current system date for testing purposes.' +
-      ' When provided in DEBUG mode, the system will use this date instead of the actual current date' +
-      ' to determine which image codes are deprecated (older than 24 hours from this mock date).' +
-      ' Has no effect in production environments.',
-    example: '2023-01-01T00:00:00.000Z',
+    description: `
+    **TESTING ONLY**: Allows overriding the current system date for testing purposes.
+    When provided in DEBUG mode, the system will use this date instead of the actual current date
+    to determine which image codes are deprecated (older than 24 hours from this mock date).
+    Has no effect in production environments.
+  `,
+    example: '2021-02-01T00:00:00.000Z',
   })
   @IsOptional()
   @IsDateString()

--- a/services/121-service/src/payments/fsp-integration/intersolve-voucher/dto/remove-deprecated-image-codes-dto.ts
+++ b/services/121-service/src/payments/fsp-integration/intersolve-voucher/dto/remove-deprecated-image-codes-dto.ts
@@ -1,0 +1,16 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsOptional } from 'class-validator';
+
+export class RemoveDeprecatedImageCodesDto {
+  @ApiPropertyOptional({
+    description:
+      'TESTING ONLY: Allows overriding the current system date for testing purposes.' +
+      ' When provided in DEBUG mode, the system will use this date instead of the actual current date' +
+      ' to determine which image codes are deprecated (older than 24 hours from this mock date).' +
+      ' Has no effect in production environments.',
+    example: '2023-01-01T00:00:00.000Z',
+  })
+  @IsOptional()
+  @IsDateString()
+  mockCurrentDate?: string;
+}

--- a/services/121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-voucher.controller.ts
+++ b/services/121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-voucher.controller.ts
@@ -1,5 +1,7 @@
 import {
+  Body,
   Controller,
+  Delete,
   Get,
   HttpStatus,
   Param,
@@ -27,6 +29,7 @@ import stream from 'stream';
 import { AuthenticatedUser } from '@121-service/src/guards/authenticated-user.decorator';
 import { AuthenticatedUserGuard } from '@121-service/src/guards/authenticated-user.guard';
 import { IdentifyVoucherDto } from '@121-service/src/payments/fsp-integration/intersolve-voucher/dto/identify-voucher.dto';
+import { RemoveDeprecatedImageCodesDto } from '@121-service/src/payments/fsp-integration/intersolve-voucher/dto/remove-deprecated-image-codes-dto';
 import { IntersolveVoucherService } from '@121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-voucher.service';
 import { IntersolveVoucherCronService } from '@121-service/src/payments/fsp-integration/intersolve-voucher/services/intersolve-voucher-cron.service';
 import { IMAGE_UPLOAD_API_FORMAT } from '@121-service/src/shared/file-upload-api-format';
@@ -182,5 +185,28 @@ export class IntersolveVoucherController {
     console.info('CronjobService - Started: cronSendWhatsappReminders');
     await this.intersolveVoucherCronService.sendWhatsappReminders();
     console.info('CronjobService - Complete: cronSendWhatsappReminders');
+  }
+
+  @AuthenticatedUser({ isAdmin: true })
+  @ApiOperation({
+    summary: '[CRON] Remove deprecated image codes',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Successfully removed deprecated image codes',
+  })
+  @Delete(
+    '/financial-service-providers/intersolve-voucher/deprecated-image-codes',
+  )
+  public async removeDeprecatedImageCodes(
+    @Body() body: RemoveDeprecatedImageCodesDto,
+  ): Promise<number> {
+    console.info('CronjobService - Started: removeDeprecatedImageCodes');
+    const numberOfDeleted =
+      await this.intersolveVoucherService.removeDeprecatedImageCodes(
+        body.mockCurrentDate,
+      );
+    console.info('CronjobService - Complete: removeDeprecatedImageCodes');
+    return numberOfDeleted;
   }
 }

--- a/services/121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-voucher.service.ts
+++ b/services/121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-voucher.service.ts
@@ -848,19 +848,18 @@ export class IntersolveVoucherService
    *
    * A one-day retention provides a generous safety buffer (only seconds are actually needed),
    * ensuring any delayed processing or retry attempts have completed while preventing
-   * unnecessary storage consumption and minimizes the risk by reducing the amount of voucher exposed via the APi.
+   * unnecessary storage consumption and minimizes the risk by reducing the amount of voucher exposed via the API.
    */
   public async removeDeprecatedImageCodes(
-    currentDate: string | undefined,
+    mockCurrentDate?: string | undefined,
   ): Promise<number> {
-    // Date is optional it's only made available for testing purposes
-    let date: Date;
-    if (currentDate && DEBUG) {
-      date = new Date(currentDate);
+    // mockCurrentDate is only made available for testing purposes, as there is no easy way to mock the current date in out test setup
+    let dateFilter: Date;
+    if (mockCurrentDate && DEBUG) {
+      dateFilter = new Date(mockCurrentDate);
     } else {
-      date = new Date();
+      dateFilter = new Date();
     }
-    const dateFilter = date;
     dateFilter.setDate(dateFilter.getDate() - 1);
     return await this.imageCodeService.removeImageCodesCreatedBefore({
       date: dateFilter,

--- a/services/121-service/src/shared/services/custom-http.service.ts
+++ b/services/121-service/src/shared/services/custom-http.service.ts
@@ -130,6 +130,29 @@ export class CustomHttpService {
     );
   }
 
+  public async delete<T>(url: string, headers?: Header[]): Promise<T> {
+    return await lastValueFrom(
+      this.httpService
+        .delete(url, {
+          headers: this.createHeaders(headers),
+        })
+        .pipe(
+          map((response) => {
+            this.logMessageRequest({ headers, url, payload: null }, response);
+            return response;
+          }),
+          catchError((err) => {
+            const errorResponse = err.response || this.setNoResponseError(err);
+            this.logErrorRequest(
+              { headers, url, payload: null },
+              errorResponse,
+            );
+            return of(errorResponse);
+          }),
+        ),
+    );
+  }
+
   public async request<T>({
     method,
     url,

--- a/services/121-service/swagger.json
+++ b/services/121-service/swagger.json
@@ -451,6 +451,11 @@
     "params": []
   },
   {
+    "method": "delete",
+    "path": "/api/financial-service-providers/intersolve-voucher/deprecated-image-codes",
+    "params": []
+  },
+  {
     "method": "get",
     "path": "/api/programs/{programId}/transactions",
     "params": [

--- a/services/121-service/test/helpers/program.helper.ts
+++ b/services/121-service/test/helpers/program.helper.ts
@@ -517,3 +517,21 @@ export async function setAllProgramsRegistrationAttributesNonRequired(
     });
   }
 }
+
+export async function removeDeprecatedImageCodes(
+  {
+    accessToken,
+    mockCurrentDate,
+  }: { accessToken: string; mockCurrentDate?: string }, // ISO string format
+): Promise<request.Response> {
+  const body: Record<string, string> = {};
+  if (mockCurrentDate) {
+    body.mockCurrentDate = mockCurrentDate;
+  }
+  return await getServer()
+    .delete(
+      '/financial-service-providers/intersolve-voucher/deprecated-image-codes',
+    )
+    .set('Cookie', [accessToken])
+    .send(body);
+}

--- a/services/121-service/test/helpers/program.helper.ts
+++ b/services/121-service/test/helpers/program.helper.ts
@@ -518,15 +518,16 @@ export async function setAllProgramsRegistrationAttributesNonRequired(
   }
 }
 
-export async function removeDeprecatedImageCodes(
-  {
-    accessToken,
-    mockCurrentDate,
-  }: { accessToken: string; mockCurrentDate?: string }, // ISO string format
-): Promise<request.Response> {
+export async function removeDeprecatedImageCodes({
+  accessToken,
+  mockCurrentDateIsoString,
+}: {
+  accessToken: string;
+  mockCurrentDateIsoString?: string;
+}): Promise<request.Response> {
   const body: Record<string, string> = {};
-  if (mockCurrentDate) {
-    body.mockCurrentDate = mockCurrentDate;
+  if (mockCurrentDateIsoString) {
+    body.mockCurrentDate = mockCurrentDateIsoString;
   }
   return await getServer()
     .delete(

--- a/services/121-service/test/voucher/delete-deprecated-vouchers.test.ts
+++ b/services/121-service/test/voucher/delete-deprecated-vouchers.test.ts
@@ -21,7 +21,7 @@ describe('Delete deprecated vouchers', () => {
     accessToken = await getAccessToken();
   });
 
-  it(`should not deprecate images that are not older than a day`, async () => {
+  it(`should not delete images that are not older than a day`, async () => {
     // Arrange
     await seedPaidRegistrations([registrationPV5], programIdPV);
 
@@ -38,7 +38,7 @@ describe('Delete deprecated vouchers', () => {
     expect(response.text).toBe('0');
   });
 
-  it(`should deprecate image that is older than a day`, async () => {
+  it(`should delete image that is older than a day`, async () => {
     // Arrange
     await seedPaidRegistrations([registrationPV5], programIdPV);
 
@@ -54,7 +54,7 @@ describe('Delete deprecated vouchers', () => {
     });
     const response = await removeDeprecatedImageCodes({
       accessToken,
-      mockCurrentDate: dayAfterTomorrow.toISOString(),
+      mockCurrentDateIsoString: dayAfterTomorrow.toISOString(),
     });
 
     // Assert

--- a/services/121-service/test/voucher/delete-deprecated-vouchers.test.ts
+++ b/services/121-service/test/voucher/delete-deprecated-vouchers.test.ts
@@ -1,0 +1,64 @@
+import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
+import {
+  removeDeprecatedImageCodes,
+  waitForMessagesToComplete,
+} from '@121-service/test/helpers/program.helper';
+import { seedPaidRegistrations } from '@121-service/test/helpers/registration.helper';
+import {
+  getAccessToken,
+  resetDB,
+} from '@121-service/test/helpers/utility.helper';
+import {
+  programIdPV,
+  registrationPV5,
+} from '@121-service/test/registrations/pagination/pagination-data';
+
+describe('Delete deprecated vouchers', () => {
+  let accessToken: string;
+
+  beforeEach(async () => {
+    await resetDB(SeedScript.nlrcMultiple);
+    accessToken = await getAccessToken();
+  });
+
+  it(`should not deprecate images that are not older than a day`, async () => {
+    // Arrange
+    await seedPaidRegistrations([registrationPV5], programIdPV);
+
+    // Act
+    const response = await removeDeprecatedImageCodes({ accessToken });
+    await waitForMessagesToComplete({
+      programId: programIdPV,
+      referenceIds: [registrationPV5.referenceId],
+      accessToken,
+      minimumNumberOfMessages: 3,
+    });
+    // Assert
+    // We expect that no image codes are deleted because all of them are still valid
+    expect(response.text).toBe('0');
+  });
+
+  it(`should deprecate image that is older than a day`, async () => {
+    // Arrange
+    await seedPaidRegistrations([registrationPV5], programIdPV);
+
+    // Act
+    // pretend that it is 2 days later
+    const dayAfterTomorrow = new Date();
+    dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 2);
+    await waitForMessagesToComplete({
+      programId: programIdPV,
+      referenceIds: [registrationPV5.referenceId],
+      accessToken,
+      minimumNumberOfMessages: 3,
+    });
+    const response = await removeDeprecatedImageCodes({
+      accessToken,
+      mockCurrentDate: dayAfterTomorrow.toISOString(),
+    });
+
+    // Assert
+    // We expect that one image code is deleted because it is older than a day
+    expect(response.text).toBe('1');
+  });
+});


### PR DESCRIPTION
[AB#34346](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/34346) [AB#34445](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/34445) <!--- Replace this with a reference to a devops issue -->

## Describe your changes

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
