### PR TITLE
Test flakiness: wait for events instead of changed registrations

### DIFF
--- a/services/121-service/test/event/filter-events.test.ts
+++ b/services/121-service/test/event/filter-events.test.ts
@@ -71,12 +71,13 @@ describe('Get events', () => {
       accessToken,
     );
 
-    const eventsResult = await getEvents(
-      programIdOcw,
-      dateString,
-      tomorrowDateString,
-      undefined,
-    );
+    const eventsResult = await getEvents({
+      programId: programIdOcw,
+      fromDate: dateString,
+      toDate: tomorrowDateString,
+      referenceId: undefined,
+      accessToken,
+    });
 
     // Assert
     expect(eventsResult.statusCode).toBe(HttpStatus.OK);
@@ -105,12 +106,13 @@ describe('Get events', () => {
       reason,
       accessToken,
     );
-    const eventsResult = await getEvents(
-      programIdOcw,
-      yesterdayString,
-      yesterdayString, // same date makes sure no events are found
-      undefined,
-    );
+    const eventsResult = await getEvents({
+      programId: programIdOcw,
+      fromDate: yesterdayString,
+      toDate: yesterdayString,
+      referenceId: undefined,
+      accessToken,
+    });
 
     // Assert
     expect(eventsResult.statusCode).toBe(HttpStatus.NOT_FOUND);

--- a/services/121-service/test/helpers/registration.helper.ts
+++ b/services/121-service/test/helpers/registration.helper.ts
@@ -146,18 +146,20 @@ export async function waitForDeleteRegistrations({
   maxWaitTimeMs?: number;
 }) {
   const startTime = Date.now();
+  const accessToken = await getAccessToken();
   while (Date.now() - startTime < maxWaitTimeMs) {
     // Get payment transactions
     let totalRegistrationSuccesfullyDeleted = 0;
+
     for (const referenceId of referenceIds) {
-      const getEventResponse = await getEvents({
+      const getEventsResponse = await getEvents({
         programId,
         fromDate: undefined,
         toDate: undefined,
         referenceId,
-        accessToken: await getAccessToken(),
+        accessToken,
       });
-      const deleteEvent = getEventResponse.body.find(
+      const deleteEvent = getEventsResponse.body.find(
         (event) =>
           event.type === EventEnum.registrationStatusChange &&
           event.attributes?.newValue === RegistrationStatusEnum.deleted,

--- a/services/121-service/test/helpers/registration.helper.ts
+++ b/services/121-service/test/helpers/registration.helper.ts
@@ -360,7 +360,6 @@ export async function waitForStatusChangeToComplete(
 ): Promise<void> {
   const startTime = Date.now();
   while (Date.now() - startTime < maxWaitTimeMs) {
-    // Get payment transactions
     const eventsResult = await getEvents({ programId, accessToken });
     const filteredEvents = eventsResult.body.filter(
       (event) =>

--- a/services/121-service/test/registrations/delete-registration.test.ts
+++ b/services/121-service/test/registrations/delete-registration.test.ts
@@ -61,7 +61,7 @@ describe('Delete PA', () => {
       programId,
       accessToken,
     );
-    const eventsResponse = await getEvents(programId);
+    const eventsResponse = await getEvents({ programId, accessToken });
     const deleteEvent = eventsResponse.body[0];
 
     // Assert

--- a/services/121-service/test/registrations/pagination/update-registration-status.test.ts
+++ b/services/121-service/test/registrations/pagination/update-registration-status.test.ts
@@ -67,7 +67,10 @@ describe('change the status of a set of registrations', () => {
     });
     const registrations = getRegistrationsResponse.body.data;
 
-    const eventsReponse = await getEvents(programIdOCW);
+    const eventsReponse = await getEvents({
+      programId: programIdOCW,
+      accessToken,
+    });
 
     // Assert
     expect(updateStatusResponse.body.totalFilterCount).toBe(

--- a/services/121-service/test/registrations/pagination/update-registration-status.test.ts
+++ b/services/121-service/test/registrations/pagination/update-registration-status.test.ts
@@ -67,7 +67,7 @@ describe('change the status of a set of registrations', () => {
     });
     const registrations = getRegistrationsResponse.body.data;
 
-    const eventsReponse = await getEvents({
+    const eventsResponse = await getEvents({
       programId: programIdOCW,
       accessToken,
     });
@@ -82,7 +82,7 @@ describe('change the status of a set of registrations', () => {
     for (const registration of registrations) {
       expect(registration.status).toBe(newStatus);
       // For each registration status change, there should be an event with a reason
-      const event = eventsReponse.body.find(
+      const event = eventsResponse.body.find(
         (event) =>
           event.registrationId === registration.id &&
           event.attributes.newValue === newStatus,


### PR DESCRIPTION
[AB#36898](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/36898) <!--- Replace this with a reference to a DevOps/backlog-issue -->

In the 121-service docker logs of the [failed api tests](https://github.com/global-121/121-platform/actions/runs/15773000731/job/44461262205) I found the followig event related errors: 
<img width="2156" alt="image" src="https://github.com/user-attachments/assets/6aa09b7c-8cdf-410e-976f-d43c9f9705fe" />

My assumption is, is the we reset the database while our 121-service is still trying to store events. The registrations in the database are than already gone due to the reset. Which is why that error is thrown in the screenshot and the server crashes.

To fix this I changed the `waitForStatusChangeToComplete` to wait for the registration status change events to be created instead of waiting for the moment that registration.status changed. Because the events are created after the registrations status change.

Not sure if all these assumptions are correct or if this PR will solve the issues. I also don't think it will hurt to try it and conceptually I think this is an improvement anyway.

Edit: 

<img width="2183" alt="image" src="https://github.com/user-attachments/assets/1e3854f5-e0fa-4102-9cad-f467eac6421e" />

In this[ api test](https://github.com/global-121/121-platform/actions/runs/15632769116/job/44040722982) run I found an error on the insertion of event. I think this support my earlier made hypothesis that the db resets before events are inserted

## Describe your changes

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
