### PR TITLE
fix: warning message when including included registrations

### DIFF
--- a/interfaces/Portalicious/src/app/pages/project-registrations/components/change-status-dialog/change-status-dialog.component.html
+++ b/interfaces/Portalicious/src/app/pages/project-registrations/components/change-status-dialog/change-status-dialog.component.html
@@ -135,59 +135,16 @@
     {{ changeStatusMutation.data()?.nonApplicableCount }}
     registration(s) that don't support this action</b
   >
-  @switch (status()) {
-    @case (RegistrationStatusEnum.validated) {
-      <p
-        i18n="@@change-status-validate-warning"
-        class="pt-2"
-      >
-        The action "Validate" can only be applied to registrations with the
-        "Registered" status. Registrations with other statuses will remain with
-        their current status.
-      </p>
-    }
-    @case (RegistrationStatusEnum.included) {
-      <p
-        i18n="@@change-status-include-warning"
-        class="pt-2"
-      >
-        The action "Include" can only be applied to registrations that do not
-        have status "Included" and whose “Payments left” is larger than 0.
-        Registrations with 0 payments left will remain with their current
-        status.
-      </p>
-    }
-    @case (RegistrationStatusEnum.paused) {
-      <p
-        i18n="@@change-status-pause-warning"
-        class="pt-2"
-      >
-        The action "Pause" can only be applied to registrations with the
-        "Included" status. Registrations with other statuses will remain with
-        their current status.
-      </p>
-    }
-    @case (RegistrationStatusEnum.declined) {
-      <p
-        i18n="@@change-status-decline-warning"
-        class="pt-2"
-      >
-        The action "Decline" can not be applied to registrations with the
-        "Declined" or "Completed" status. Registrations with the “Completed”
-        status will remain with their current status.
-      </p>
-    }
-    @case (RegistrationStatusEnum.deleted) {
-      <p
-        i18n="@@change-status-delete-warning"
-        class="pt-2"
-      >
-        The action "Delete" can not be applied to registrations with the
-        "Completed" status. Registrations with “completed” status will remain
-        with their current status.
-      </p>
-    }
-  }
+  <p class="pt-2">
+    {{ changeStatusWarningMessage() }}
+  </p>
+  <p
+    class="pt-2"
+    i18n
+  >
+    Registrations that do not support this action will remain in their current
+    status.
+  </p>
   <p
     i18n
     class="pt-2"
@@ -211,98 +168,15 @@
     </h3>
   </ng-template>
   <b i18n>0 selected registrations support this action. </b>
-  @switch (status()) {
-    @case (RegistrationStatusEnum.validated) {
-      <p
-        i18n
-        class="pt-2"
-      >
-        The action "Validate" can only be applied to registrations with the
-        "Registered" status.
-      </p>
-      <p
-        i18n
-        class="pt-2"
-      >
-        Select registrations with the status “Registered” and try again.
-      </p>
-    }
-    @case (RegistrationStatusEnum.included) {
-      <p
-        i18n
-        class="pt-2"
-      >
-        The action "Include" can only be applied to registrations who's
-        “Payments left” is larger than 0.
-      </p>
-      <p
-        i18n
-        class="pt-2"
-      >
-        Select registrations who's “Payments left” is larger than 0 and try
-        again.
-      </p>
-    }
-    @case (RegistrationStatusEnum.paused) {
-      <p
-        i18n
-        class="pt-2"
-      >
-        The action "Pause" can only be applied to registrations with the
-        "Included" status.
-      </p>
-      <p
-        i18n
-        class="pt-2"
-      >
-        Select registrations with the status “included” and try again.
-      </p>
-    }
-    @case (RegistrationStatusEnum.declined) {
-      <p
-        i18n
-        class="pt-2"
-      >
-        The action "Decline" can not be applied to registrations with the
-        "Completed" status.
-      </p>
-      <p
-        i18n
-        class="pt-2"
-      >
-        Select registrations with other status and try again.
-      </p>
-    }
-    @case (RegistrationStatusEnum.deleted) {
-      <p
-        i18n
-        class="pt-2"
-      >
-        The action "Delete" can not be applied to registrations with the
-        "Completed" status.
-      </p>
-      <p
-        i18n
-        class="pt-2"
-      >
-        Select registrations with other status and try again.
-      </p>
-    }
-    @default {
-      <p
-        i18n
-        class="pt-2"
-      >
-        This action can not be applied to the registrations you have selected.
-      </p>
-      <p
-        i18n
-        class="pt-2"
-      >
-        Select registrations with another status and try again.
-      </p>
-    }
-  }
+  <p class="pt-2">
+    {{ changeStatusWarningMessage() }}
+  </p>
+  <p
+    i18n
+    class="pt-2"
+  >
+    Select registrations that support this action, and try again.
+  </p>
   <div class="mt-6 flex justify-end gap-x-2">
     <p-button
       label="Cancel"

