### PR TITLE
ci: Make downloading translations configurable from the ENV-variables in GitHub-environments

### DIFF
--- a/.github/actions/build-interface/action.yml
+++ b/.github/actions/build-interface/action.yml
@@ -77,7 +77,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.interfacePath }}
       env:
-        NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: true
+        # Only if NG_DOWNLOAD_TRANSLATIONS_AT_BUILD is explicitly set to 'false', it will be set to 'false'. Otherwise it will be set to 'true'.
+        NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ env.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD == 'false' && 'false' || 'true' }}
         LOKALISE_PROJECT_ID: ${{ env.LOKALISE_PROJECT_ID }}
         LOKALISE_API_TOKEN: ${{ env.LOKALISE_API_TOKEN }}
       run: |

--- a/.github/workflows/deploy_client-benin_portal.yml
+++ b/.github/workflows/deploy_client-benin_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-demo_portal.yml
+++ b/.github/workflows/deploy_client-demo_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-drc_portal.yml
+++ b/.github/workflows/deploy_client-drc_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-eswatini_portal.yml
+++ b/.github/workflows/deploy_client-eswatini_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-ethiopia_portal.yml
+++ b/.github/workflows/deploy_client-ethiopia_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-greece_portal.yml
+++ b/.github/workflows/deploy_client-greece_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-ivorycoast_portal.yml
+++ b/.github/workflows/deploy_client-ivorycoast_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-jrethiopia_portal.yml
+++ b/.github/workflows/deploy_client-jrethiopia_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-krcs_portal.yml
+++ b/.github/workflows/deploy_client-krcs_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-nigeria_portal.yml
+++ b/.github/workflows/deploy_client-nigeria_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-nlrc_portalicious.yml
+++ b/.github/workflows/deploy_client-nlrc_portalicious.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-slovakia_portal.yml
+++ b/.github/workflows/deploy_client-slovakia_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-somalia_portal.yml
+++ b/.github/workflows/deploy_client-somalia_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-southafrica_portal.yml
+++ b/.github/workflows/deploy_client-southafrica_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-sudan_portal.yml
+++ b/.github/workflows/deploy_client-sudan_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-togo_portal.yml
+++ b/.github/workflows/deploy_client-togo_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-training_portal.yml
+++ b/.github/workflows/deploy_client-training_portal.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-zambia_portal.yml
+++ b/.github/workflows/deploy_client-zambia_portal.yml
@@ -46,6 +46,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_staging_portalicious.yml
+++ b/.github/workflows/deploy_staging_portalicious.yml
@@ -47,6 +47,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_test_portalicious.yml
+++ b/.github/workflows/deploy_test_portalicious.yml
@@ -64,6 +64,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/test_e2e_portalicious.yml
+++ b/.github/workflows/test_e2e_portalicious.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           NG_PRODUCTION: true
           NG_URL_121_SERVICE_API: http://localhost:3000/api
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: true
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         run: |

--- a/interfaces/Portalicious/.knip.json
+++ b/interfaces/Portalicious/.knip.json
@@ -3,7 +3,12 @@
   "angular": {
     "config": ["angular.json"]
   },
-  "entry": ["index.{js,ts}", "src/index.{js,ts}", "src/logout/logout.js"],
+  "entry": [
+    "index.{js,ts}",
+    "src/index.{js,ts}",
+    "src/logout/logout.js",
+    "./_env.utils.spec.ts"
+  ],
   "project": ["**/*.{js,ts}"],
   "rules": {
     "dependencies": "warn",

--- a/interfaces/Portalicious/.vscode/extensions.json
+++ b/interfaces/Portalicious/.vscode/extensions.json
@@ -1,17 +1,18 @@
 {
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=827846
   "recommendations": [
+    "aar.xlf-editor",
     "angular.ng-template",
     "ban.spellright",
     "bradlc.vscode-tailwindcss",
     "dotiful.dotfiles-syntax-highlighting",
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
+    "lucono.karma-test-explorer",
     "ms-azuretools.vscode-azureappservice",
     "ms-azuretools.vscode-azureresourcegroups",
     "ms-azuretools.vscode-azurestaticwebapps",
     "ms-vscode.azure-account",
-    "tombonnike.vscode-status-bar-format-toggle",
-    "aar.xlf-editor"
+    "tombonnike.vscode-status-bar-format-toggle"
   ]
 }

--- a/interfaces/Portalicious/_build-deployment-configuration.mjs
+++ b/interfaces/Portalicious/_build-deployment-configuration.mjs
@@ -6,6 +6,7 @@
 
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 
+import { shouldBeEnabled } from './_env.utils.mjs';
 import { parseMatomoConnectionString } from './_matomo.utils.mjs';
 
 // Set up specifics
@@ -59,7 +60,7 @@ if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
 }
 
 // Optional: Azure Entra SSO
