### PR TITLE
chore: also workaround onafriq sandbox cert error on test

### DIFF
--- a/services/121-service/src/config.ts
+++ b/services/121-service/src/config.ts
@@ -1,6 +1,7 @@
 import { env } from '@121-service/src/env';
 
 export const IS_DEVELOPMENT = env.NODE_ENV === 'development';
+export const IS_TEST = env.NODE_ENV === 'test';
 export const IS_PRODUCTION = env.NODE_ENV === 'production';
 
 // Configure Swagger UI appearance:

--- a/services/121-service/src/payments/fsp-integration/onafriq/services/onafriq.api.service.ts
+++ b/services/121-service/src/payments/fsp-integration/onafriq/services/onafriq.api.service.ts
@@ -1,7 +1,7 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
 import * as https from 'https';
 
-import { EXTERNAL_API, IS_DEVELOPMENT } from '@121-service/src/config';
+import { EXTERNAL_API, IS_DEVELOPMENT, IS_TEST } from '@121-service/src/config';
 import { env } from '@121-service/src/env';
 import { OnafriqApiCallServiceRequestBody } from '@121-service/src/payments/fsp-integration/onafriq/dtos/onafriq-api/onafriq-api-call-service-request-body.dto';
 import { OnafriqApiCallServiceResponseBody } from '@121-service/src/payments/fsp-integration/onafriq/dtos/onafriq-api/onafriq-api-call-service-response-body.dto';
@@ -26,7 +26,8 @@ export class OnafriqApiService {
   ) {
     // NOTE: Adding this was needed to get past an UNABLE_TO_GET_ISSUER_CERT_LOCALLY error on sandbox API. Create a custom HTTPS agent that ignores certificate errors
     // For now, do not use this on production, but first test there without this work-around. If needed, we can add it to production as well.
-    if (IS_DEVELOPMENT) {
+    // The IS_TEST assumes that on test we are using the sandbox API, which is not production.
+    if (IS_DEVELOPMENT || IS_TEST) {
       this.httpsAgent = new https.Agent({
         rejectUnauthorized: false,
       });


### PR DESCRIPTION
[AB#37316](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37316) 

## Describe your changes

Since test uses the Onafriq sandbox API, it also needs the workaround to ignore the certificate error that we use on local.

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
