### PR TITLE
feat: change position of fail reason in activity overview

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,9 +17,5 @@
     "class:list"
   ],
   "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true,
-  // The following setting is necessary to avoid false negatives in the VSCode Angular Language
-  // Service because of discrepancies between the angular versions used in Portal and Portalicious.
-  // It can be removed when the Portal is removed.
-  "angular.suppressAngularDiagnosticCodes": "-992010,-998001,-998002"
+  "typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/interfaces/Portalicious/src/app/pages/project-registration-activity-log/components/activity-log-expanded-row/activity-log-expanded-row.component.ts
+++ b/interfaces/Portalicious/src/app/pages/project-registration-activity-log/components/activity-log-expanded-row/activity-log-expanded-row.component.ts
@@ -190,20 +190,20 @@ export class ActivityLogExpandedRowComponent
           },
         ];
 
-        if (item.attributes.status === TransactionStatusEnum.error) {
-          list.push({
-            label: $localize`Fail reason`,
-            value: item.attributes.errorMessage,
-            type: 'text',
-          });
-        }
-
         if (this.isIntersolveVoucher()) {
           list.push({
             label: $localize`Current balance`,
             value: this.intersolveVoucherBalance.data(),
             type: 'currency',
             loading: this.intersolveVoucherBalance.isLoading(),
+          });
+        }
+
+        if (item.attributes.status === TransactionStatusEnum.error) {
+          list.push({
+            label: $localize`Fail reason`,
+            value: item.attributes.errorMessage,
+            type: 'text',
           });
         }
 


### PR DESCRIPTION
[AB#34382](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/34382)

I'm also sneaking in a settings.json change. This exception is seemingly not necessary anymore (I think because of a fix in the Angular Language Service extension). This means that clicking through on components in a template should work again.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6630.westeurope.5.azurestaticapps.net
