### PR TITLE
refactor: Remove the extraneous volumes that require double installs of dependencies

### DIFF
--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -90,12 +90,6 @@ jobs:
           cp .env.example .env
           npm run start:debug-production > run-portal-logs.txt 2>&1 &
 
-      - name: Install 121-Service dependencies
-        # This step is necessary because the tests run functions in this folder
-        working-directory: ./services/121-service
-        run: |
-          npm install
-
       - name: Install E2E-Tests runtime-dependencies
         working-directory: ${{ env.e2eTestsPath }}
         run: |

--- a/services/docker-compose.development.yml
+++ b/services/docker-compose.development.yml
@@ -20,7 +20,6 @@ services:
       - '${PORT_MOCK_SERVICE}:${PORT_MOCK_SERVICE}'
       - '9230:9230'
     volumes:
-      - 'mock_service_node_modules:/home/node/app/node_modules'
       - './mock-service:/home/node/app'
     restart: unless-stopped
 
@@ -32,11 +31,6 @@ services:
       - '9229:9229'
       - '9231:9231'
     volumes:
-      - '121_service_node_modules:/home/node/app/node_modules'
       - './121-service:/home/node/app'
     command: 'npm run start:dev${WINDOWS_DEV_STARTUP_SUFFIX}'
     restart: unless-stopped
-
-volumes:
-  121_service_node_modules:
-  mock_service_node_modules:


### PR DESCRIPTION
[AB#37189](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37189)

## Describe your changes

Now that we're all running the development-stack on macOS, I think it is safe to remove the 'one-way shared volume' of the `node_modules`-folders.
This was supposed to 'speed up' the `watch`-type commands or to fix/prevent some other speed/performance issue...

But sometimes, after locally rebasing back on `main`, this was causing the need to run `npm i` in the `services/121-service`-folder an extra time, even if you already "created the Docker-containers from scratch"..

Now the `node_modules`-folder in the Docker-container should contain the same files as the local `node_modules`-folder. And each OS (Ubuntu from within the container; macOS from 'outside') should be able to use the same code. (Ubuntu for running the 121-service, macOS for running the ESLint/Prettier code)



## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] Adding tests is unnecessary/irrelevant
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
