### PR TITLE
fix: currency defaulting to EUR

### DIFF
--- a/.github/workflows/test_pull_request_formatting.yml
+++ b/.github/workflows/test_pull_request_formatting.yml
@@ -60,10 +60,10 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Check that no "XXX" comments have been left on the PR
+      - name: Check that no "XXX:" comments have been left on the PR
         run: |
-          echo "The following files contain 'XXX' comments that should be removed:"
-          ! grep -RI --exclude-dir=.git --exclude=\*.{json,md,xml,nvmrc} --exclude=test_pull_request_formatting.yml "XXX" .
+          echo "The following files contain 'XXX:' comments that should be removed:"
+          ! grep -RI --exclude-dir=.git --exclude=\*.{json,md,xml,nvmrc} --exclude=test_pull_request_formatting.yml "XXX:" .
 
       - name: Check that no "##TODO" comments have been left on the PR
         run: |

--- a/interfaces/Portalicious/src/app/app.config.ts
+++ b/interfaces/Portalicious/src/app/app.config.ts
@@ -5,6 +5,7 @@ import {
 } from '@angular/common/http';
 import {
   ApplicationConfig,
+  DEFAULT_CURRENCY_CODE,
   LOCALE_ID,
   provideExperimentalZonelessChangeDetection,
 } from '@angular/core';
@@ -74,5 +75,6 @@ export const getAppConfig = (locale: Locale): ApplicationConfig => ({
     ...TrackingService.APP_PROVIDERS,
     { provide: TitleStrategy, useClass: CustomPageTitleStrategy },
     { provide: LOCALE_ID, useValue: locale },
+    { provide: DEFAULT_CURRENCY_CODE, useValue: 'XXX' },
   ],
 });

--- a/interfaces/Portalicious/src/app/components/data-list/data-list.component.html
+++ b/interfaces/Portalicious/src/app/components/data-list/data-list.component.html
@@ -41,7 +41,7 @@
                 {{
                   item.value
                     | currency
-                      : item.currencyCode ?? 'EUR'
+                      : item.currencyCode ?? undefined
                       : 'symbol-narrow'
                       : item.currencyFormat
                 }}

--- a/interfaces/Portalicious/src/app/pages/project-monitoring/project-monitoring.page.html
+++ b/interfaces/Portalicious/src/app/pages/project-monitoring/project-monitoring.page.html
@@ -40,10 +40,7 @@
       i18n-chipTooltip
       [metricValue]="
         remainingBudget()
-          | currency
-            : project.data()?.currency ?? 'EUR'
-            : 'symbol-narrow'
-            : '1.0-0'
+          | currency: project.data()?.currency : 'symbol-narrow' : '1.0-0'
       "
       metricLabel="Remaining budget"
       data-testid="metric-remaining-budget"
@@ -58,10 +55,7 @@
         latestPaymentAmount
           ? '+ ' +
             (latestPaymentAmount
-              | currency
-                : project.data()?.currency ?? 'EUR'
-                : 'symbol-narrow'
-                : '1.0-0')
+              | currency: project.data()?.currency : 'symbol-narrow' : '1.0-0')
           : '—'
       "
       chipIcon="pi pi-money-bill"
@@ -70,10 +64,7 @@
       chipVariant="blue"
       [metricValue]="
         metrics.data()?.spentMoney
-          | currency
-            : project.data()?.currency ?? 'EUR'
-            : 'symbol-narrow'
-            : '1.0-0'
+          | currency: project.data()?.currency : 'symbol-narrow' : '1.0-0'
       "
       metricLabel="Cash disbursed"
       data-testid="metric-cash-disbursed"

