### PR TITLE
fix: Reduce downloads of translations (in E2E-test runs)

### DIFF
--- a/.github/workflows/test_e2e_portalicious.yml
+++ b/.github/workflows/test_e2e_portalicious.yml
@@ -65,7 +65,6 @@ jobs:
         run: |
           npm install
           cp .env.example .env
-          npm run build:download-translations
           npm run start:debug-production > portalicious-server-logs.txt 2>&1 &
 
       - name: Install 121-Service dependencies


### PR DESCRIPTION
[AB#34724](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/34724)

The task/command `npm run build:download-translations` is now included into the generic `npm run build`-command, see https://github.com/global-121/121-platform/pull/6628

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or the changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
