### PR TITLE
ci: Make the path-filter external-action only run on PRs, to prevent confusing errors

### DIFF
--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -139,8 +139,13 @@ jobs:
     needs: [test-shard]
     if: ${{ always() }}
     steps:
-      - name: Required check failed
+      - name: Check required job results
         if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
-      - name: Dummy step
-        run: echo "All required checks have successfully passed."
+        run: |
+          echo "Some checks have failed." >> $GITHUB_STEP_SUMMARY
+          exit 1
+      - name: Check required job results
+        if: ${{ contains(needs.*.result, 'failure') != 'true' || contains(needs.*.result, 'cancelled') != 'true' || contains(needs.*.result, 'skipped') != 'true' }}
+        run: |
+          echo "All required checks have successfully passed." >> $GITHUB_STEP_SUMMARY
+          exit 0

--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -21,13 +21,14 @@ jobs:
       should_skip: ${{ steps.filter.outputs.should_skip }}
     steps:
       - uses: actions/checkout@v4
+        # Other events (from the merge-queue) can safely ignore the path-filter; Its output would default to 'NOT true'
         if: github.event_name == 'pull_request'
         with:
           filter: blob:none # Reduce clone size/speed
           fetch-depth: 0 # Full history is needed to determine the "changed files in this PR"
 
       - uses: leavesster/pull-request-path-filter@v0.2
-        # Other events (from the merge-queue) can safely ignore the path-filter
+        # Other events (from the merge-queue) can safely ignore the path-filter; Its output would default to 'NOT true'
         if: github.event_name == 'pull_request'
         id: filter
         with:

--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -138,15 +138,15 @@ jobs:
   test-shard-resolution-e2e:
     runs-on: ubuntu-latest
     needs: [test-shard]
-    if: ${{ always() }}
+    if: always()
     steps:
       - name: Check required job results
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "Some checks have failed." >> $GITHUB_STEP_SUMMARY
           exit 1
       - name: Check required job results
-        if: ${{ contains(needs.*.result, 'failure') != 'true' || contains(needs.*.result, 'cancelled') != 'true' }}
+        if: contains(needs.*.result, 'failure') != 'true' || contains(needs.*.result, 'cancelled') != 'true'
         run: |
           echo "All required checks have successfully passed." >> $GITHUB_STEP_SUMMARY
           exit 0

--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -20,15 +20,17 @@ jobs:
     outputs:
       should_skip: ${{ steps.filter.outputs.should_skip }}
     steps:
-      - uses: actions/checkout@v4 # better this action use git diff, so you need checkout the code first
+      - uses: actions/checkout@v4
         with:
-          filter: blob:none # reduce clone size
-          fetch-depth: 0 # need full history, the default is 1, which is not enough. if you limit the pull request' commit length, you can set it to your limit.
-      - uses: leavesster/pull-request-path-filter@v0.2 # v0.2 is the latest version
-        id: 'filter'
+          filter: blob:none # Reduce clone size/speed
+          fetch-depth: 0 # Full history is needed to determine the "changed files in this PR"
+
+      - uses: leavesster/pull-request-path-filter@v0.2
+        # Other events (from the merge-queue) can safely ignore the path-filter
+        if: github.event_name == 'pull_request'
+        id: filter
         with:
-          paths:
-            | # notice the `|`, it's required. the left is same as github action's path and paths-ignore
+          paths: |
             - '.github/workflows/test_e2e_portal.yml'
             - 'e2e/**'
             - 'services/.env.example'
@@ -39,6 +41,7 @@ jobs:
             - '!interfaces/portal/**.test.ts'
             - '!interfaces/portal/**.spec.ts'
             - '!**.md'
+
   test-shard:
     runs-on: ubuntu-latest
     needs: path-filter

--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -146,7 +146,7 @@ jobs:
           echo "Some checks have failed." >> $GITHUB_STEP_SUMMARY
           exit 1
       - name: Check required job results
-        if: ${{ contains(needs.*.result, 'failure') != 'true' || contains(needs.*.result, 'cancelled') != 'true' || contains(needs.*.result, 'skipped') != 'true' }}
+        if: ${{ contains(needs.*.result, 'failure') != 'true' || contains(needs.*.result, 'cancelled') != 'true' }}
         run: |
           echo "All required checks have successfully passed." >> $GITHUB_STEP_SUMMARY
           exit 0

