### PR TITLE
fix: Prevent timeout on CBE-endpoint triggered by Cronjob (to improve clarity in logs/monitoring)

### DIFF
--- a/services/121-service/src/payments/reconciliation/commercial-bank-ethiopia-reconciliation/commercial-bank-ethiopia-reconciliation.controller.ts
+++ b/services/121-service/src/payments/reconciliation/commercial-bank-ethiopia-reconciliation/commercial-bank-ethiopia-reconciliation.controller.ts
@@ -58,9 +58,13 @@ export class CommercialBankEthiopiaReconciliationController {
     console.info(
       'CronjobService - Started: CBE retrieveAndUpsertAccountEnquiries',
     );
-    await this.commercialBankEthiopiaReconciliationService.retrieveAndUpsertAccountEnquiries();
-    console.info(
-      'CronjobService - Complete: CBE retrieveAndUpsertAccountEnquiries',
-    );
+    // Don't wait for the result, as that can cause a timeout on the API
+    void this.commercialBankEthiopiaReconciliationService
+      .retrieveAndUpsertAccountEnquiries()
+      .finally(() => {
+        console.info(
+          'CronjobService - Complete: CBE retrieveAndUpsertAccountEnquiries',
+        );
+      });
   }
 }

--- a/services/121-service/src/utils/soap/soap.service.ts
+++ b/services/121-service/src/utils/soap/soap.service.ts
@@ -159,15 +159,22 @@ export class SoapService {
       soapAction,
     };
 
-    let agent;
-    try {
-      const certPath = process.env.COMMERCIAL_BANK_ETHIOPIA_CERTIFICATE_PATH!;
-      const cert = fs.readFileSync(certPath);
-      agent = new https.Agent({
-        ca: cert,
-      });
-    } catch (error) {
-      throw error;
+    let agent: https.Agent;
+
+    if (!!process.env.COMMERCIAL_BANK_ETHIOPIA_CERTIFICATE_PATH) {
+      try {
+        const certificate = fs.readFileSync(
+          process.env.COMMERCIAL_BANK_ETHIOPIA_CERTIFICATE_PATH,
+        );
+        agent = new https.Agent({
+          ca: certificate,
+        });
+      } catch (error) {
+        throw error;
+      }
+    } else {
+      // If no certificate path is provided, create an agent without certificate (for use with the sandbox CBE-API)
+      agent = new https.Agent();
     }
 
     return soapRequest({


### PR DESCRIPTION
[AB#35563](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/35563)

## Describe your changes

This would make the cron-triggered-endpoint *not* wait for the results of the loop...
So effectively moving the timeout-window from something controlled by the Nest.js-API to the Node-process...

And hopefully keep the Docker-logs in a sane shape...


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or the changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
