### PR TITLE
Reduce downloads of translations via cache-per-day + Disable async-downloading (for now)

### DIFF
--- a/.github/actions/build-interface/action.yml
+++ b/.github/actions/build-interface/action.yml
@@ -53,6 +53,14 @@ runs:
         cache: 'npm'
         cache-dependency-path: '${{ inputs.interfacePath }}/package-lock.json'
 
+    - name: Set VERSION of build/deployment
+      shell: bash
+      id: build-version
+      run: |
+        echo "NG_BUILD_VERSION=$(git describe --tags --dirty --broken)" >> $GITHUB_ENV
+        echo "version=$NG_BUILD_VERSION" >> $GITHUB_OUTPUT
+        echo "date=$(/bin/date --utc --iso-8601)" >> $GITHUB_OUTPUT
+
     - name: Install
       shell: bash
       working-directory: ${{ inputs.interfacePath }}
@@ -60,10 +68,27 @@ runs:
         HUSKY: '0'
       run: 'npm ci --no-fund --no-audit'
 
-    - name: Set VERSION of build/deployment
+    - name: Re-use downloaded translations
+      if: inputs.buildType == 'portalicious'
+      uses: actions/cache@v4
+      id: cache_translations
+      env:
+        TRANSLATIONS_SOURCE_FILE: ${{ inputs.interfacePath }}/src/locale/messages.xlf
+      with:
+        path: '${{ inputs.interfacePath }}/src/locale/'
+        key: 'translations-${{ hashFiles(env.TRANSLATIONS_SOURCE_FILE) }}-${{ steps.build-version.outputs.date }}'
+
+    - name: Download translations
+      if: inputs.buildType == 'portalicious' && steps.cache_translations.outputs.cache-hit != 'true'
       shell: bash
+      working-directory: ${{ inputs.interfacePath }}
+      env:
+        NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: true
+        LOKALISE_PROJECT_ID: ${{ env.LOKALISE_PROJECT_ID }}
+        LOKALISE_API_TOKEN: ${{ env.LOKALISE_API_TOKEN }}
       run: |
-        echo "NG_BUILD_VERSION=$(git describe --tags --dirty --broken)" >> $GITHUB_ENV
+        echo "\n\n# This file should exist in Node v20, is optional in Node v22\n\n" >> .env
+        npm run build:download-translations
 
     - name: Add environment-specific icon
       if: ${{ inputs.envIcon }} != ''
@@ -77,10 +102,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.interfacePath }}
       env:
-        # Only if NG_DOWNLOAD_TRANSLATIONS_AT_BUILD is explicitly set to 'false', it will be set to 'false'. Otherwise it will be set to 'true'.
-        NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ env.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD == 'false' && 'false' || 'true' }}
-        LOKALISE_PROJECT_ID: ${{ env.LOKALISE_PROJECT_ID }}
-        LOKALISE_API_TOKEN: ${{ env.LOKALISE_API_TOKEN }}
+        NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: false
       run: |
         echo "\n\n# This file should exist in Node v20, is optional in Node v22\n\n" >> .env
         npm run build:production

--- a/.github/workflows/deploy_client-benin_portal.yml
+++ b/.github/workflows/deploy_client-benin_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-demo_portal.yml
+++ b/.github/workflows/deploy_client-demo_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-drc_portal.yml
+++ b/.github/workflows/deploy_client-drc_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-eswatini_portal.yml
+++ b/.github/workflows/deploy_client-eswatini_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-ethiopia_portal.yml
+++ b/.github/workflows/deploy_client-ethiopia_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-greece_portal.yml
+++ b/.github/workflows/deploy_client-greece_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-ivorycoast_portal.yml
+++ b/.github/workflows/deploy_client-ivorycoast_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-jrethiopia_portal.yml
+++ b/.github/workflows/deploy_client-jrethiopia_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-krcs_portal.yml
+++ b/.github/workflows/deploy_client-krcs_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-nigeria_portal.yml
+++ b/.github/workflows/deploy_client-nigeria_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-nlrc_portalicious.yml
+++ b/.github/workflows/deploy_client-nlrc_portalicious.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-slovakia_portal.yml
+++ b/.github/workflows/deploy_client-slovakia_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-somalia_portal.yml
+++ b/.github/workflows/deploy_client-somalia_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-southafrica_portal.yml
+++ b/.github/workflows/deploy_client-southafrica_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-sudan_portal.yml
+++ b/.github/workflows/deploy_client-sudan_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-togo_portal.yml
+++ b/.github/workflows/deploy_client-togo_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-training_portal.yml
+++ b/.github/workflows/deploy_client-training_portal.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_client-zambia_portal.yml
+++ b/.github/workflows/deploy_client-zambia_portal.yml
@@ -46,7 +46,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_staging_portalicious.yml
+++ b/.github/workflows/deploy_staging_portalicious.yml
@@ -47,7 +47,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/deploy_test_portalicious.yml
+++ b/.github/workflows/deploy_test_portalicious.yml
@@ -64,7 +64,6 @@ jobs:
         id: build
         uses: ./.github/actions/build-interface
         env:
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         with:

