### PR TITLE
fix: Only handle in numbers when using the currencyPipe

### DIFF
--- a/interfaces/Portalicious/src/app/pages/project-registration-debit-cards/project-registration-debit-cards.page.ts
+++ b/interfaces/Portalicious/src/app/pages/project-registration-debit-cards/project-registration-debit-cards.page.ts
@@ -80,12 +80,20 @@ export class ProjectRegistrationDebitCardsPageComponent {
       this.currentCard()?.actions.includes(VisaCardAction[action]),
   );
 
+  readonly convertCentsToMainUnits = (
+    value: null | number | undefined,
+  ): number => {
+    if (!value) {
+      return 0;
+    }
+    return value / 100;
+  };
+
   readonly walletWithCurrentCardListData = computed(() => {
     const { chipLabel, chipVariant } = getChipDataByVisaCardStatus(
       this.currentCard()?.status,
     );
-    const balance = this.walletWithCards.data()?.balance;
-    const spentThisMonth = this.walletWithCards.data()?.spentThisMonth;
+
     const listData: DataListItem[] = [
       {
         label: $localize`:@@debit-card-number:Card number`,
@@ -98,12 +106,16 @@ export class ProjectRegistrationDebitCardsPageComponent {
       },
       {
         label: $localize`:@@debit-card-balance:Current balance`,
-        value: balance ? balance / 100 : '-',
+        value: this.convertCentsToMainUnits(
+          this.walletWithCards.data()?.balance,
+        ),
         type: 'currency',
       },
       {
         label: $localize`:@@debit-card-spent-this-month:Spent this month (max. EUR 150)`,
-        value: spentThisMonth ? spentThisMonth / 100 : '-',
+        value: this.convertCentsToMainUnits(
+          this.walletWithCards.data()?.spentThisMonth,
+        ),
         type: 'currency',
       },
       {


### PR DESCRIPTION
(let the data-list.component handle the '-')

[AB#34773](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/34773)
[AB#34789](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/34789)


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or the changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6658.westeurope.5.azurestaticapps.net
