### PR TITLE
E2E test for advanced filtering by date cherry pick

### DIFF
--- a/e2e/portalicious/components/TableComponent.ts
+++ b/e2e/portalicious/components/TableComponent.ts
@@ -19,6 +19,7 @@ class TableComponent {
   readonly approveButton: Locator;
   readonly calendar: Locator;
   readonly datePicker: Locator;
+  readonly datePickerRangeDropdown: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -45,6 +46,10 @@ class TableComponent {
     this.approveButton = this.page.getByRole('button', { name: 'Approve' });
     this.calendar = this.page.getByLabel('Choose Date');
     this.datePicker = this.page.getByLabel('Choose Date').locator('tbody');
+    this.datePickerRangeDropdown = this.page
+      .getByRole('dialog')
+      .getByRole('combobox')
+      .first();
   }
 
   async getCell(row: number, column: number) {
@@ -205,9 +210,11 @@ class TableComponent {
   async filterColumnByDate({
     columnName,
     day,
+    range = 'Date',
   }: {
     columnName: string;
     day: number;
+    range?: string;
   }) {
     const filterMenuButton = this.table
       .getByRole('columnheader', { name: columnName })
@@ -216,6 +223,10 @@ class TableComponent {
     await filterMenuButton.scrollIntoViewIfNeeded();
     await filterMenuButton.click();
 
+    await this.datePickerRangeDropdown.click();
+    await this.page.getByRole('option', { name: range }).click();
+
+    await this.page.locator('input[type="text"]').click();
     await this.datePicker.getByText(`${day}`, { exact: true }).first().click();
 
     await this.applyFiltersButton.click();
@@ -323,6 +334,12 @@ class TableComponent {
       .locator('app-form-error')
       .filter({ hasText: errorMessage });
     await expect(errorElement).toContainText(errorMessage);
+  }
+
+  async assertEmptyTableState() {
+    await this.page.waitForTimeout(200);
+    await this.page.waitForSelector('table tbody tr td');
+    await expect(this.page.getByText('No results found')).toBeVisible();
   }
 }
 

--- a/e2e/portalicious/components/TableComponent.ts
+++ b/e2e/portalicious/components/TableComponent.ts
@@ -210,11 +210,11 @@ class TableComponent {
   async filterColumnByDate({
     columnName,
     day,
-    range = 'Date',
+    filterMode,
   }: {
     columnName: string;
     day: number;
-    range?: string;
+    filterMode: string;
   }) {
     const filterMenuButton = this.table
       .getByRole('columnheader', { name: columnName })
@@ -224,7 +224,7 @@ class TableComponent {
     await filterMenuButton.click();
 
     await this.datePickerRangeDropdown.click();
-    await this.page.getByRole('option', { name: range }).click();
+    await this.page.getByRole('option', { name: filterMode }).click();
 
     await this.page.locator('input[type="text"]').click();
     await this.datePicker.getByText(`${day}`, { exact: true }).first().click();

--- a/e2e/portalicious/pages/RegistrationsPage.ts
+++ b/e2e/portalicious/pages/RegistrationsPage.ts
@@ -222,7 +222,7 @@ class RegistrationsPage extends BasePage {
     expect(statusText).toBe(status);
   }
 
-  async validateRegistrationIsNotPresent() {
+  async assertEmptyTableState() {
     await this.page.waitForTimeout(200);
     await this.page.waitForSelector('table tbody tr td');
     await expect(this.page.getByText('No results found')).toBeVisible();

--- a/e2e/portalicious/pages/RegistrationsPage.ts
+++ b/e2e/portalicious/pages/RegistrationsPage.ts
@@ -222,12 +222,6 @@ class RegistrationsPage extends BasePage {
     expect(statusText).toBe(status);
   }
 
-  async assertEmptyTableState() {
-    await this.page.waitForTimeout(200);
-    await this.page.waitForSelector('table tbody tr td');
-    await expect(this.page.getByText('No results found')).toBeVisible();
-  }
-
   async goToRegistrationByName({
     registrationName,
   }: {

--- a/e2e/portalicious/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusCompleted.spec.ts
+++ b/e2e/portalicious/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusCompleted.spec.ts
@@ -69,6 +69,6 @@ test('[34411] Delete registration with status "Completed"', async ({
       columnName: 'Registration Status',
       selection: 'Completed',
     });
-    await registrations.validateRegistrationIsNotPresent();
+    await tableComponent.assertEmptyTableState();
   });
 });

--- a/e2e/portalicious/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusDeclined.spec.ts
+++ b/e2e/portalicious/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusDeclined.spec.ts
@@ -58,6 +58,6 @@ test('[34412] Delete registration with status "Declined"', async ({ page }) => {
       columnName: 'Registration Status',
       selection: 'Declined',
     });
-    await registrations.validateRegistrationIsNotPresent();
+    await tableComponent.assertEmptyTableState();
   });
 });

--- a/e2e/portalicious/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusIncluded.spec.ts
+++ b/e2e/portalicious/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusIncluded.spec.ts
@@ -58,6 +58,6 @@ test('[34409] Delete registration with status "Included"', async ({ page }) => {
       columnName: 'Registration Status',
       selection: 'Included',
     });
-    await registrations.validateRegistrationIsNotPresent();
+    await tableComponent.assertEmptyTableState();
   });
 });

--- a/e2e/portalicious/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusPaused.spec.ts
+++ b/e2e/portalicious/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusPaused.spec.ts
@@ -58,6 +58,6 @@ test('[34410] Delete registration with status "Paused"', async ({ page }) => {
       columnName: 'Registration Status',
       selection: 'Paused',
     });
-    await registrations.validateRegistrationIsNotPresent();
+    await tableComponent.assertEmptyTableState();
   });
 });