--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -21,6 +21,7 @@ jobs:
       should_skip: ${{ steps.filter.outputs.should_skip }}
     steps:
       - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request'
         with:
           filter: blob:none # Reduce clone size/speed
           fetch-depth: 0 # Full history is needed to determine the "changed files in this PR"

--- a/.github/workflows/test_service_api.yml
+++ b/.github/workflows/test_service_api.yml
@@ -29,21 +29,26 @@ jobs:
     outputs:
       should_skip: ${{ steps.filter.outputs.should_skip }}
     steps:
-      - uses: actions/checkout@v4 # better this action use git diff, so you need checkout the code first
+      - uses: actions/checkout@v4
+        # Other events (from the merge-queue) can safely ignore the path-filter; Its output would default to 'NOT true'
+        if: github.event_name == 'pull_request'
         with:
-          filter: blob:none # reduce clone size
-          fetch-depth: 0 # need full history, the default is 1, which is not enough. if you limit the pull request' commit length, you can set it to your limit.
-      - uses: leavesster/pull-request-path-filter@v0.2 # v0.2 is the latest version
+          filter: blob:none # Reduce clone size/speed
+          fetch-depth: 0 # Full history is needed to determine the "changed files in this PR"
+
+      - uses: leavesster/pull-request-path-filter@v0.2
+        # Other events (from the merge-queue) can safely ignore the path-filter; Its output would default to 'NOT true'
+        if: github.event_name == 'pull_request'
         id: 'filter'
         with:
-          paths:
-            | # notice the `|`, it's required. the left is same as github action's path and paths-ignore
+          paths: |
             - .github/workflows/test_service_api.yml
             - .github/actions/build-service/action.yml
             - services/.env.example
             - services/121-service/**
             - services/mock-service/**
             - '!**.md'
+
   test-shard:
     runs-on: ubuntu-latest
     needs: path-filter

--- a/.github/workflows/test_service_api.yml
+++ b/.github/workflows/test_service_api.yml
@@ -169,15 +169,15 @@ jobs:
   test-shard-resolution-api:
     runs-on: ubuntu-latest
     needs: [test-shard, test]
-    if: ${{ always() }}
+    if: always()
     steps:
       - name: Check required job results
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "Some checks have failed." >> $GITHUB_STEP_SUMMARY
           exit 1
       - name: Check required job results
-        if: ${{ contains(needs.*.result, 'failure') != 'true' || contains(needs.*.result, 'cancelled') != 'true' }}
+        if: contains(needs.*.result, 'failure') != 'true' || contains(needs.*.result, 'cancelled') != 'true'
         run: |
           echo "All required checks have successfully passed." >> $GITHUB_STEP_SUMMARY
           exit 0

--- a/.github/workflows/test_service_api.yml
+++ b/.github/workflows/test_service_api.yml
@@ -171,8 +171,13 @@ jobs:
     needs: [test-shard, test]
     if: ${{ always() }}
     steps:
-      - name: Required check failed
+      - name: Check required job results
         if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
-      - name: Dummy step
-        run: echo "All required checks have successfully passed."
+        run: |
+          echo "Some checks have failed." >> $GITHUB_STEP_SUMMARY
+          exit 1
+      - name: Check required job results
+        if: ${{ contains(needs.*.result, 'failure') != 'true' || contains(needs.*.result, 'cancelled') != 'true' || contains(needs.*.result, 'skipped') != 'true' }}
+        run: |
+          echo "All required checks have successfully passed." >> $GITHUB_STEP_SUMMARY
+          exit 0

--- a/.github/workflows/test_service_api.yml
+++ b/.github/workflows/test_service_api.yml
@@ -177,7 +177,7 @@ jobs:
           echo "Some checks have failed." >> $GITHUB_STEP_SUMMARY
           exit 1
       - name: Check required job results
-        if: ${{ contains(needs.*.result, 'failure') != 'true' || contains(needs.*.result, 'cancelled') != 'true' || contains(needs.*.result, 'skipped') != 'true' }}
+        if: ${{ contains(needs.*.result, 'failure') != 'true' || contains(needs.*.result, 'cancelled') != 'true' }}
         run: |
           echo "All required checks have successfully passed." >> $GITHUB_STEP_SUMMARY
           exit 0


### PR DESCRIPTION

[AB#37303](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37303)

## Describe your changes

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] Adding tests is unnecessary/irrelevant
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
