### PR TITLE
ci: Prevent local changes to lock-file

### DIFF
--- a/.github/workflows/test_interface_portalicious.yml
+++ b/.github/workflows/test_interface_portalicious.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - '.github/workflows/test_interface_portalicious.yml'
       - 'interfaces/Portalicious/**'
+      - 'services/121-service/**' # 121-service's code is imported/used
 
 env:
   interfacePath: 'interfaces/Portalicious'

--- a/services/121-service/package.json
+++ b/services/121-service/package.json
@@ -18,7 +18,7 @@
     "start:dev:nest": "nest start --require=tsconfig-paths/register --debug=0.0.0.0:9229 --watch --path=tsconfig.json",
     "start:dev:windows": "nodemon --config nodemon.json --legacy-watch --watch src --ext ts,js,json --exec 'npm run start:dev:nest:windows'",
     "start:dev:nest:windows": "nest start --require=tsconfig-paths/register --debug=0.0.0.0:9229 --path=tsconfig.json",
-    "prestart:dev": "npm install --no-fund --no-audit --no-save",
+    "prestart:dev": "npm install --no-fund --no-audit",
     "seed:dev": "ts-node --require=tsconfig-paths/register src/scripts seed-dev",
     "test": "echo 'No automated tests. Run `npm run test:integration:all` to run API-tests locally. Run `npm run test:unit:all` to run unit-tests locally.' && exit 0",
     "test:unit:all": "jest --runInBand --config=./jest.unit.config.js",

--- a/services/121-service/package.json
+++ b/services/121-service/package.json
@@ -37,7 +37,7 @@
     "knip:fix": "knip --fix-type files,exports,types",
     "typecheck": "tsc --noEmit",
     "typecheck:dev": "tsc --noEmit --watch",
-    "install:dependencies-for-portal": "npm install --no-fund --no-audit"
+    "install:dependencies-for-portal": "npm ci --no-fund --no-audit"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
[AB#35607](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/35607)

## Describe your changes

This would prevent any issues with "out-of-sync" lockfiles in unexpected places.

Using `npm ci` in all test-runs would highlight any not-up-to-date-ness-issues _very_ early.
It would also "not really hide" it from installs triggerd from Portalicious-code only.

Removal of the `--no-save`-flag would highlight any "forgotten changes" locally more clearly.


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or the changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
