### PR TITLE
Retry first send attempt when sending voucher via whatsapp

### DIFF
--- a/services/121-service/src/notifications/whatsapp/whatsapp.service.ts
+++ b/services/121-service/src/notifications/whatsapp/whatsapp.service.ts
@@ -58,7 +58,7 @@ export class WhatsappService {
     messageProcessType?: MessageProcessType;
     existingSidToUpdate?: string;
     userId: number;
-    firstAttempt?: boolean;
+    firstAttempt?: boolean; // Controls retry logic for Twilio media errors (63021)
   }): Promise<string> {
     const payload = {
       body: contentSid ? undefined : message,
@@ -102,10 +102,8 @@ export class WhatsappService {
     } catch (error) {
       if (error.code == 63021 && mediaUrl && firstAttempt) {
         firstAttempt = false;
-        // This is a bug that occur on twilio side where it sometimes randomly return error 63021 when sending a message with a mediaUrl
-        // We try here to send the message again
-        // This bug is further desrcibed in backlog item 34346
-        // We just retry the message here once
+        // Retry once due to Twilio bug (error 63021) that randomly occurs when sending messages with mediaUrl
+        // Reference: backlog item 34346
         return this.sendWhatsapp({
           message,
           contentSid,


### PR DESCRIPTION
[AB#35786](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/35786)<!--- Replace this with a reference to a devops issue -->

## Describe your changes

This PR adds a retry mechanism for sending a WhatsApp notification when a specific Twilio error (code 63021) occurs on the first send attempt

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes, or adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or the changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
