### PR TITLE
Await status change, improve test flakiness

### DIFF
--- a/services/121-service/test/helpers/registration.helper.ts
+++ b/services/121-service/test/helpers/registration.helper.ts
@@ -1,3 +1,4 @@
+import { HttpStatus } from '@nestjs/common';
 import { isMatch } from 'lodash';
 import * as request from 'supertest';
 
@@ -270,7 +271,7 @@ export function getRegistrations({
     .send();
 }
 
-export async function changeRegistrationStatus({
+async function changeRegistrationStatus({
   programId,
   referenceIds,
   status,
@@ -341,6 +342,10 @@ export async function awaitChangeRegistrationStatus({
     accessToken,
     options,
   });
+  // If the changeRegistrationStatus throws an error, it means that the status change is not allowed/succesful so we don't need to wait for it
+  if (result.status !== HttpStatus.ACCEPTED) {
+    return result;
+  }
 
   await waitForStatusChangeToComplete(
     programId,

--- a/services/121-service/test/registrations/pagination/update-registration-status.test.ts
+++ b/services/121-service/test/registrations/pagination/update-registration-status.test.ts
@@ -4,7 +4,6 @@ import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { waitForStatusUpdateToComplete } from '@121-service/test/helpers/program.helper';
 import {
   awaitChangeRegistrationStatus,
-  changeRegistrationStatus,
   getEvents,
   getRegistrations,
   importRegistrations,
@@ -170,7 +169,7 @@ describe('change the status of a set of registrations', () => {
 
       for (const status of statusesThatRequireReason) {
         // Act
-        const updateStatusResponse = await changeRegistrationStatus({
+        const updateStatusResponse = await awaitChangeRegistrationStatus({
           programId: programIdOCW,
           referenceIds,
           status,


### PR DESCRIPTION
[AB#36863](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/36863) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes


- Replaced direct changeRegistrationStatus calls with the new awaitChangeRegistrationStatus helper
- Ensures tests now await the eventual status update rather than proceeding immediately
- May prevent cases like [this](https://github.com/global-121/121-platform/actions/runs/15996123736/job/45119841936?pr=6969)

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
