### PR TITLE
chore: make 121-service start non-detached

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,8 @@ To start all services, after setup, from the root of this repository, run:
 
     npm run start:services
 
-This will run Docker Compose in "attached" mode. The logs for all containers
-will be output to stdout. To stop all services press <button>Ctrl</button> +
-<button>c</button>.
+This will run Docker Compose in "attached" mode. The logs for all containers will be output to `stdout`.  
+To stop all services press <kbd>⌃ Control</kbd> + <kbd>C</kbd>.
 
 To see the status/logs of all/a specific Docker-container(s), run: (Where `<container-name>` is optional; See container-names in [`docker-compose.yml`](services/docker-compose.yml)).
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ To start all services, after setup, from the root of this repository, run:
 
     npm run start:services
 
+This will run Docker Compose in "attached" mode. The logs for all containers
+will be output to stdout. To stop all services press <button>Ctrl</button> +
+<button>c</button>.
+
 To see the status/logs of all/a specific Docker-container(s), run: (Where `<container-name>` is optional; See container-names in [`docker-compose.yml`](services/docker-compose.yml)).
 
     npm run logs:services <container-name>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "echo 'See README.md#getting-started \\n\\n'",
     "start:all": "npx npm-run-all --npm-path npm --print-label --parallel start:services start:portal",
     "logs:services": "cd services/ && docker compose logs --follow",
-    "start:services": "cd services/ && docker compose --file=docker-compose.yml --file=docker-compose.development.yml up --detach --build",
+    "start:services": "cd services/ && docker compose --file=docker-compose.yml --file=docker-compose.development.yml up --build",
     "start:services:production": "cd services/ && docker compose --file=docker-compose.yml up --detach --build",
     "start:services:appmap": "cd services/ && docker compose --file=docker-compose.yml --file=docker-compose.development.yml --file=docker-compose.development-appmap.yml up --detach --build",
     "start:portal": "npm run start:portalicious",


### PR DESCRIPTION
[AB#35953](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/35953)

## Describe your changes

When running 121-service locally it's helpful to see all the logs and to be able to quickly stop it. By *not* detaching it we:
- see the logs and keep seeing them in the terminal where we run `npm run start:services`
- can easily stop the 121-service by pressing Ctrl + c

It is possible to do both things using Docker commands, but then you need to take extra steps.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
