### PR TITLE
Body by content sid instead of message sid

### DIFF
--- a/services/121-service/src/notifications/whatsapp/whatsapp.service.ts
+++ b/services/121-service/src/notifications/whatsapp/whatsapp.service.ts
@@ -82,11 +82,11 @@ export class WhatsappService {
       // If the message is a template, we need to fetch the body from Twilio due to what we think is a bug in Twilio Node library
       // I opened an issue for it here: https://github.com/twilio/twilio-node/issues/1081
       if (contentSid && !messageToStore.body) {
-        const fetchedMessage = await twilioClient
-          .messages(messageToStore.sid)
+        const fetchedTemplate = await twilioClient.content.v1
+          .contents(contentSid)
           .fetch();
-        // If the contentSid is not found the body will be an empty string. We will later get an error by callback where we can store the error
-        messageToStore.body = fetchedMessage.body;
+        messageToStore.body =
+          fetchedTemplate.types['twilio/quick-reply']?.body ?? '';
       }
       await this.storeSendWhatsapp({
         message: messageToStore,

--- a/services/mock-service/src/twilio/twilio.controller.ts
+++ b/services/mock-service/src/twilio/twilio.controller.ts
@@ -52,22 +52,23 @@ export class TwilioController {
 
   @ApiOperation({
     summary:
-      'Fetch message. We only mocked a body return when getting by messageSid for message created with a contentSid as this is the only part that is used in the 121-service',
+      'Fetch content template. Mocks the Twilio Content API for template fetching.',
   })
   @ApiParam({
-    name: 'messageSid',
+    name: 'contentSid',
     required: true,
     type: 'string',
-    description: 'Message SID returned from Twilio',
+    description: 'Content SID for a Twilio template',
   })
-  @Get('2010-04-01/Accounts/:accountSid/Messages/:messageSid.json')
-  public async fetchMessage(
-    @Param('accountSid') accountSid: string,
-    @Param('messageSid') messageSid: string,
-  ): Promise<{ body: string }> {
-    console.info(
-      `GET api/2010-04-01/Accounts/${accountSid}/Messages/${messageSid}.json`,
-    );
-    return this.twilioService.fetchMessage({ messageSid });
+  @Get('v1/Content/:contentSid')
+  public async fetchContent(@Param('contentSid') contentSid: string): Promise<{
+    types: {
+      'twilio/quick-reply'?: {
+        body: string;
+      };
+    };
+  }> {
+    console.info(`GET api/v1/Content/${contentSid}`);
+    return this.twilioService.fetchContent({ contentSid });
   }
 }

--- a/services/mock-service/src/twilio/twilio.service.ts
+++ b/services/mock-service/src/twilio/twilio.service.ts
@@ -52,23 +52,31 @@ export class TwilioService {
     };
   }
 
-  public async fetchMessage({ messageSid }: { messageSid: string }): Promise<{
-    body: string;
-  }> {
-    // If the messageSid contains 'mock', return the mock message that is related to the contentSid
-    if (messageSid.includes('mock')) {
-      const contentSid = messageSid.split('-mock-')[1];
-      const body = ContentSidMessageMockMap[contentSid];
-      if (!body) {
-        throw new HttpException(
-          `ContentSid ${body} not found`,
-          HttpStatus.BAD_REQUEST,
-        );
-      }
-      return {
-        body,
+  public async fetchContent({ contentSid }: { contentSid: string }): Promise<{
+    types: {
+      'twilio/quick-reply'?: {
+        body: string;
       };
+    };
+  }> {
+    // Check if the contentSid exists in your mock map
+    const body = ContentSidMessageMockMap[contentSid];
+
+    if (!body) {
+      throw new HttpException(
+        `ContentSid ${contentSid} not found`,
+        HttpStatus.BAD_REQUEST,
+      );
     }
+
+    // Return in the format that matches Twilio's content API
+    return {
+      types: {
+        'twilio/quick-reply': {
+          body,
+        },
+      },
+    };
   }
 
   public createMessage(
@@ -80,10 +88,7 @@ export class TwilioService {
       ? ''
       : twilioMessagesCreateDto.Body;
 
-    let messageSid = 'SM' + this.createRandomHexaDecimalString(32);
-    if (twilioMessagesCreateDto.ContentSid) {
-      messageSid = `${messageSid}-mock-${twilioMessagesCreateDto.ContentSid}`;
-    }
+    const messageSid = 'SM' + this.createRandomHexaDecimalString(32);
 
     const response = {
       body,


### PR DESCRIPTION
[AB#34877](https://dev.azure.com/redcrossnl/121%20Platform/_sprints/taskboard/121%20Development%20Team/121%20Platform/Sprint%20151?System.State=Flagged%2CIn%20Progress%2CNew%2CReady%2CReview%2CTo%20Do&workitem=34877)

Apparently when getting message using message sid the same bug occurs as with the return object. So instead of fetching the body using the messageSid this PR uses contentSid

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or the changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
