### PR TITLE
fix: Combine build-steps, so they share ENV-variables

### DIFF
--- a/.github/actions/build-interface/action.yml
+++ b/.github/actions/build-interface/action.yml
@@ -72,7 +72,7 @@ runs:
       run: |
         echo "${{ inputs.envIcon }}" | sed 's/data:image\/.*;base64,//' | base64 --decode > ${{ inputs.envIconPath }}
 
-    - name: Download latest translations
+    - name: Build (Portalicious)
       if: inputs.buildType == 'portalicious'
       shell: bash
       working-directory: ${{ inputs.interfacePath }}
@@ -82,13 +82,6 @@ runs:
         LOKALISE_API_TOKEN: ${{ env.LOKALISE_API_TOKEN }}
       run: |
         echo "\n\n# This file should exist in Node v20, is optional in Node v22\n\n" >> .env
-        npm run build:download-translations
-
-    - name: Build (Portalicious)
-      if: inputs.buildType == 'portalicious'
-      shell: bash
-      working-directory: ${{ inputs.interfacePath }}
-      run: |
         npm run build:production
 
     - name: Build (deprecated Portal)


### PR DESCRIPTION
[AB#34716](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/34716)

## Describe your changes

These steps where separated before, so they wouldn't share the ENV-variables.
That made the `build:production`-step(which now INCLUDES the `build:download-translations`!) assume the ENV-variables where not set, therefore set to "only create mock translations-files" (and thus overriding the previously downloaded production/real translations-files.)


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes, or adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or the changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

Triggered manually: https://github.com/global-121/121-platform/actions/runs/14030759837/job/39277663600

https://new.portal.test.121.global/

<!-- end deployment url -->
