### PR TITLE
feat: default sort by registrationProgramId -> descending in registrations table

### DIFF
--- a/e2e/portalicious/tests/DoPayment/ShowPaymentSummary.spec.ts
+++ b/e2e/portalicious/tests/DoPayment/ShowPaymentSummary.spec.ts
@@ -34,8 +34,8 @@ test('[31971] Show payment summary', async ({ page }) => {
 
   const projectTitle = 'NLRC OCW Program';
   const financialServiceProviders: string[] = [
-    'Visa debit card',
     'Albert Heijn voucher WhatsApp',
+    'Visa debit card',
   ];
   const numberOfPas = registrationsOCW.length;
   const defaultTransferValue = NLRCProgram.fixedTransferValue;

--- a/interfaces/Portalicious/eslint.config.mjs
+++ b/interfaces/Portalicious/eslint.config.mjs
@@ -131,7 +131,6 @@ export default tsEslint.config(
         {
           checkId: false,
           ignoreAttributes: [
-            'app-query-table[localStorageKey]',
             'data-testid',
             'field',
             'img[ngSrc]',
@@ -166,6 +165,8 @@ export default tsEslint.config(
             'app-import-file-dialog[accept]',
             'app-metric-tile[chipIcon]',
             'app-metric-tile[chipVariant]',
+            'app-query-table[localStorageKey]',
+            'app-query-table[initialSortField]',
             'iframe[referrerpolicy]',
             'iframe[loading]',
             'iframe[sandbox]',

--- a/interfaces/Portalicious/src/app/components/registrations-table/registrations-table.component.html
+++ b/interfaces/Portalicious/src/app/components/registrations-table/registrations-table.component.html
@@ -11,6 +11,8 @@
   [contextMenuItems]="contextMenuItems()"
   (updateContextMenuItem)="contextMenuRegistration.set($event)"
   [enableColumnManagement]="true"
+  initialSortField="registrationProgramId"
+  [initialSortOrder]="-1"
 >
   <div table-actions>
     @if (showSelectionInHeader()) {


### PR DESCRIPTION
[AB#35373](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/35373)

I haven't asked design for a review, even though it affects the UI, because this is using an existing design pattern which was already used on other pages.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or adding tests is unnecessary/irrelevant
- [ ] I have asked the design team to review these changes, or the changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6740.westeurope.5.azurestaticapps.net
