### PR TITLE
docs: Use JSDoc-syntax to highlight explanation for method

### DIFF
--- a/services/121-service/test/helpers/registration.helper.ts
+++ b/services/121-service/test/helpers/registration.helper.ts
@@ -409,7 +409,9 @@ export async function waitForStatusChangeToComplete(
   }
 }
 
-// It's only useful to call this function on bulk updates, because single updates happen synchronously
+/**
+ * It's only useful to call this function on bulk updates, because single updates happen synchronously
+ */
 export async function waitForBulkRegistrationChanges(
   expectedChanges: {
     referenceId: string;


### PR DESCRIPTION
[AB#36805](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/36805)

## Describe your changes

Using JSDoc-syntax will make the comment appear closer to the place where its "supposed to be read", i.e. "the place where the method is/will-be used".

![image](https://github.com/user-attachments/assets/d1dca81f-64a5-4aa3-acf2-2719659a978d)

See about JSDoc (in general): <https://jsdoc.app/>

About the things relevant when used inside TypeScript: <https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#documentation-1>

### TL;DR

Start typing `/**`+<kbd>Enter</kbd> and type any descriptions/notes/warnings above a method that you want to show up in the 'tooltip' shown at the usages of that method.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [ ] Adding tests is unnecessary/irrelevant
  We _could_ find some ESLint-rule to 'prevent' these 'errors'?
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
