### PR TITLE
fix: cash disbursed discrepancy AB#36934

### DIFF
--- a/interfaces/portal/src/app/pages/project-monitoring/project-monitoring.page.html
+++ b/interfaces/portal/src/app/pages/project-monitoring/project-monitoring.page.html
@@ -63,7 +63,7 @@
       i18n-chipTooltip
       chipVariant="blue"
       [metricValue]="
-        metrics.data()?.spentMoney
+        metrics.data()?.cashDisbursed
           | currency: project.data()?.currency : 'symbol-narrow' : '1.0-0'
       "
       metricLabel="Cash disbursed"

--- a/interfaces/portal/src/app/pages/project-monitoring/project-monitoring.page.ts
+++ b/interfaces/portal/src/app/pages/project-monitoring/project-monitoring.page.ts
@@ -78,15 +78,15 @@ export class ProjectMonitoringPageComponent {
       return;
     }
 
-    if (!metricsData.totalBudget && metricsData.spentMoney) {
-      return -metricsData.spentMoney;
+    if (!metricsData.totalBudget && metricsData.cashDisbursed) {
+      return -metricsData.cashDisbursed;
     }
 
     if (!metricsData.totalBudget) {
       return;
     }
 
-    return metricsData.totalBudget - metricsData.spentMoney;
+    return metricsData.totalBudget - metricsData.cashDisbursed;
   });
 
   readonly latestPaymentNumber = computed(() => {

--- a/interfaces/portal/src/app/pages/projects-overview/components/project-summary-card/project-summary-card.component.ts
+++ b/interfaces/portal/src/app/pages/projects-overview/components/project-summary-card/project-summary-card.component.ts
@@ -89,7 +89,7 @@ export class ProjectSummaryCardComponent {
       },
       {
         value: this.currencyPipe.transform(
-          this.metrics.data()?.spentMoney,
+          this.metrics.data()?.cashDisbursed,
           this.project.data()?.currency,
           'symbol-narrow',
           '1.0-0',

--- a/services/121-service/src/metrics/dto/program-stats.dto.ts
+++ b/services/121-service/src/metrics/dto/program-stats.dto.ts
@@ -5,5 +5,5 @@ export class ProgramStats {
   public registeredPeople: number;
   public newPeople: number;
   public totalBudget: number | null;
-  public spentMoney: number;
+  public cashDisbursed: number;
 }


### PR DESCRIPTION
AB#36923

## Describe your changes

See analysis in AB#36923. This PR does 3 things:
1. Filter out error transactions from the cash disbursed metrics.
2. Cast 'amount' explicitly to 'numeric'  before summing to get to the correct sum.
3. Rename 'moneySpent' to 'cashDisbursed' throughout the platform to align with UX copy name.

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
