### PR TITLE
Simplify block visa using sms instead of whatsapp

### DIFF
--- a/services/121-service/test/visa-card/block-visa-card.test.ts
+++ b/services/121-service/test/visa-card/block-visa-card.test.ts
@@ -20,6 +20,8 @@ import {
   resetDB,
 } from '@121-service/test/helpers/utility.helper';
 
+const noWhatsappSetup = null; // Do not use WhatsApp for this test to avoid race conditions - our mock server replies 'yes' on pending whatsapp message a bit too fast
+
 describe('(Un)Block visa debit card', () => {
   let accessToken: string;
 
@@ -33,7 +35,7 @@ describe('(Un)Block visa debit card', () => {
     const testRegistration = {
       ...registrationVisa,
       referenceId: 'test-registration-visa--block-card',
-      whatsappPhoneNumber: null, // Do not use WhatsApp for this test to avoid race conditions - our api test replies 'yes' on pending whatsapp message a bit too fast
+      whatsappPhoneNumber: noWhatsappSetup,
     };
     await seedPaidRegistrations([testRegistration], programIdVisa);
     const visaWalletResponseBefore = await getVisaWalletsAndDetails(
@@ -89,7 +91,7 @@ describe('(Un)Block visa debit card', () => {
     const testRegistration = {
       ...registrationVisa,
       referenceId: 'test-registration-visa--unblock-card',
-      whatsappPhoneNumber: null, // Do not use WhatsApp for this test to avoid race conditions - our api test replies 'yes' on pending whatsapp message a bit too fast
+      whatsappPhoneNumber: noWhatsappSetup,
     };
     await seedPaidRegistrations([testRegistration], programIdVisa);
 


### PR DESCRIPTION
[AB#37302](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37302) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

In this[ failed run](https://github.com/global-121/121-platform/actions/runs/16270077058/job/45935170718?pr=7034) I see the payment messages twice

My hypothesis is that this test fails because in our API test the our mock-service replies 'yes' a bit too fast on incoming whatsapp an therefore the minimumNumberOfMessagesPerReferenceId is reached too fast with messages that are accidentally send duplicate. 

This duplicate sending of whatsapp messages is something we encountered befor, but is not rely a problem on production because people generally do no reply as fast with 'yes' as machines

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
