### PR TITLE
Also log kobo errors

### DIFF
--- a/services/121-service/src/kobo-connect/kobo-connect.service.ts
+++ b/services/121-service/src/kobo-connect/kobo-connect.service.ts
@@ -33,6 +33,9 @@ export class KoboConnectService {
       errors.push(result.detail);
     }
 
+    // Log the error details for debugging else we get a 500 email without context
+    console.error('KoboConnectService ~ errors:', errors);
+
     throw new HttpException(
       {
         message: 'Kobo-Connect API did not return a result',


### PR DESCRIPTION
[AB#37113](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37113) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

A 500 error triggers an email. If we use this: 
```
    throw new HttpException(
      {
        message: 'Kobo-Connect API did not return a result',
        errors,
      },
      HttpStatus.INTERNAL_SERVER_ERROR,
    );
```

instead of 

```
throw new Error()

```
we get an email but we see nothing in the logs. In this case we do not want to use a normal error because than our CVA_IM user will get no feedback because the errors are not returned to the caller. 

I therefore added a line to also log the error.

We could also argue it should be a bad request instead of an INTERNAL_SERVER_ERROR. But maybe we do want the email, i am not sure. But such a change could be a separate PR

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
