### PR TITLE
ci: Replace external diff-check with local, specific test for translations ONLY

### DIFF
--- a/.github/workflows/test_interface_portalicious.yml
+++ b/.github/workflows/test_interface_portalicious.yml
@@ -55,7 +55,9 @@ jobs:
         working-directory: ${{ env.interfacePath }}
         run: 'npm run test:ci'
 
-      - name: 'Check translations'
-        uses: nickcharlton/diff-check@main
-        with:
-          command: cd ${{ env.interfacePath }} && npm run set-env-variables -- env=development && npm run extract-i18n
+      - name: 'Check translations output-file'
+        working-directory: ${{ env.interfacePath }}
+        run: |
+          npm run set-env-variables -- env=development
+          npm run extract-i18n
+          git diff --exit-code src/locale/messages.xlf


### PR DESCRIPTION
[AB#35606](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/35606)

## Describe your changes

This will ONLY check for any changes to the `messages.xlf`-file.
So this will prevent any "false positives" triggered by other changes/errors/bugs. (These will be covered by other tests/fixes, see #6770)

Also, this removes the need/risk of using an external party for a relatively simple check/test.


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or the changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
