### PR TITLE
docs: Add config to auto-link backlog-items mentioned in code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,14 +5,18 @@
     "angular.ng-template",
     "arahata.linter-actionlint",
     "ban.spellright",
+    "bierner.markdown-mermaid",
     "bradlc.vscode-tailwindcss",
     "danlevett.regex-robin",
+    "davidanson.vscode-markdownlint",
+    "dbaeumer.vscode-eslint",
     "dotiful.dotfiles-syntax-highlighting",
     "editorconfig.editorconfig",
-    "eg2.vscode-npm-script",
     "esbenp.prettier-vscode",
     "github.vscode-github-actions",
     "lokalise.i18n-ally",
+    "mechatroner.rainbow-csv",
+    "meganrogge.template-string-converter",
     "mikestead.dotenv",
     "ms-azuretools.vscode-azureappservice",
     "ms-azuretools.vscode-azureresourcegroups",
@@ -20,6 +24,10 @@
     "ms-azuretools.vscode-cosmosdb",
     "ms-azuretools.vscode-docker",
     "ms-playwright.playwright",
-    "tombonnike.vscode-status-bar-format-toggle"
+    "redhat.vscode-yaml",
+    "sburg.vscode-javascript-booster",
+    "sysoev.vscode-open-in-github",
+    "tombonnike.vscode-status-bar-format-toggle",
+    "whtouche.vscode-js-console-utils"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
     "arahata.linter-actionlint",
     "ban.spellright",
     "bradlc.vscode-tailwindcss",
+    "danlevett.regex-robin",
     "dotiful.dotfiles-syntax-highlighting",
     "editorconfig.editorconfig",
     "eg2.vscode-npm-script",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,18 @@
     "source.fixAll.eslint": "explicit",
     "source.removeUnusedImports": "explicit"
   },
+  "regexrobin.rules": [
+    {
+      "regex": "AB#(\\d+)",
+      "tree": { "group": "Azure DevOps backlog items" },
+      "editor": [
+        {
+          "link": "https://dev.azure.com/redcrossnl/121%20Platform/_workitems/edit/$1",
+          "hoverMessage": "Azure DevOps backlog item: **$1**"
+        }
+      ]
+    }
+  ],
   "tailwindCSS.rootFontSize": 14,
   "tailwindCSS.showPixelEquivalents": true,
   "tailwindCSS.classAttributes": [

--- a/e2e/.vscode/settings.json
+++ b/e2e/.vscode/settings.json
@@ -7,6 +7,18 @@
   "eslint.enable": true,
   "eslint.format.enable": true,
   "eslint.workingDirectories": [{ "mode": "auto" }],
+  "regexrobin.rules": [
+    {
+      "regex": "AB#(\\d+)",
+      "tree": { "group": "Azure DevOps backlog items" },
+      "editor": [
+        {
+          "link": "https://dev.azure.com/redcrossnl/121%20Platform/_workitems/edit/$1",
+          "hoverMessage": "Azure DevOps backlog item: **$1**"
+        }
+      ]
+    }
+  ],
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/interfaces/portal/.vscode/extensions.json
+++ b/interfaces/portal/.vscode/extensions.json
@@ -5,6 +5,7 @@
     "angular.ng-template",
     "ban.spellright",
     "bradlc.vscode-tailwindcss",
+    "danlevett.regex-robin",
     "dotiful.dotfiles-syntax-highlighting",
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",

--- a/interfaces/portal/.vscode/extensions.json
+++ b/interfaces/portal/.vscode/extensions.json
@@ -1,19 +1,30 @@
 {
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=827846
   "recommendations": [
+    // Sorted alphabetically:
     "aar.xlf-editor",
     "angular.ng-template",
     "ban.spellright",
+    "bierner.markdown-mermaid",
     "bradlc.vscode-tailwindcss",
     "danlevett.regex-robin",
+    "davidanson.vscode-markdownlint",
+    "dbaeumer.vscode-eslint",
     "dotiful.dotfiles-syntax-highlighting",
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
     "lucono.karma-test-explorer",
+    "mechatroner.rainbow-csv",
+    "meganrogge.template-string-converter",
+    "mikestead.dotenv",
     "ms-azuretools.vscode-azureappservice",
     "ms-azuretools.vscode-azureresourcegroups",
     "ms-azuretools.vscode-azurestaticwebapps",
     "ms-vscode.azure-account",
-    "tombonnike.vscode-status-bar-format-toggle"
+    "redhat.vscode-yaml",
+    "sburg.vscode-javascript-booster",
+    "sysoev.vscode-open-in-github",
+    "tombonnike.vscode-status-bar-format-toggle",
+    "whtouche.vscode-js-console-utils"
   ]
 }

--- a/interfaces/portal/.vscode/settings.json
+++ b/interfaces/portal/.vscode/settings.json
@@ -8,6 +8,18 @@
   "eslint.format.enable": true,
   "eslint.workingDirectories": [{ "mode": "auto" }],
   "css.customData": [".vscode/tailwind.json"],
+  "regexrobin.rules": [
+    {
+      "regex": "AB#(\\d+)",
+      "tree": { "group": "Azure DevOps backlog items" },
+      "editor": [
+        {
+          "link": "https://dev.azure.com/redcrossnl/121%20Platform/_workitems/edit/$1",
+          "hoverMessage": "Azure DevOps backlog item: **$1**"
+        }
+      ]
+    }
+  ],
   "tailwindCSS.rootFontSize": 14,
   "tailwindCSS.showPixelEquivalents": true,
   "tailwindCSS.classAttributes": [

--- a/services/121-service/.vscode/extensions.json
+++ b/services/121-service/.vscode/extensions.json
@@ -1,18 +1,22 @@
 {
   "recommendations": [
-    "editorconfig.editorconfig",
-    "mikestead.dotenv",
-    "danlevett.regex-robin",
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "tombonnike.vscode-status-bar-format-toggle",
-    "whtouche.vscode-js-console-utils",
-    "sburg.vscode-javascript-booster",
-    "meganrogge.template-string-converter",
-    "redhat.vscode-yaml",
-    "sysoev.vscode-open-in-github",
-    "davidanson.vscode-markdownlint",
+    // Sorted alphabetically:
+    "ban.spellright",
     "bierner.markdown-mermaid",
-    "mechatroner.rainbow-csv"
+    "danlevett.regex-robin",
+    "davidanson.vscode-markdownlint",
+    "dbaeumer.vscode-eslint",
+    "dotiful.dotfiles-syntax-highlighting",
+    "editorconfig.editorconfig",
+    "esbenp.prettier-vscode",
+    "esbenp.prettier-vscode",
+    "mechatroner.rainbow-csv",
+    "meganrogge.template-string-converter",
+    "mikestead.dotenv",
+    "redhat.vscode-yaml",
+    "sburg.vscode-javascript-booster",
+    "sysoev.vscode-open-in-github",
+    "tombonnike.vscode-status-bar-format-toggle",
+    "whtouche.vscode-js-console-utils"
   ]
 }

--- a/services/121-service/.vscode/extensions.json
+++ b/services/121-service/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "editorconfig.editorconfig",
     "mikestead.dotenv",
+    "danlevett.regex-robin",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "tombonnike.vscode-status-bar-format-toggle",

--- a/services/121-service/.vscode/settings.json
+++ b/services/121-service/.vscode/settings.json
@@ -7,6 +7,18 @@
     "source.fixAll.eslint": "explicit",
     "source.removeUnusedImports": "explicit"
   },
+  "regexrobin.rules": [
+    {
+      "regex": "AB#(\\d+)",
+      "tree": { "group": "Azure DevOps backlog items" },
+      "editor": [
+        {
+          "link": "https://dev.azure.com/redcrossnl/121%20Platform/_workitems/edit/$1",
+          "hoverMessage": "Azure DevOps backlog item: **$1**"
+        }
+      ]
+    }
+  ],
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/services/mock-service/.vscode/extensions.json
+++ b/services/mock-service/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    // Sorted alphabetically:
+    "danlevett.regex-robin"
+  ]
+}