--- a/.github/workflows/test_e2e_portalicious.yml
+++ b/.github/workflows/test_e2e_portalicious.yml
@@ -61,9 +61,7 @@ jobs:
         env:
           NG_PRODUCTION: true
           NG_URL_121_SERVICE_API: http://localhost:3000/api
-          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: ${{ vars.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD }}
-          LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
-          LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
+          NG_DOWNLOAD_TRANSLATIONS_AT_BUILD: false
         run: |
           npm ci --no-fund --no-audit
           cp .env.example .env

--- a/.github/workflows/test_e2e_portalicious.yml
+++ b/.github/workflows/test_e2e_portalicious.yml
@@ -65,7 +65,7 @@ jobs:
           LOKALISE_PROJECT_ID: ${{ vars.LOKALISE_PROJECT_ID }}
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
         run: |
-          npm install
+          npm ci --no-fund --no-audit
           cp .env.example .env
           npm run start:debug-production > portalicious-server-logs.txt 2>&1 &
 

--- a/.github/workflows/test_e2e_portalicious.yml
+++ b/.github/workflows/test_e2e_portalicious.yml
@@ -99,6 +99,11 @@ jobs:
             ${{ env.e2eTestsPath }}/test-results/
             ./interfaces/Portalicious/portalicious-server-logs.txt
 
+      - name: Portalicious logs
+        if: always()
+        shell: bash
+        run: cat ./interfaces/Portalicious/portalicious-server-logs.txt
+
       - name: Docker logs
         if: always()
         uses: jwalton/gh-docker-logs@v2

--- a/.github/workflows/test_e2e_portalicious.yml
+++ b/.github/workflows/test_e2e_portalicious.yml
@@ -98,7 +98,6 @@ jobs:
           path: |
             ${{ env.e2eTestsPath }}/test-results/
             ./interfaces/Portalicious/portalicious-server-logs.txt
-          retention-days: 30
 
       - name: Docker logs
         if: always()

--- a/interfaces/Portalicious/_build-download-translations.mjs
+++ b/interfaces/Portalicious/_build-download-translations.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { LokaliseDownload } from 'lokalise-file-exchange';
-import { accessSync, constants, writeFileSync } from 'node:fs';
+import { accessSync, constants, existsSync, writeFileSync } from 'node:fs';
 
 import { shouldBeEnabled } from './_env.utils.mjs';
 import {
@@ -20,9 +20,15 @@ const requiredTranslations = getRequiredTranslations();
 console.log('Required translations: ', requiredTranslations);
 
 if (!shouldBeEnabled(process.env.NG_DOWNLOAD_TRANSLATIONS_AT_BUILD)) {
-  console.info('Skipping download of translations. Creating mocks instead.');
+  console.info('Skipping download of translations.');
+
   for (const lang of requiredTranslations) {
     const filePath = getTranslationFilePath(lang);
+
+    if (existsSync(filePath)) {
+      console.info(`✅ Translations already available: ${filePath}`);
+      continue;
+    }
 
     writeFileSync(
       filePath,

--- a/interfaces/Portalicious/_build-download-translations.mjs
+++ b/interfaces/Portalicious/_build-download-translations.mjs
@@ -57,7 +57,7 @@ await lokaliseDownloader.downloadTranslations({
     original_filenames: false,
   },
   processDownloadFileParams: {
-    asyncDownload: true,
+    asyncDownload: false, // Disabled although recommended by Lokalise. It doesn't work reliable enough.
   },
 });
 console.info(`Download done ✅`);


### PR DESCRIPTION
[AB#35632](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/35632)

## Describe your changes

TopPrevent flaky build-steps...
- Disable download of translations in E2E-test runs
- Create cache of downloaded translations
  - Will be re-used on multiple builds/deployments on the same day (test/staging-environment)
  - Will be at least run once-per-day for production release/deploys (so once for first client, reuse for other clients)


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or the changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://lively-river-04adce503-6790.westeurope.5.azurestaticapps.net