-if (process.env.USE_SSO_AZURE_ENTRA === 'true') {
+if (shouldBeEnabled(process.env.USE_SSO_AZURE_ENTRA)) {
   console.info('✅ Allow use of Azure Entra endpoints and iframe(s)');
 
   let connectSrc = contentSecurityPolicy.get('connect-src') ?? [];
@@ -76,7 +77,7 @@ if (process.env.USE_SSO_AZURE_ENTRA === 'true') {
 }
 
 // Optional: Twilio Flex
-if (process.env.USE_IN_TWILIO_FLEX_IFRAME === 'true') {
+if (shouldBeEnabled(process.env.USE_IN_TWILIO_FLEX_IFRAME)) {
   console.info('✅ Allow loading the Portal in an iframe on Twilio Flex');
 
   let frameAncestors = contentSecurityPolicy.get('frame-ancestors') ?? [];
@@ -88,8 +89,8 @@ if (process.env.USE_IN_TWILIO_FLEX_IFRAME === 'true') {
 
 // Depending on: Using "Azure Entra SSO" AND "Twilio Flex"
 if (
-  process.env.USE_SSO_AZURE_ENTRA === 'true' &&
-  process.env.USE_IN_TWILIO_FLEX_IFRAME === 'true'
+  shouldBeEnabled(process.env.USE_SSO_AZURE_ENTRA) &&
+  shouldBeEnabled(process.env.USE_IN_TWILIO_FLEX_IFRAME)
 ) {
   console.info(
     '✅ Allow control of pop-ups for SSO when the Portal is in an iframe on Twilio Flex',
@@ -99,7 +100,7 @@ if (
 }
 
 // Optional: PowerBI Dashboard(s)
-if (process.env.USE_POWERBI_DASHBOARDS === 'true') {
+if (shouldBeEnabled(process.env.USE_POWERBI_DASHBOARDS)) {
   console.info('✅ Allow loading Power BI-dashboards');
 
   let frameSrc = contentSecurityPolicy.get('frame-src') ?? [];
@@ -142,7 +143,7 @@ const contentSecurityPolicyValue = Array.from(contentSecurityPolicy)
   .join(' ; ');
 
 // Set the Content-Security-Policy header-value
-if (process.env.DEBUG) {
+if (shouldBeEnabled(process.env.DEBUG)) {
   console.log(`Content-Security-Policy: "${contentSecurityPolicyValue}"`);
 }
 swaConfig.globalHeaders['Content-Security-Policy'] = contentSecurityPolicyValue;

--- a/interfaces/Portalicious/_build-deployment-configuration.mjs
+++ b/interfaces/Portalicious/_build-deployment-configuration.mjs
@@ -5,6 +5,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'fs';
+
 import { parseMatomoConnectionString } from './_matomo.utils.mjs';
 
 // Set up specifics
@@ -25,8 +26,8 @@ if (!swaConfig.globalHeaders) {
 
 // NOTE: All values in each array are written as template-strings, as the use of single-quotes around some values (i.e. 'self') is mandatory and will affect the working of the HTTP-Header.
 let contentSecurityPolicy = new Map([
-  ['default-src', [`'self'`]],
   ['connect-src', [`'self'`]],
+  ['default-src', [`'self'`]],
   ['frame-ancestors', [`'self'`]],
   ['frame-src', [`blob:`, `'self'`]],
   ['img-src', [`data:`, `'self'`]],

--- a/interfaces/Portalicious/_build-download-translations.mjs
+++ b/interfaces/Portalicious/_build-download-translations.mjs
@@ -3,6 +3,7 @@
 import { LokaliseDownload } from 'lokalise-file-exchange';
 import { accessSync, constants, writeFileSync } from 'node:fs';
 
+import { shouldBeEnabled } from './_env.utils.mjs';
 import {
   createMockTranslations,
   getRequiredTranslations,
@@ -18,7 +19,7 @@ import {
 const requiredTranslations = getRequiredTranslations();
 console.log('Required translations: ', requiredTranslations);
 
-if (!process.env.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD) {
+if (!shouldBeEnabled(process.env.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD)) {
   console.info('Skipping download of translations. Creating mocks instead.');
   for (const lang of requiredTranslations) {
     const filePath = getTranslationFilePath(lang);

--- a/interfaces/Portalicious/_build-download-translations.mjs
+++ b/interfaces/Portalicious/_build-download-translations.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
-import { accessSync, constants, writeFileSync } from 'node:fs';
+
 import { LokaliseDownload } from 'lokalise-file-exchange';
+import { accessSync, constants, writeFileSync } from 'node:fs';
+
 import {
+  createMockTranslations,
   getRequiredTranslations,
   getTranslationFilePath,
-  createMockTranslations,
 } from './_translations.utils.mjs';
 
 /**
@@ -20,13 +22,16 @@ if (!process.env.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD) {
   console.info('Skipping download of translations. Creating mocks instead.');
   for (const lang of requiredTranslations) {
     const filePath = getTranslationFilePath(lang);
+
     writeFileSync(
       filePath,
       // Use the most minimal, yet valid XLIFF file:
       createMockTranslations(lang),
     );
+
     console.info(`☑️  Mock created: ${filePath}`);
   }
+
   process.exit(0);
 }
 
@@ -44,14 +49,14 @@ const lokaliseDownloader = new LokaliseDownload(
   },
 );
 await lokaliseDownloader.downloadTranslations({
-  processDownloadFileParams: {
-    asyncDownload: true,
-  },
   downloadFileParams: {
-    format: 'xlf',
-    original_filenames: false,
     bundle_structure: 'src/locale/messages.%LANG_ISO%.%FORMAT%',
     export_empty_as: 'skip',
+    format: 'xlf',
+    original_filenames: false,
+  },
+  processDownloadFileParams: {
+    asyncDownload: true,
   },
 });
 console.info(`Download done ✅`);
@@ -61,7 +66,9 @@ console.info(`Download done ✅`);
 console.info(`Verify required translations have been downloaded...`);
 for (const lang of requiredTranslations) {
   const filePath = getTranslationFilePath(lang);
+
   accessSync(filePath, constants.R_OK);
+
   console.info(`✅ Translations downloaded: ${filePath}`);
 }
 

--- a/interfaces/Portalicious/_build-manual-logout.mjs
+++ b/interfaces/Portalicious/_build-manual-logout.mjs
@@ -5,11 +5,11 @@
  */
 
 import {
+  copyFileSync,
   existsSync,
   mkdirSync,
   readFileSync,
   writeFileSync,
-  copyFileSync,
 } from 'fs';
 
 // Set up specifics

--- a/interfaces/Portalicious/_env.utils.mjs
+++ b/interfaces/Portalicious/_env.utils.mjs
@@ -1,0 +1,19 @@
+/**
+ * Determines if a given environment variable/"feature flag" should be considered enabled.
+ *
+ * @param {string | undefined} envVariable - The environment variable to check.
+ * @returns {boolean} - Returns `true` if the environment variable matches any of the enabled values, otherwise `false`.
+ */
+export const shouldBeEnabled = (envVariable) => {
+  const enabledValues = [
+    'true',
+    '1',
+    'y',
+    'yes',
+    'yep',
+    'on',
+    'enabled',
+    'enable',
+  ];
+  return !!envVariable && enabledValues.includes(envVariable.toLowerCase());
+};

--- a/interfaces/Portalicious/_env.utils.spec.ts
+++ b/interfaces/Portalicious/_env.utils.spec.ts
@@ -1,0 +1,66 @@
+import { shouldBeEnabled } from '_env.utils.mjs';
+
+describe('Utils: shouldBeEnabled', () => {
+  it('should return a boolean true for select ENV-variable values', () => {
+    // Arrange
+    const testValues = [
+      '1',
+      'enable',
+      'Enable',
+      'enabled',
+      'Enabled',
+      'on',
+      'On',
+      'true',
+      'True',
+      'TRUE',
+      'y',
+      'Y',
+      'yep',
+      'yes',
+      'Yes',
+      'YES',
+    ];
+
+    // Act
+    testValues.forEach((value) => {
+      const result = shouldBeEnabled(value);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+  });
+
+  it('should return a boolean false for other possible ENV-variable values', () => {
+    // Arrange
+    const testValues = [
+      ' ',
+      '!',
+      '!true',
+      '?',
+      '',
+      '[]',
+      '0',
+      'disable',
+      'disabled',
+      'false',
+      'FALSE',
+      'n',
+      'no',
+      'No',
+      'nope',
+      'null',
+      'off',
+      'random value',
+      'undefined',
+    ];
+
+    // Act
+    testValues.forEach((value) => {
+      const result = shouldBeEnabled(value);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/interfaces/Portalicious/_matomo.utils.mjs
+++ b/interfaces/Portalicious/_matomo.utils.mjs
@@ -4,8 +4,8 @@
  */
 export const parseMatomoConnectionString = (connectionString) => {
   const connection = {
-    id: '',
     api: '',
+    id: '',
     sdk: '',
   };
 

--- a/interfaces/Portalicious/_set-env-variables.mjs
+++ b/interfaces/Portalicious/_set-env-variables.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { writeFile } from 'fs';
+
 import configFileTemplate from './src/environments/environment.ts.template.mjs';
 
 let targetEnv = 'production';

--- a/interfaces/Portalicious/_set-env-variables.mjs
+++ b/interfaces/Portalicious/_set-env-variables.mjs
@@ -2,6 +2,7 @@
 
 import { writeFile } from 'fs';
 
+import { shouldBeEnabled } from './_env.utils.mjs';
 import configFileTemplate from './src/environments/environment.ts.template.mjs';
 
 let targetEnv = 'production';
@@ -14,7 +15,7 @@ if (process.argv[2] === 'env=development') {
 const targetPath = `./src/environments/environment.${targetEnv}.ts`;
 
 writeFile(targetPath, configFileTemplate, (err) => {
-  if (process.env.DEBUG || process.env.CI) {
+  if (shouldBeEnabled(process.env.DEBUG) || shouldBeEnabled(process.env.CI)) {
     console.log(configFileTemplate);
   }
 

--- a/interfaces/Portalicious/_test-deployment-configuration.mjs
+++ b/interfaces/Portalicious/_test-deployment-configuration.mjs
@@ -8,6 +8,7 @@ import { doesNotMatch, match, ok } from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { shouldBeEnabled } from './_env.utils.mjs';
 import { parseMatomoConnectionString } from './_matomo.utils.mjs';
 
 const swaConfig = JSON.parse(
@@ -55,7 +56,7 @@ test('Content-Security-Policy configuration for Azure Entra SSO', () => {
   const frameSrcCondition =
     /frame-src[^;]* https:\/\/login\.microsoftonline\.com/;
 
-  if (process.env.USE_SSO_AZURE_ENTRA === 'true') {
+  if (shouldBeEnabled(process.env.USE_SSO_AZURE_ENTRA)) {
     match(csp, connectSrcCondition);
     match(csp, frameSrcCondition);
   } else {
@@ -68,7 +69,7 @@ test('Content-Security-Policy configuration for loading as iframe in Twilio Flex
   const frameAncestorsCondition =
     /frame-ancestors[^;]* https:\/\/flex\.twilio\.com/;
 
-  if (process.env.USE_IN_TWILIO_FLEX_IFRAME === 'true') {
+  if (shouldBeEnabled(process.env.USE_IN_TWILIO_FLEX_IFRAME)) {
     match(csp, frameAncestorsCondition);
   } else {
     doesNotMatch(csp, frameAncestorsCondition);
@@ -79,8 +80,8 @@ test('Configuration to control pop-ups for SSO when the Portal is in an iframe o
   const openerPolicy = swaConfig.globalHeaders['Cross-Origin-Opener-Policy'];
 
   if (
-    process.env.USE_IN_TWILIO_FLEX_IFRAME === 'true' &&
-    process.env.USE_SSO_AZURE_ENTRA === 'true'
+    shouldBeEnabled(process.env.USE_IN_TWILIO_FLEX_IFRAME) &&
+    shouldBeEnabled(process.env.USE_SSO_AZURE_ENTRA)
   ) {
     match(openerPolicy, /unsafe-none/);
   } else {
@@ -91,7 +92,7 @@ test('Configuration to control pop-ups for SSO when the Portal is in an iframe o
 test('Content-Security-Policy configuration to load PowerBI dashboard(s) in iframe', () => {
   const frameSrcCondition = /frame-src[^;]* https:\/\/app\.powerbi\.com/;
 
-  if (process.env.USE_POWERBI_DASHBOARDS === 'true') {
+  if (shouldBeEnabled(process.env.USE_POWERBI_DASHBOARDS)) {
     match(csp, frameSrcCondition);
   } else {
     doesNotMatch(csp, frameSrcCondition);

--- a/interfaces/Portalicious/_test-deployment-configuration.mjs
+++ b/interfaces/Portalicious/_test-deployment-configuration.mjs
@@ -4,9 +4,10 @@
  * See the "Deployment"-section of the interfaces/README.md-file for more information.
  */
 
-import test from 'node:test';
-import { ok, match, doesNotMatch } from 'node:assert/strict';
+import { doesNotMatch, match, ok } from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
 import { parseMatomoConnectionString } from './_matomo.utils.mjs';
 
 const swaConfig = JSON.parse(

--- a/interfaces/Portalicious/_verify-build.mjs
+++ b/interfaces/Portalicious/_verify-build.mjs
@@ -4,6 +4,7 @@ import { match, notEqual } from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { shouldBeEnabled } from './_env.utils.mjs';
 import {
   createMockTranslations,
   getRequiredTranslations,
@@ -17,7 +18,7 @@ console.log('Required translations: ', requiredTranslations);
 
 test(
   'Translations do not contain mock-value',
-  { skip: !process.env.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD },
+  { skip: !shouldBeEnabled(process.env.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD) },
   () => {
     requiredTranslations.forEach((lang) => {
       const filePath = getTranslationFilePath(lang);
@@ -35,7 +36,7 @@ test(
 
 test(
   'Translations are downloaded',
-  { skip: !process.env.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD },
+  { skip: !shouldBeEnabled(process.env.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD) },
   () => {
     const validTranslations = {
       ar: 'رسالة مخصصة',

--- a/interfaces/Portalicious/_verify-build.mjs
+++ b/interfaces/Portalicious/_verify-build.mjs
@@ -3,6 +3,7 @@
 import { match, notEqual } from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
+
 import {
   createMockTranslations,
   getRequiredTranslations,

--- a/interfaces/Portalicious/_verify-deployment-configuration.mjs
+++ b/interfaces/Portalicious/_verify-deployment-configuration.mjs
@@ -7,6 +7,7 @@
 import { doesNotMatch, match, ok } from 'node:assert/strict';
 import test from 'node:test';
 
+import { shouldBeEnabled } from './_env.utils.mjs';
 import { parseMatomoConnectionString } from './_matomo.utils.mjs';
 
 const url = process.argv[2]?.replace('--url=', '');
@@ -60,7 +61,7 @@ test('Content-Security-Policy set for Azure Entra SSO', () => {
   const frameSrcCondition =
     /frame-src[^;]* https:\/\/login\.microsoftonline\.com/;
 
-  if (process.env.USE_SSO_AZURE_ENTRA === 'true') {
+  if (shouldBeEnabled(process.env.USE_SSO_AZURE_ENTRA)) {
     match(csp, connectSrcCondition);
     match(csp, frameSrcCondition);
   } else {
@@ -73,7 +74,7 @@ test('Content-Security-Policy set for loading as iframe in Twilio Flex', () => {
   const frameAncestorsCondition =
     /frame-ancestors[^;]* https:\/\/flex\.twilio\.com/;
 
-  if (process.env.USE_IN_TWILIO_FLEX_IFRAME === 'true') {
+  if (shouldBeEnabled(process.env.USE_IN_TWILIO_FLEX_IFRAME)) {
     match(csp, frameAncestorsCondition);
   } else {
     doesNotMatch(csp, frameAncestorsCondition);
@@ -84,8 +85,8 @@ test('Configuration set to control pop-ups for SSO when the Portal is in an ifra
   const openerPolicy = response.headers.get('Cross-Origin-Opener-Policy') ?? '';
 
   if (
-    process.env.USE_IN_TWILIO_FLEX_IFRAME === 'true' &&
-    process.env.USE_SSO_AZURE_ENTRA === 'true'
+    shouldBeEnabled(process.env.USE_IN_TWILIO_FLEX_IFRAME) &&
+    shouldBeEnabled(process.env.USE_SSO_AZURE_ENTRA)
   ) {
     match(openerPolicy, /unsafe-none/);
   } else {
@@ -96,7 +97,7 @@ test('Configuration set to control pop-ups for SSO when the Portal is in an ifra
 test('Content-Security-Policy set to load PowerBI dashboard(s) in iframe', () => {
   const frameSrcCondition = /frame-src[^;]* https:\/\/app\.powerbi\.com/;
 
-  if (process.env.USE_POWERBI_DASHBOARDS === 'true') {
+  if (shouldBeEnabled(process.env.USE_POWERBI_DASHBOARDS)) {
     match(csp, frameSrcCondition);
   } else {
     doesNotMatch(csp, frameSrcCondition);

--- a/interfaces/Portalicious/_verify-deployment-configuration.mjs
+++ b/interfaces/Portalicious/_verify-deployment-configuration.mjs
@@ -4,8 +4,9 @@
  * See the "Deployment"-section of the interfaces/README.md-file for more information.
  */
 
+import { doesNotMatch, match, ok } from 'node:assert/strict';
 import test from 'node:test';
-import { ok, match, doesNotMatch } from 'node:assert/strict';
+
 import { parseMatomoConnectionString } from './_matomo.utils.mjs';
 
 const url = process.argv[2]?.replace('--url=', '');

--- a/interfaces/Portalicious/angular.json
+++ b/interfaces/Portalicious/angular.json
@@ -177,7 +177,10 @@
               "@angular/localize/init"
             ],
             "tsConfig": "tsconfig.spec.json",
+            "include": ["src/**/*.spec.ts", "../*.spec.ts"],
             "inlineStyleLanguage": "scss",
+            "codeCoverage": true,
+            "progress": true,
             "assets": [
               {
                 "glob": "**/*",

--- a/interfaces/Portalicious/package.json
+++ b/interfaces/Portalicious/package.json
@@ -20,7 +20,7 @@
     "watch": "ng build --watch --configuration=development",
     "lint": "ng lint",
     "fix": "ng lint --fix",
-    "test:all": "npm run lint && npm run typecheck && npm test && npm run extract-i18n",
+    "test:all": "npm run knip && npm run lint && npm run typecheck && npm test && npm run extract-i18n",
     "test:deployment-configuration": "node --env-file=.env ./_test-deployment-configuration.mjs",
     "test:ci": "npm test -- --no-watch --no-progress --browsers=ChromeHeadless",
     "test": "ng test",

--- a/interfaces/Portalicious/tsconfig.spec.json
+++ b/interfaces/Portalicious/tsconfig.spec.json
@@ -6,5 +6,5 @@
     "outDir": "./out-tsc/spec",
     "types": ["jasmine", "@angular/localize"]
   },
-  "include": ["src/**/*.spec.ts"]
+  "include": ["src/**/*.spec.ts", "./*.spec.ts"] // NOTE: This must be 'in-syc' (but NOT exactly the same) with the "test"-section in angular.json
 }


### PR DESCRIPTION
[AB#35431](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/35431)

## Describe your changes

This will give us the option to "bypass" the blocking build-step where the Translations are downloaded from Lokalise.

This would help to get around Lokalise API-performance/availability issues; So we won't be blocked by it....

It does have the downside that the translations on the test-environment/preview-builds won't work... So its only an emergency-escape-hatch for special occasions...

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6753.westeurope.5.azurestaticapps.net