--- a/services/mock-service/.vscode/extensions.json
+++ b/services/mock-service/.vscode/extensions.json
@@ -1,6 +1,22 @@
 {
   "recommendations": [
     // Sorted alphabetically:
-    "danlevett.regex-robin"
+    "ban.spellright",
+    "bierner.markdown-mermaid",
+    "danlevett.regex-robin",
+    "davidanson.vscode-markdownlint",
+    "dbaeumer.vscode-eslint",
+    "dotiful.dotfiles-syntax-highlighting",
+    "editorconfig.editorconfig",
+    "esbenp.prettier-vscode",
+    "esbenp.prettier-vscode",
+    "mechatroner.rainbow-csv",
+    "meganrogge.template-string-converter",
+    "mikestead.dotenv",
+    "redhat.vscode-yaml",
+    "sburg.vscode-javascript-booster",
+    "sysoev.vscode-open-in-github",
+    "tombonnike.vscode-status-bar-format-toggle",
+    "whtouche.vscode-js-console-utils"
   ]
 }

--- a/services/mock-service/.vscode/settings.json
+++ b/services/mock-service/.vscode/settings.json
@@ -7,6 +7,18 @@
     "source.fixAll.eslint": "explicit",
     "source.removeUnusedImports": "explicit"
   },
+  "regexrobin.rules": [
+    {
+      "regex": "AB#(\\d+)",
+      "tree": { "group": "Azure DevOps backlog items" },
+      "editor": [
+        {
+          "link": "https://dev.azure.com/redcrossnl/121%20Platform/_workitems/edit/$1",
+          "hoverMessage": "Azure DevOps backlog item: **$1**"
+        }
+      ]
+    }
+  ],
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true
 }


### PR DESCRIPTION
AB#36708

## Describe your changes

The added configuration/settings will make comments in code in the form of `AB#36708` clickable in VSCode. So its easy to jump to the backlog-item, without the need for copy-pasting IDs of full-URLs in a (maybe too lengthy) code-comment.


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] Adding tests is unnecessary/irrelevant
- [x] The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

> [!NOTE]
> Some of these JSON-files are technically "JSON-with-comments-files", handled (only) by VSCode... So no need to worry about the red-highlighted text on GitHub...  
> I know we could configure that somewhere in some file as well, but the scope-creep has already gotten me this far...

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
