### PR TITLE
refactor: Align Dockerfile(s) + define their own healthcheck

### DIFF
--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -52,9 +52,8 @@ jobs:
           cp services/.env.example services/.env
 
       - name: Run Services with Docker
-        working-directory: ./services
         run: |
-          docker --log-level 'warn' compose -f docker-compose.yml up -d --quiet-pull --wait --wait-timeout 300
+          npm run start:services:ci
 
       - name: Run Portal
         working-directory: ./interfaces/portal

--- a/.github/workflows/test_service_api.yml
+++ b/.github/workflows/test_service_api.yml
@@ -39,9 +39,8 @@ jobs:
           cp ./services/.env.example services/.env
 
       - name: Run Services with Docker
-        working-directory: ./services
         run: |
-          docker --log-level 'warn' compose -f docker-compose.yml up -d --quiet-pull --wait --wait-timeout 300
+          npm run start:services:ci
 
       - name: Check that no new migrations are necessary
         working-directory: ./services

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "logs:services": "cd services/ && docker compose logs --follow",
     "start:services": "cd services/ && docker compose --file=docker-compose.yml --file=docker-compose.development.yml up --build",
     "start:services:detach": "npm run start:services -- --detach",
-    "start:services:production": "cd services/ && docker compose --file=docker-compose.yml up --detach --build",
+    "start:services:ci": "cd services/ && docker --log-level='warn' compose --file=docker-compose.yml up --detach --build --quiet-pull --wait --wait-timeout 300",
     "start:services:appmap": "cd services/ && docker compose --file=docker-compose.yml --file=docker-compose.development.yml --file=docker-compose.development-appmap.yml up --detach --build",
     "start:portal": "npm start --prefix interfaces/portal/ -- --port=8888",
     "start:portal:e2e": "npm run start:debug-production --prefix interfaces/portal/ -- --port=8088",

--- a/services/121-service/Dockerfile
+++ b/services/121-service/Dockerfile
@@ -5,6 +5,13 @@ RUN apt-get update && apt-get install -y curl procps
 
 WORKDIR /home/node/app
 
+EXPOSE ${PORT_121_SERVICE}
+
+HEALTHCHECK \
+  --start-period=60s \
+  --timeout=300s \
+  CMD curl --fail http://localhost:${PORT_121_SERVICE}/api/health/health || exit 1
+
 FROM base AS production
 
 COPY ./package*.json ./
@@ -22,4 +29,4 @@ FROM base AS development
 
 COPY . .
 
-# Starting the node process happens in docker-compose-development.yml
+CMD ["npm", "run", "start:dev"]

--- a/services/121-service/Dockerfile
+++ b/services/121-service/Dockerfile
@@ -5,12 +5,13 @@ RUN apt-get update && apt-get install -y curl procps
 
 WORKDIR /home/node/app
 
+# This exposed port is technically not the same as the published port using Compose (we use the same number for simplicity)
 EXPOSE ${PORT_121_SERVICE}
 
 HEALTHCHECK \
   --start-period=60s \
   --timeout=300s \
-  CMD curl --fail http://localhost:${PORT_121_SERVICE}/api/health/health || exit 1
+  CMD curl --fail http://0.0.0.0:${PORT_121_SERVICE}/api/health/health || exit 1
 
 FROM base AS production
 

--- a/services/docker-compose.development.yml
+++ b/services/docker-compose.development.yml
@@ -13,6 +13,17 @@
 #
 
 services:
+  mock-service:
+    build:
+      target: development
+    ports:
+      - '${PORT_MOCK_SERVICE}:${PORT_MOCK_SERVICE}'
+      - '9230:9230'
+    volumes:
+      - 'mock_service_node_modules:/home/node/app/node_modules'
+      - './mock-service:/home/node/app'
+    restart: unless-stopped
+
   121-service:
     build:
       target: development
@@ -24,16 +35,6 @@ services:
       - '121_service_node_modules:/home/node/app/node_modules'
       - './121-service:/home/node/app'
     command: 'npm run start:dev${WINDOWS_DEV_STARTUP_SUFFIX}'
-    restart: unless-stopped
-  mock-service:
-    build:
-      target: development
-    ports:
-      - '${PORT_MOCK_SERVICE}:${PORT_MOCK_SERVICE}'
-      - '9230:9230'
-    volumes:
-      - 'mock_service_node_modules:/home/node/app/node_modules'
-      - './mock-service:/home/node/app'
     restart: unless-stopped
 
 volumes:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -45,12 +45,6 @@ services:
     stdin_open: true
     tty: true
     restart: on-failure
-    healthcheck:
-      test: curl --fail http://mock-service:${PORT_MOCK_SERVICE}/api/instance/version || exit 1
-      interval: 15s
-      retries: 15
-      start_period: 60s
-      timeout: 300s
 
   121-service:
     container_name: 121-service
@@ -74,9 +68,3 @@ services:
         required: true
         restart: true
     restart: on-failure
-    healthcheck:
-      test: curl --fail ${EXTERNAL_121_SERVICE_URL}api/organization || exit 1
-      interval: 15s
-      retries: 15
-      start_period: 60s
-      timeout: 300s

--- a/services/mock-service/Dockerfile
+++ b/services/mock-service/Dockerfile
@@ -5,9 +5,17 @@ RUN apt-get update && apt-get install -y curl procps
 
 WORKDIR /home/node/app
 
+EXPOSE ${PORT_MOCK_SERVICE}
+
+HEALTHCHECK \
+  --start-period=60s \
+  --timeout=300s \
+  CMD curl --fail http://localhost:${PORT_MOCK_SERVICE}/api/instance/version || exit 1
+
 FROM base AS production
 
 COPY ./package*.json ./
+COPY ./.npmrc ./
 
 RUN npm ci
 

--- a/services/mock-service/Dockerfile
+++ b/services/mock-service/Dockerfile
@@ -5,12 +5,13 @@ RUN apt-get update && apt-get install -y curl procps
 
 WORKDIR /home/node/app
 
+# This exposed port is technically not the same as the published port using Compose (we use the same number for simplicity)
 EXPOSE ${PORT_MOCK_SERVICE}
 
 HEALTHCHECK \
   --start-period=60s \
   --timeout=300s \
-  CMD curl --fail http://localhost:${PORT_MOCK_SERVICE}/api/instance/version || exit 1
+  CMD curl --fail http://0.0.0.0:${PORT_MOCK_SERVICE}/api/instance/version || exit 1
 
 FROM base AS production
 


### PR DESCRIPTION
[AB#37006](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37006)

## Describe your changes

Be explicit in each service's `Dockerfile`, to remove some confusion on "what this `localhost`-URL actually is".

To summarise/visualise:

- Inside a `Dockerfile` (inside the individual container), the container is 'known' as `localhost`, addressable to any port you `EXPOSE`
  - So this address should be used for the health-check.
  - We _could_ expose port `8080` for every service/container here...
- In a `docker-compose.yml`-file, you define something that 'wraps around some containers'.  
  So in there, you can map the 'internal ports' to 'externally exposed ports'.  
  This is what enables the URL `localhost:3000`(=your local development machine's `localhost`+the external port `3000`) to access `localhost:8080`(=container's `localhost`+'exposed' port `8080`)

But, in this PR, to be explicit about the final state we'd like and 'hide' the container-internal-specifics; I've 'overruled' any of these dynamics with "one set truth, defined by the ENV-variables.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] Adding tests is unnecessary/irrelevant
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