--- a/interfaces/Portalicious/src/app/pages/project-payment/project-payment.page.ts
+++ b/interfaces/Portalicious/src/app/pages/project-payment/project-payment.page.ts
@@ -166,7 +166,7 @@ export class ProjectPaymentPageComponent {
     return (
       this.currencyPipe.transform(
         totalAmount,
-        this.project.data()?.currency ?? 'EUR',
+        this.project.data()?.currency,
         'symbol-narrow',
         '1.2-2',
       ) ?? '0'
@@ -181,7 +181,7 @@ export class ProjectPaymentPageComponent {
     return (
       this.currencyPipe.transform(
         this.payment.data().success.amount,
-        this.project.data()?.currency ?? 'EUR',
+        this.project.data()?.currency,
         'symbol-narrow',
         '1.0-0',
       ) ?? '0'
@@ -244,7 +244,7 @@ export class ProjectPaymentPageComponent {
         getCellText: (transaction) =>
           this.currencyPipe.transform(
             transaction.amount,
-            this.project.data()?.currency ?? 'EUR',
+            this.project.data()?.currency,
             'symbol-narrow',
             '1.2-2',
           ) ?? '',

--- a/interfaces/Portalicious/src/app/pages/project-payments/components/create-payment/create-payment.component.ts
+++ b/interfaces/Portalicious/src/app/pages/project-payments/components/create-payment/create-payment.component.ts
@@ -258,7 +258,7 @@ export class CreatePaymentComponent {
         label: $localize`Total payment amount`,
         value: this.currencyPipe.transform(
           this.paymentAmount() * dryRunResult.sumPaymentAmountMultiplier,
-          this.project.data()?.currency ?? 'EUR',
+          this.project.data()?.currency,
           'symbol-narrow',
           '1.2-2',
         ),

--- a/interfaces/Portalicious/src/app/pages/project-payments/components/payment-summary-card/payment-summary-card.component.ts
+++ b/interfaces/Portalicious/src/app/pages/project-payments/components/payment-summary-card/payment-summary-card.component.ts
@@ -111,7 +111,7 @@ export class PaymentSummaryCardComponent {
       {
         value: this.currencyPipe.transform(
           this.expectedAmount(),
-          this.project.data()?.currency ?? 'EUR',
+          this.project.data()?.currency,
           'symbol-narrow',
           '1.2-2',
         ),
@@ -125,7 +125,7 @@ export class PaymentSummaryCardComponent {
       {
         value: this.currencyPipe.transform(
           this.successAmount(),
-          this.project.data()?.currency ?? 'EUR',
+          this.project.data()?.currency,
           'symbol-narrow',
           '1.2-2',
         ),

--- a/interfaces/Portalicious/src/app/pages/project-registration-activity-log/components/activity-log-expanded-row/activity-log-expanded-row.component.ts
+++ b/interfaces/Portalicious/src/app/pages/project-registration-activity-log/components/activity-log-expanded-row/activity-log-expanded-row.component.ts
@@ -187,6 +187,7 @@ export class ActivityLogExpandedRowComponent
             label: $localize`Amount`,
             value: item.attributes.amount,
             type: 'currency',
+            currencyCode: this.context().currencyCode(),
           },
         ];
 
@@ -195,6 +196,7 @@ export class ActivityLogExpandedRowComponent
             label: $localize`Current balance`,
             value: this.intersolveVoucherBalance.data(),
             type: 'currency',
+            currencyCode: this.context().currencyCode(),
             loading: this.intersolveVoucherBalance.isLoading(),
           });
         }

--- a/interfaces/Portalicious/src/app/pages/project-registration-activity-log/project-registration-activity-log.page.ts
+++ b/interfaces/Portalicious/src/app/pages/project-registration-activity-log/project-registration-activity-log.page.ts
@@ -18,6 +18,7 @@ import {
   QueryTableComponent,
 } from '~/components/query-table/query-table.component';
 import { RegistrationPageLayoutComponent } from '~/components/registration-page-layout/registration-page-layout.component';
+import { ProjectApiService } from '~/domains/project/project.api.service';
 import { RegistrationApiService } from '~/domains/registration/registration.api.service';
 import { ACTIVITY_LOG_ITEM_TYPE_LABELS } from '~/domains/registration/registration.helper';
 import { Activity } from '~/domains/registration/registration.model';
@@ -28,6 +29,7 @@ import { TableCellOverviewComponent } from '~/pages/project-registration-activit
 export interface ActivityLogTableCellContext {
   projectId: Signal<string>;
   registrationId: Signal<string>;
+  currencyCode: Signal<string | undefined>;
   referenceId?: string;
 }
 
@@ -49,12 +51,14 @@ export class ProjectRegistrationActivityLogPageComponent {
   readonly registrationId = input.required<string>();
 
   registrationApiService = inject(RegistrationApiService);
+  projectApiService = inject(ProjectApiService);
 
   expandableRowTemplate = ActivityLogExpandedRowComponent;
   readonly tableCellContext = computed<ActivityLogTableCellContext>(() => ({
     projectId: this.projectId,
     registrationId: this.registrationId,
     referenceId: this.registration.data()?.referenceId,
+    currencyCode: this.currencyCode,
   }));
 
   registration = injectQuery(
@@ -70,6 +74,8 @@ export class ProjectRegistrationActivityLogPageComponent {
       this.registrationId,
     ),
   );
+
+  project = injectQuery(this.projectApiService.getProject(this.projectId));
 
   readonly activities = computed(() => this.activityLog.data()?.data ?? []);
 
@@ -120,4 +126,6 @@ export class ProjectRegistrationActivityLogPageComponent {
       options: this.uniqueAuthors(),
     },
   ]);
+
+  readonly currencyCode = computed(() => this.project.data()?.currency);
 }

--- a/interfaces/Portalicious/src/app/pages/project-registration-debit-cards/project-registration-debit-cards.page.ts
+++ b/interfaces/Portalicious/src/app/pages/project-registration-debit-cards/project-registration-debit-cards.page.ts
@@ -27,6 +27,7 @@ import {
   DataListItem,
 } from '~/components/data-list/data-list.component';
 import { RegistrationPageLayoutComponent } from '~/components/registration-page-layout/registration-page-layout.component';
+import { ProjectApiService } from '~/domains/project/project.api.service';
 import { RegistrationApiService } from '~/domains/registration/registration.api.service';
 import { RtlHelperService } from '~/services/rtl-helper.service';
 import { ToastService } from '~/services/toast.service';
@@ -58,6 +59,7 @@ export class ProjectRegistrationDebitCardsPageComponent {
   private readonly registrationApiService = inject(RegistrationApiService);
   private readonly toastService = inject(ToastService);
   private readonly queryClient = inject(QueryClient);
+  private readonly projectApiService = inject(ProjectApiService);
 
   registration = injectQuery(
     this.registrationApiService.getRegistrationById(
@@ -81,6 +83,8 @@ export class ProjectRegistrationDebitCardsPageComponent {
     () => (action: 'pause' | 'reissue' | 'unpause') =>
       this.currentCard()?.actions.includes(VisaCardAction[action]),
   );
+
+  project = injectQuery(this.projectApiService.getProject(this.projectId));
 
   readonly convertCentsToMainUnits = (
     value: null | number | undefined,
@@ -113,6 +117,7 @@ export class ProjectRegistrationDebitCardsPageComponent {
           this.walletWithCards.data()?.balance,
         ),
         type: 'currency',
+        currencyCode: this.currencyCode(),
       },
       {
         label: $localize`:@@debit-card-spent-this-month:Spent this month (max. EUR 150)`,
@@ -120,6 +125,7 @@ export class ProjectRegistrationDebitCardsPageComponent {
           this.walletWithCards.data()?.spentThisMonth,
         ),
         type: 'currency',
+        currencyCode: this.currencyCode(),
       },
       {
         label: $localize`:@@debit-card-issued-on:Issued on`,
@@ -232,6 +238,8 @@ export class ProjectRegistrationDebitCardsPageComponent {
       this.invalidateWalletQuery();
     },
   }));
+
+  readonly currencyCode = computed(() => this.project.data()?.currency);
 
   private invalidateWalletQuery() {
     void this.queryClient.invalidateQueries({

--- a/interfaces/Portalicious/src/app/pages/projects-overview/components/project-summary-card/project-summary-card.component.ts
+++ b/interfaces/Portalicious/src/app/pages/projects-overview/components/project-summary-card/project-summary-card.component.ts
@@ -81,7 +81,7 @@ export class ProjectSummaryCardComponent {
       {
         value: this.currencyPipe.transform(
           this.metrics.data()?.totalBudget,
-          this.project.data()?.currency ?? 'EUR',
+          this.project.data()?.currency,
           'symbol-narrow',
           '1.0-0',
         ),
@@ -90,7 +90,7 @@ export class ProjectSummaryCardComponent {
       {
         value: this.currencyPipe.transform(
           this.metrics.data()?.spentMoney,
-          this.project.data()?.currency ?? 'EUR',
+          this.project.data()?.currency,
           'symbol-narrow',
           '1.0-0',
         ),


### PR DESCRIPTION
[AB#35525](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/35525) <!--- Replace this with a reference to a devops issue -->

## Describe your changes

### What was happening
Transfer rows in `Activity log` always showed `EUR` as currency, because the actual currency wasn't added to those rows.

### What has been done
- Added the project currency to transfer rows in `Activity log` and to `Debit cards`
- Removed the fallback to `EUR` to every field using `CurrencyPipe`
- Added a global fallback to `XXX` so no currency is shown if it's missing from the Project settings

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or the changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6763.westeurope.5.azurestaticapps.net
