### PR TITLE
refactor: Don't use hard-coded numbers, used named status-codes

### DIFF
--- a/services/121-service/src/payments/fsp-integration/nedbank/services/nedbank-api-client.service.spec.ts
+++ b/services/121-service/src/payments/fsp-integration/nedbank/services/nedbank-api-client.service.spec.ts
@@ -1,3 +1,4 @@
+import { HttpStatus } from '@nestjs/common';
 import { AxiosResponse } from '@nestjs/terminus/dist/health-indicator/http/axios.interfaces';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as https from 'https';
@@ -63,7 +64,7 @@ describe('NedbankApiClientService', () => {
           Links: { Self: '' },
           Meta: {},
         },
-        status: 201,
+        status: HttpStatus.CREATED,
         statusText: 'OK',
         headers: {},
         config: {},
@@ -120,7 +121,7 @@ describe('NedbankApiClientService', () => {
             { ErrorCode: 'NB.APIM.Field.Invalid', Message: 'Error message' },
           ],
         },
-        status: 400,
+        status: HttpStatus.BAD_REQUEST,
         statusText: 'Bad Request',
         headers: {},
         config: {},

--- a/services/121-service/src/payments/fsp-integration/onafriq/services/onafriq.api.service.spec.ts
+++ b/services/121-service/src/payments/fsp-integration/onafriq/services/onafriq.api.service.spec.ts
@@ -1,3 +1,4 @@
+import { HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { OnafriqApiResponseStatusType } from '@121-service/src/payments/fsp-integration/onafriq/enum/onafriq-api-response-status-type.enum';
@@ -53,7 +54,7 @@ describe('OnafriqApiService', () => {
 
     it('should return success status on success response', async () => {
       const validResponse = {
-        status: 200,
+        status: HttpStatus.OK,
         data: {
           totalTxSent: 1,
           noTxAccepted: 1,
@@ -92,12 +93,12 @@ describe('OnafriqApiService', () => {
     it('should call post twice and return the second response on success', async () => {
       process.env.MOCK_ONAFRIQ = '';
       const firstResponse = {
-        status: 200,
+        status: HttpStatus.OK,
         statusText: 'OK',
         data: { message: 'Success' },
       };
       const secondResponse = {
-        status: 200,
+        status: HttpStatus.OK,
         statusText: 'OK',
         data: { message: 'Success' },
       };
@@ -113,7 +114,7 @@ describe('OnafriqApiService', () => {
     it('should return after first post if not 200 or message not Success', async () => {
       process.env.MOCK_ONAFRIQ = '';
       const firstResponse = {
-        status: 400,
+        status: HttpStatus.BAD_REQUEST,
         statusText: 'Bad Request',
         data: { message: 'Error' },
       };

--- a/services/121-service/src/payments/fsp-integration/onafriq/services/onafriq.api.service.ts
+++ b/services/121-service/src/payments/fsp-integration/onafriq/services/onafriq.api.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
 import * as https from 'https';
 
 import { DEBUG, EXTERNAL_API } from '@121-service/src/config';
@@ -56,7 +56,7 @@ export class OnafriqApiService {
         headers,
         DEBUG ? this.httpsAgent : undefined, // Use the custom HTTPS agent only in debug mode
       );
-    if (status !== 200 || data?.message !== 'Success') {
+    if (status !== HttpStatus.OK || data?.message !== 'Success') {
       return { status, statusText, data };
     }
 


### PR DESCRIPTION
AB#37029

## Describe your changes

I haven't found a specific lint-rule for this;
But: https://typescript-eslint.io/rules/no-magic-numbers (even with all the exception-options) causes `894` issues... :/

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] Adding tests is unnecessary/irrelevant
- [x] The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