--- a/e2e/portalicious/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusRegistered.spec.ts
+++ b/e2e/portalicious/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusRegistered.spec.ts
@@ -60,6 +60,6 @@ test('[34408] Delete registration with status "Registered"', async ({
       columnName: 'Registration Status',
       selection: 'Registered',
     });
-    await registrations.validateRegistrationIsNotPresent();
+    await tableComponent.assertEmptyTableState();
   });
 });

--- a/e2e/portalicious/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusValidated.spec.ts
+++ b/e2e/portalicious/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusValidated.spec.ts
@@ -60,6 +60,6 @@ test('[31223] Delete registration with status "Validated"', async ({
       columnName: 'Registration Status',
       selection: 'Validated',
     });
-    await registrations.validateRegistrationIsNotPresent();
+    await tableComponent.assertEmptyTableState();
   });
 });

--- a/e2e/portalicious/tests/ViewFilterAndSortRegistrations/FilterRegistrationsByDate.spec.ts
+++ b/e2e/portalicious/tests/ViewFilterAndSortRegistrations/FilterRegistrationsByDate.spec.ts
@@ -50,7 +50,7 @@ test('[34947] Filter registrations by Date selection', async ({ page }) => {
     await tableComponent.filterColumnByDate({
       columnName: 'Registration created',
       day,
-      range: 'Equals',
+      filterMode: 'Equals',
     });
     await tableComponent.validateAllRecordsCount(4);
     await tableComponent.clearAllFilters();
@@ -60,7 +60,7 @@ test('[34947] Filter registrations by Date selection', async ({ page }) => {
       await tableComponent.filterColumnByDate({
         columnName: 'Registration created',
         day: diffDay,
-        range: 'Equals',
+        filterMode: 'Equals',
       });
     }
     await tableComponent.assertEmptyTableState();
@@ -72,7 +72,7 @@ test('[34947] Filter registrations by Date selection', async ({ page }) => {
     await tableComponent.filterColumnByDate({
       columnName: 'Registration created',
       day,
-      range: 'Less than',
+      filterMode: 'Less than',
     });
     await tableComponent.assertEmptyTableState();
     await tableComponent.clearAllFilters();
@@ -83,7 +83,7 @@ test('[34947] Filter registrations by Date selection', async ({ page }) => {
     await tableComponent.filterColumnByDate({
       columnName: 'Registration created',
       day,
-      range: 'Greater than',
+      filterMode: 'Greater than',
     });
     await tableComponent.assertEmptyTableState();
   });

--- a/e2e/portalicious/tests/ViewFilterAndSortRegistrations/FilterRegistrationsByDate.spec.ts
+++ b/e2e/portalicious/tests/ViewFilterAndSortRegistrations/FilterRegistrationsByDate.spec.ts
@@ -14,7 +14,6 @@ import {
 
 import TableComponent from '@121-e2e/portalicious/components/TableComponent';
 import LoginPage from '@121-e2e/portalicious/pages/LoginPage';
-import RegistrationsPage from '@121-e2e/portalicious/pages/RegistrationsPage';
 
 // Get current date information
 const currentDate = new Date();
@@ -44,24 +43,48 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('[34947] Filter registrations by Date selection', async ({ page }) => {
-  const registrations = new RegistrationsPage(page);
   const tableComponent = new TableComponent(page);
   // Act & Assert
-  await test.step('Filter registrations columns by date', async () => {
+  await test.step('Filter registration created column by "Equals" date', async () => {
     // Filter Registration column by date
     await tableComponent.filterColumnByDate({
       columnName: 'Registration created',
       day,
+      range: 'Equals',
     });
     await tableComponent.validateAllRecordsCount(4);
+    await tableComponent.clearAllFilters();
     // Filter by different date
     const diffDay = currentDate.getDate() === 1 ? 2 : 1;
     if (diffDay !== undefined) {
       await tableComponent.filterColumnByDate({
         columnName: 'Registration created',
         day: diffDay,
+        range: 'Equals',
       });
     }
-    await registrations.validateRegistrationIsNotPresent();
+    await tableComponent.assertEmptyTableState();
+    await tableComponent.clearAllFilters();
+  });
+
+  await test.step('Filter registration created column by "Less than" date', async () => {
+    // Filter Registration column by date
+    await tableComponent.filterColumnByDate({
+      columnName: 'Registration created',
+      day,
+      range: 'Less than',
+    });
+    await tableComponent.assertEmptyTableState();
+    await tableComponent.clearAllFilters();
+  });
+
+  await test.step('Filter registration created column by "Greater than" date', async () => {
+    // Filter Registration column by date
+    await tableComponent.filterColumnByDate({
+      columnName: 'Registration created',
+      day,
+      range: 'Greater than',
+    });
+    await tableComponent.assertEmptyTableState();
   });
 });

--- a/e2e/portalicious/tests/ViewFilterAndSortRegistrations/FilterRegistrationsByDropdownSelection.spec.ts
+++ b/e2e/portalicious/tests/ViewFilterAndSortRegistrations/FilterRegistrationsByDropdownSelection.spec.ts
@@ -51,7 +51,7 @@ test('[34946] Filter registrations by dropdown selection', async ({ page }) => {
       columnName: 'Status',
       selection: 'Registered',
     });
-    await registrations.validateRegistrationIsNotPresent();
+    await tableComponent.assertEmptyTableState();
     await tableComponent.clearAllFilters();
   });
 


### PR DESCRIPTION
[AB#35094](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/35094) <!--- Replace this with a reference to a devops issue -->

## Describe your changes

Adds additional test steps for existing e2e tests "Filter by date" to allocate advanced filtering: Equals, less then, more then etc.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or adding tests is unnecessary/irrelevant
- [ ] I have asked the design team to review these changes, or the changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
