### PR TITLE
fix: flaky do-payment-filter AB#37009

### DIFF
--- a/services/121-service/test/helpers/registration.helper.ts
+++ b/services/121-service/test/helpers/registration.helper.ts
@@ -363,6 +363,10 @@ export async function waitForStatusChangeToComplete(
   const startTime = Date.now();
   while (Date.now() - startTime < maxWaitTimeMs) {
     const eventsResult = await getEvents({ programId, accessToken });
+    if (!eventsResult?.body || !Array.isArray(eventsResult.body)) {
+      await waitFor(200);
+      continue;
+    }
     const filteredEvents = eventsResult.body.filter(
       (event) =>
         event.type === EventEnum.registrationStatusChange &&


### PR DESCRIPTION
[AB#37009](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37009)

## Describe your changes

- when looking at a recent occurence of this here: https://github.com/global-121/121-platform/actions/runs/15972884791/job/45048604813#step:6:469
- I saw that a recent change actually caused the code to break on eventsResult.body.filter if eventsResult.body was not an array yet, instead of staying in the while loop until it was.
- So if directly an array, the test still passes, but if not, then it fails. This PR should solve that.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