--- a/interfaces/Portalicious/src/app/pages/project-registrations/components/change-status-dialog/change-status-dialog.component.ts
+++ b/interfaces/Portalicious/src/app/pages/project-registrations/components/change-status-dialog/change-status-dialog.component.ts
@@ -118,6 +118,22 @@ export class ChangeStatusDialogComponent
     }
     return REGISTRATION_STATUS_VERB[status];
   });
+  readonly changeStatusWarningMessage = computed(() => {
+    switch (this.status()) {
+      case RegistrationStatusEnum.validated:
+        return $localize`:@@change-status-validate-warning:The action "Validate" can only be applied to registrations with the "Registered" status.`;
+      case RegistrationStatusEnum.included:
+        return $localize`:@@change-status-include-warning:The action "Include" can only be applied to registrations that do not have status "Included" and whose “Payments left” is larger than 0.`;
+      case RegistrationStatusEnum.paused:
+        return $localize`:@@change-status-pause-warning:The action "Pause" can only be applied to registrations with the "Included" status.`;
+      case RegistrationStatusEnum.declined:
+        return $localize`:@@change-status-decline-warning:The action "Decline" can not be applied to registrations with the "Declined" or "Completed" status.`;
+      case RegistrationStatusEnum.deleted:
+        return $localize`:@@change-status-delete-warning:The action "Delete" can not be applied to registrations with the "Completed" status.`;
+      default:
+        return $localize`:@@change-status-default-warning:This action can not be applied to registrations you have selected.`;
+    }
+  });
   readonly canSendMessage = computed(() => {
     const status = this.status();
     if (!status) {

--- a/interfaces/Portalicious/src/locale/messages.xlf
+++ b/interfaces/Portalicious/src/locale/messages.xlf
@@ -893,16 +893,10 @@
         <source>I understand this action can not be undone.</source>
       </trans-unit>
       <trans-unit id="change-status-include-warning" datatype="html">
-        <source>The action &quot;Include&quot; can only be applied to registrations that do not have status &quot;Included&quot; and whose “Payments left” is larger than 0. Registrations with 0 payments left will remain with their current status.</source>
-      </trans-unit>
-      <trans-unit id="276843485197819536" datatype="html">
-        <source>Select registrations with the status “included” and try again.</source>
+        <source>The action &quot;Include&quot; can only be applied to registrations that do not have status &quot;Included&quot; and whose “Payments left” is larger than 0.</source>
       </trans-unit>
       <trans-unit id="3302381073867974185" datatype="html">
         <source><x ctype="x-b" equiv-text="&lt;b&gt;" id="START_BOLD_TEXT"/>This action can not be undone.<x ctype="x-b" equiv-text="&lt;/b&gt;" id="CLOSE_BOLD_TEXT"/><x ctype="lb" equiv-text="&lt;br /&gt;" id="LINE_BREAK"/> Are you sure you want to delete these registrations?</source>
-      </trans-unit>
-      <trans-unit id="3523288603730580118" datatype="html">
-        <source>The action &quot;Delete&quot; can not be applied to registrations with the &quot;Completed&quot; status.</source>
       </trans-unit>
       <trans-unit id="3626484707935812949" datatype="html">
         <source>0 selected registrations support this action.</source>
@@ -911,37 +905,22 @@
         <source>Would you like to proceed with <x equiv-text="{{ changeStatusMutation.data()?.applicableCount }}" id="INTERPOLATION"/> registration(s)?</source>
       </trans-unit>
       <trans-unit id="change-status-pause-warning" datatype="html">
-        <source>The action &quot;Pause&quot; can only be applied to registrations with the &quot;Included&quot; status. Registrations with other statuses will remain with their current status.</source>
-      </trans-unit>
-      <trans-unit id="4547875681494013767" datatype="html">
-        <source>This action can not be applied to the registrations you have selected.</source>
-      </trans-unit>
-      <trans-unit id="change-status-delete-warning" datatype="html">
-        <source>The action &quot;Delete&quot; can not be applied to registrations with the &quot;Completed&quot; status. Registrations with “completed” status will remain with their current status.</source>
-      </trans-unit>
-      <trans-unit id="5209857233936409392" datatype="html">
         <source>The action &quot;Pause&quot; can only be applied to registrations with the &quot;Included&quot; status.</source>
       </trans-unit>
-      <trans-unit id="6345542796169013745" datatype="html">
-        <source>Select registrations who&apos;s “Payments left” is larger than 0 and try again.</source>
+      <trans-unit id="change-status-delete-warning" datatype="html">
+        <source>The action &quot;Delete&quot; can not be applied to registrations with the &quot;Completed&quot; status.</source>
       </trans-unit>
       <trans-unit id="change-status-validate-warning" datatype="html">
-        <source>The action &quot;Validate&quot; can only be applied to registrations with the &quot;Registered&quot; status. Registrations with other statuses will remain with their current status.</source>
-      </trans-unit>
-      <trans-unit id="652725573989033199" datatype="html">
         <source>The action &quot;Validate&quot; can only be applied to registrations with the &quot;Registered&quot; status.</source>
       </trans-unit>
       <trans-unit id="change-status-decline-warning" datatype="html">
-        <source>The action &quot;Decline&quot; can not be applied to registrations with the &quot;Declined&quot; or &quot;Completed&quot; status. Registrations with the “Completed” status will remain with their current status.</source>
+        <source>The action &quot;Decline&quot; can not be applied to registrations with the &quot;Declined&quot; or &quot;Completed&quot; status.</source>
       </trans-unit>
       <trans-unit id="6369488977592373957" datatype="html">
         <source>This means that they will not be included in payments.</source>
       </trans-unit>
       <trans-unit id="generic-warning" datatype="html">
         <source>Warning</source>
-      </trans-unit>
-      <trans-unit id="684272908201420787" datatype="html">
-        <source>The action &quot;Decline&quot; can not be applied to registrations with the &quot;Completed&quot; status.</source>
       </trans-unit>
       <trans-unit id="561353031255604069" datatype="html">
         <source>There are <x equiv-text="{{ changeStatusMutation.data()?.nonApplicableCount }}" id="INTERPOLATION"/> registration(s) that don&apos;t support this action</source>
@@ -951,18 +930,6 @@
       </trans-unit>
       <trans-unit id="7483364924749111553" datatype="html">
         <source>They will not be included in payments.</source>
-      </trans-unit>
-      <trans-unit id="7582384076029482676" datatype="html">
-        <source>Select registrations with other status and try again.</source>
-      </trans-unit>
-      <trans-unit id="8563473409467586384" datatype="html">
-        <source>Select registrations with another status and try again.</source>
-      </trans-unit>
-      <trans-unit id="8668090925608056170" datatype="html">
-        <source>The action &quot;Include&quot; can only be applied to registrations who&apos;s “Payments left” is larger than 0.</source>
-      </trans-unit>
-      <trans-unit id="8967125351109863286" datatype="html">
-        <source>Select registrations with the status “Registered” and try again.</source>
       </trans-unit>
       <trans-unit id="6828231165009897209" datatype="html">
         <source>You must select this to proceed.</source>
@@ -1597,6 +1564,15 @@
       </trans-unit>
       <trans-unit id="7239750919884229270" datatype="html">
         <source>Updated</source>
+      </trans-unit>
+      <trans-unit id="1850330008029608959" datatype="html">
+        <source>Select registrations that support this action, and try again.</source>
+      </trans-unit>
+      <trans-unit id="8735352957921555136" datatype="html">
+        <source>Registrations that do not support this action will remain in their current status.</source>
+      </trans-unit>
+      <trans-unit id="change-status-default-warning" datatype="html">
+        <source>This action can not be applied to registrations you have selected.</source>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
[AB#35796](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/35796)

This applies to two scenarios:
1. Try to change a status and 0 registrations support the new status
2. Try to change a status and only some of the registrations support the new status

Previously, the error messages for these two scenarios were duplicated.

Now there is a variable `changeStatusWarningMessage` that is used in both scenarios.

I've also removed customised suggested actions for the warnings in both scenarios, making the suggested action more vague to avoid additional, IMHO unnecessary ifs.

In other words, in the following screenshots
- the text circled in red is customised per status (as it was before)
- the text circled in green is generic and does not change per status

Scenario 1

<img width="937" alt="Screenshot 2025-05-07 at 10 45 41" src="https://github.com/user-attachments/assets/245e3fcd-a555-4efc-835c-26ffe3f3ea3f" />


Scenario 2

<img width="672" alt="Screenshot 2025-05-07 at 10 45 17" src="https://github.com/user-attachments/assets/09b997d6-8c39-4f00-9d0c-2cb787c04fe2" />

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or the changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portalicious preview deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-6819.westeurope.3.azurestaticapps.net
