### PR TITLE
refactor: Enforce rule of max. 2 parameter per method (+fix issues)

### DIFF
--- a/interfaces/Portalicious/eslint.config.js
+++ b/interfaces/Portalicious/eslint.config.js
@@ -82,6 +82,7 @@ module.exports = tseslint.config(
       '@angular-eslint/sort-lifecycle-methods': ['error'],
       '@angular-eslint/use-component-selector': ['error'],
       '@angular-eslint/use-lifecycle-interface': ['error'],
+      'max-params': ['error', 2],
       'eslint-comments/require-description': 'error',
       'no-relative-import-paths/no-relative-import-paths': [
         'error',

--- a/interfaces/Portalicious/src/app/components/colored-chip/colored-chip.helper.ts
+++ b/interfaces/Portalicious/src/app/components/colored-chip/colored-chip.helper.ts
@@ -21,11 +21,15 @@ export interface ChipData {
   chipVariant: ChipVariant;
 }
 
-const mapValueToChipData = <Enum extends string>(
-  value: Enum | null | undefined,
-  labels: Record<NonNullable<Enum>, string>,
-  chipVariants: Record<NonNullable<Enum>, ChipVariant>,
-): ChipData => {
+const mapValueToChipData = <Enum extends string>({
+  value,
+  labels,
+  chipVariants,
+}: {
+  value: Enum | null | undefined;
+  labels: Record<NonNullable<Enum>, string>;
+  chipVariants: Record<NonNullable<Enum>, ChipVariant>;
+}): ChipData => {
   if (!value) {
     return {
       chipVariant: 'grey',
@@ -42,56 +46,72 @@ const mapValueToChipData = <Enum extends string>(
 export const getChipDataByRegistrationStatus = (
   status?: null | RegistrationStatusEnum,
 ): ChipData =>
-  mapValueToChipData(status, REGISTRATION_STATUS_LABELS, {
-    [RegistrationStatusEnum.included]: 'green',
-    [RegistrationStatusEnum.registered]: 'blue',
-    [RegistrationStatusEnum.validated]: 'yellow',
-    [RegistrationStatusEnum.declined]: 'red',
-    [RegistrationStatusEnum.completed]: 'purple',
-    [RegistrationStatusEnum.deleted]: 'red',
-    [RegistrationStatusEnum.paused]: 'orange',
+  mapValueToChipData({
+    value: status,
+    labels: REGISTRATION_STATUS_LABELS,
+    chipVariants: {
+      [RegistrationStatusEnum.included]: 'green',
+      [RegistrationStatusEnum.registered]: 'blue',
+      [RegistrationStatusEnum.validated]: 'yellow',
+      [RegistrationStatusEnum.declined]: 'red',
+      [RegistrationStatusEnum.completed]: 'purple',
+      [RegistrationStatusEnum.deleted]: 'red',
+      [RegistrationStatusEnum.paused]: 'orange',
+    },
   });
 
 export const getChipDataByTransactionStatus = (
   status?: null | TransactionStatusEnum,
 ): ChipData =>
-  mapValueToChipData(status, TRANSACTION_STATUS_LABELS, {
-    [TransactionStatusEnum.waiting]: 'blue',
-    [TransactionStatusEnum.error]: 'red',
-    [TransactionStatusEnum.success]: 'green',
+  mapValueToChipData({
+    value: status,
+    labels: TRANSACTION_STATUS_LABELS,
+    chipVariants: {
+      [TransactionStatusEnum.waiting]: 'blue',
+      [TransactionStatusEnum.error]: 'red',
+      [TransactionStatusEnum.success]: 'green',
+    },
   });
 
 export const getChipDataByTwilioMessageStatus = (status: string): ChipData =>
-  mapValueToChipData(
-    convertTwilioMessageStatusToMessageStatus(status),
-    MESSAGE_STATUS_LABELS,
-    {
+  mapValueToChipData({
+    value: convertTwilioMessageStatusToMessageStatus(status),
+    labels: MESSAGE_STATUS_LABELS,
+    chipVariants: {
       [MessageStatus.delivered]: 'green',
       [MessageStatus.read]: 'green',
       [MessageStatus.failed]: 'red',
       [MessageStatus.sent]: 'blue',
       [MessageStatus.unknown]: 'blue',
     },
-  );
+  });
 
 export const getChipDataByVisaCardStatus = (
   status?: null | VisaCard121Status,
 ): ChipData =>
-  mapValueToChipData(status, VISA_CARD_STATUS_LABELS, {
-    [VisaCard121Status.Unknown]: 'grey',
-    [VisaCard121Status.Active]: 'green',
-    [VisaCard121Status.Issued]: 'blue',
-    [VisaCard121Status.Substituted]: 'red',
-    [VisaCard121Status.Blocked]: 'red',
-    [VisaCard121Status.SuspectedFraud]: 'red',
-    [VisaCard121Status.CardDataMissing]: 'orange',
-    [VisaCard121Status.Paused]: 'orange',
+  mapValueToChipData({
+    value: status,
+    labels: VISA_CARD_STATUS_LABELS,
+    chipVariants: {
+      [VisaCard121Status.Unknown]: 'grey',
+      [VisaCard121Status.Active]: 'green',
+      [VisaCard121Status.Issued]: 'blue',
+      [VisaCard121Status.Substituted]: 'red',
+      [VisaCard121Status.Blocked]: 'red',
+      [VisaCard121Status.SuspectedFraud]: 'red',
+      [VisaCard121Status.CardDataMissing]: 'orange',
+      [VisaCard121Status.Paused]: 'orange',
+    },
   });
 
 export const getChipDataByDuplicateStatus = (
   status?: DuplicateStatus | null,
 ): ChipData =>
-  mapValueToChipData(status, DUPLICATE_STATUS_LABELS, {
-    [DuplicateStatus.unique]: 'green',
-    [DuplicateStatus.duplicate]: 'red',
+  mapValueToChipData({
+    value: status,
+    labels: DUPLICATE_STATUS_LABELS,
+    chipVariants: {
+      [DuplicateStatus.unique]: 'green',
+      [DuplicateStatus.duplicate]: 'red',
+    },
   });

--- a/interfaces/Portalicious/src/app/pages/project-registrations/components/custom-message-preview/custom-message-preview.component.ts
+++ b/interfaces/Portalicious/src/app/pages/project-registrations/components/custom-message-preview/custom-message-preview.component.ts
@@ -37,11 +37,11 @@ export class CustomMessagePreviewComponent {
       this.previewRegistration(),
     ],
     queryFn: () =>
-      this.messagingService.getMessagePreview(
-        this.messageData(),
-        this.projectId,
-        this.previewRegistration(),
-      ),
+      this.messagingService.getMessagePreview({
+        input: this.messageData(),
+        projectId: this.projectId,
+        previewRegistration: this.previewRegistration(),
+      }),
   }));
 
   readonly messageText = computed(() =>

--- a/interfaces/Portalicious/src/app/services/auth/strategies/msal-auth/msal-auth.app-providers.ts
+++ b/interfaces/Portalicious/src/app/services/auth/strategies/msal-auth/msal-auth.app-providers.ts
@@ -40,6 +40,7 @@ const MSALInstanceFactory = (): IPublicClientApplication =>
       allowNativeBroker: false, // Disables WAM Broker
       allowRedirectInIframe: false,
       loggerOptions: {
+        // eslint-disable-next-line max-params -- External package defines this AP
         loggerCallback: (_level, message, containsPii) => {
           console.log(containsPii ? '👤' : '🌐', message);
         },

--- a/interfaces/Portalicious/src/app/services/messaging.service.ts
+++ b/interfaces/Portalicious/src/app/services/messaging.service.ts
@@ -88,11 +88,15 @@ export class MessagingService {
     )?.message;
   }
 
-  public async getMessagePreview(
-    input: Partial<MessageInputData>,
-    projectId: Signal<number | string>,
-    previewRegistration?: Registration,
-  ): Promise<string | undefined> {
+  public async getMessagePreview({
+    input,
+    projectId,
+    previewRegistration,
+  }: {
+    input: Partial<MessageInputData>;
+    projectId: Signal<number | string>;
+    previewRegistration?: Registration;
+  }): Promise<string | undefined> {
     const messageText = await this.getMessageText(input, projectId);
 
     if (!messageText) {


### PR DESCRIPTION
AB#34809

## Describe your changes

Allow only 2 unnamed parameters per method/function.
Force ourselves to use easily readable/understandable objects-with-properties

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or the changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
