### PR TITLE
Add GET endpoint for visible FspConfig properties

### DIFF
--- a/services/121-service/src/fsps/enums/fsp-name.enum.ts
+++ b/services/121-service/src/fsps/enums/fsp-name.enum.ts
@@ -21,3 +21,17 @@ export enum FspConfigurationProperties {
   fundingTokenCode = 'fundingTokenCode',
   paymentReferencePrefix = 'paymentReferencePrefix',
 }
+
+export const FspConfigPropertyValueVisibility: Record<
+  FspConfigurationProperties,
+  boolean
+> = {
+  [FspConfigurationProperties.password]: false,
+  [FspConfigurationProperties.username]: false,
+  [FspConfigurationProperties.columnsToExport]: true,
+  [FspConfigurationProperties.columnToMatch]: true,
+  [FspConfigurationProperties.brandCode]: true,
+  [FspConfigurationProperties.coverLetterCode]: true,
+  [FspConfigurationProperties.fundingTokenCode]: true,
+  [FspConfigurationProperties.paymentReferencePrefix]: true,
+};

--- a/services/121-service/src/program-fsp-configurations/dtos/program-fsp-configuration-property-response.dto.ts
+++ b/services/121-service/src/program-fsp-configurations/dtos/program-fsp-configuration-property-response.dto.ts
@@ -4,6 +4,9 @@ export class ProgramFspConfigurationPropertyResponseDto {
   @ApiProperty({ example: 'username' })
   public readonly name: string;
 
+  @ApiProperty({ example: 'RC01' })
+  public readonly value: string;
+
   @ApiProperty({ example: new Date() })
   public updated: Date;
 }

--- a/services/121-service/src/program-fsp-configurations/dtos/program-fsp-configuration-property-response.dto.ts
+++ b/services/121-service/src/program-fsp-configurations/dtos/program-fsp-configuration-property-response.dto.ts
@@ -5,7 +5,7 @@ export class ProgramFspConfigurationPropertyResponseDto {
   public readonly name: string;
 
   @ApiProperty({ example: 'RC01' })
-  public readonly value: string;
+  public readonly value;
 
   @ApiProperty({ example: new Date() })
   public updated: Date;

--- a/services/121-service/src/program-fsp-configurations/mappers/program-fsp-configuration.mapper.ts
+++ b/services/121-service/src/program-fsp-configurations/mappers/program-fsp-configuration.mapper.ts
@@ -67,6 +67,7 @@ export class ProgramFspConfigurationMapper {
   ): ProgramFspConfigurationPropertyResponseDto {
     return {
       name: property.name,
+      value: property.value,
       updated: property.updated,
     };
   }

--- a/services/121-service/src/program-fsp-configurations/program-fsp-configurations.controller.ts
+++ b/services/121-service/src/program-fsp-configurations/program-fsp-configurations.controller.ts
@@ -177,7 +177,7 @@ export class ProgramFspConfigurationsController {
     @Param('programId') programId: number,
     @Param('name') name: string,
   ) {
-    return this.programFspConfigurationsService.getVisibleProperties(
+    return this.programFspConfigurationsService.getProgramFspProperties(
       programId,
       name,
     );

--- a/services/121-service/src/program-fsp-configurations/program-fsp-configurations.controller.ts
+++ b/services/121-service/src/program-fsp-configurations/program-fsp-configurations.controller.ts
@@ -171,7 +171,6 @@ export class ProgramFspConfigurationsController {
   @ApiOperation({
     summary: 'Retrieve visible properties for Fsp Configuration.',
   })
-  @ApiParam({ name: 'programId', required: true, type: 'integer' })
   @Get(':programId/fsp-configurations/:name/properties')
   public async getVisibleProperties(
     @Param('programId') programId: number,

--- a/services/121-service/src/program-fsp-configurations/program-fsp-configurations.controller.ts
+++ b/services/121-service/src/program-fsp-configurations/program-fsp-configurations.controller.ts
@@ -169,6 +169,22 @@ export class ProgramFspConfigurationsController {
 
   @AuthenticatedUser({ isAdmin: true })
   @ApiOperation({
+    summary: 'Retrieve visible properties for Fsp Configuration.',
+  })
+  @ApiParam({ name: 'programId', required: true, type: 'integer' })
+  @Get(':programId/fsp-configurations/:name/properties')
+  public async getVisibleProperties(
+    @Param('programId') programId: number,
+    @Param('name') name: string,
+  ) {
+    return this.programFspConfigurationsService.getVisibleProperties(
+      programId,
+      name,
+    );
+  }
+
+  @AuthenticatedUser({ isAdmin: true })
+  @ApiOperation({
     summary: `Create properties for a Program FSP Configuration. See ${EXTERNAL_API.rootApi}/fsps for allowed properties per FSP.`,
   })
   @ApiParam({ name: 'programId', required: true, type: 'integer' })

--- a/services/121-service/src/program-fsp-configurations/program-fsp-configurations.controller.ts
+++ b/services/121-service/src/program-fsp-configurations/program-fsp-configurations.controller.ts
@@ -177,7 +177,7 @@ export class ProgramFspConfigurationsController {
     @Param('programId') programId: number,
     @Param('name') name: string,
   ) {
-    return this.programFspConfigurationsService.getProgramFspProperties(
+    return this.programFspConfigurationsService.getFspConfigurationProperties(
       programId,
       name,
     );

--- a/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.ts
+++ b/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.ts
@@ -404,7 +404,7 @@ export class ProgramFspConfigurationsService {
     return property;
   }
 
-  public async getProgramFspProperties(
+  public async getFspConfigurationProperties(
     programId: number,
     name: string,
   ): Promise<{ name: FspConfigurationProperties; value: string }[]> {

--- a/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.ts
+++ b/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.ts
@@ -421,13 +421,8 @@ export class ProgramFspConfigurationsService {
         FspConfigPropertyValueVisibility[
           prop.name as FspConfigurationProperties
         ];
-      let value: string;
-      if (isVisible) {
-        value =
-          typeof prop.value === 'string'
-            ? prop.value
-            : JSON.stringify(prop.value);
-      } else {
+      let value = String(prop.value);
+      if (!isVisible) {
         value = '[********]';
       }
       return {

--- a/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.ts
+++ b/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.ts
@@ -404,7 +404,7 @@ export class ProgramFspConfigurationsService {
     return property;
   }
 
-  public async getVisibleProperties(
+  public async getProgramFspProperties(
     programId: number,
     name: string,
   ): Promise<{ name: FspConfigurationProperties; value: string }[]> {

--- a/services/121-service/swagger.json
+++ b/services/121-service/swagger.json
@@ -433,6 +433,14 @@
     ]
   },
   {
+    "method": "get",
+    "path": "/api/programs/{programId}/fsp-configurations/{name}/properties",
+    "params": [
+      "programId",
+      "name"
+    ]
+  },
+  {
     "method": "post",
     "path": "/api/programs/{programId}/fsp-configurations/{name}/properties",
     "params": [

--- a/services/121-service/test/helpers/program-fsp-configuration.helper.ts
+++ b/services/121-service/test/helpers/program-fsp-configuration.helper.ts
@@ -138,3 +138,21 @@ export async function deleteProgramFspConfigurationProperty({
     )
     .set('Cookie', [accessToken]);
 }
+
+export async function getFspProgramProperties({
+  programId,
+  configName,
+  accessToken,
+}: {
+  programId: number;
+  configName: string;
+  accessToken: string;
+}): Promise<
+  Omit<request.Response, 'body'> & {
+    body: ProgramFspConfigurationPropertyResponseDto[];
+  }
+> {
+  return await getServer()
+    .get(`/programs/${programId}/fsp-configurations/${configName}/properties`)
+    .set('Cookie', [accessToken]);
+}

--- a/services/121-service/test/helpers/program-fsp-configuration.helper.ts
+++ b/services/121-service/test/helpers/program-fsp-configuration.helper.ts
@@ -139,7 +139,7 @@ export async function deleteProgramFspConfigurationProperty({
     .set('Cookie', [accessToken]);
 }
 
-export async function getFspProgramProperties({
+export async function getProgramFspConfigurationProperties({
   programId,
   configName,
   accessToken,

--- a/services/121-service/test/program/manage-program-fsp-configuration.test.ts
+++ b/services/121-service/test/program/manage-program-fsp-configuration.test.ts
@@ -405,8 +405,8 @@ describe('Manage Fsp configurations', () => {
       expect(property.value).not.toBe('[********]'); // Visible properties should not be masked
     });
     properties.forEach((property) => {
-      expect(property.name).not.toBe('username');
-      expect(property.name).not.toBe('password');
+      expect(property.name).not.toBe(FspConfigurationProperties.username);
+      expect(property.name).not.toBe(FspConfigurationProperties.password);
     });
     properties.forEach((property) => {
       expect(enumValues).toContain(property.name);
@@ -426,7 +426,10 @@ describe('Manage Fsp configurations', () => {
     const hiddenPropertyNames = properties.map((property) => property.name);
     // Checks that only hidden properties are returned
     expect(hiddenPropertyNames).toEqual(
-      expect.arrayContaining(['username', 'password']),
+      expect.arrayContaining([
+        FspConfigurationProperties.username,
+        FspConfigurationProperties.password,
+      ]),
     );
     properties.forEach((property) => {
       expect(property.value).toBe('[********]'); // Hidden properties should be masked

--- a/services/121-service/test/program/manage-program-fsp-configuration.test.ts
+++ b/services/121-service/test/program/manage-program-fsp-configuration.test.ts
@@ -395,7 +395,7 @@ describe('Manage Fsp configurations', () => {
     // Act
     const getVisibleProperties = await getFspProgramProperties({
       programId: programIdVisa,
-      configName: 'Intersolve-visa', //This configuration has visible properties
+      configName: Fsps.intersolveVisa, //This configuration has visible properties
       accessToken,
     });
     // Assert
@@ -417,7 +417,7 @@ describe('Manage Fsp configurations', () => {
     // Act
     const getHiddenProperties = await getFspProgramProperties({
       programId: programIdVisa,
-      configName: 'Intersolve-voucher-whatsapp', // This configuration has hidden properties
+      configName: Fsps.intersolveVoucherWhatsapp, // This configuration has hidden properties
       accessToken,
     });
     // Assert

--- a/services/121-service/test/program/manage-program-fsp-configuration.test.ts
+++ b/services/121-service/test/program/manage-program-fsp-configuration.test.ts
@@ -17,7 +17,7 @@ import { getTransactions } from '@121-service/test/helpers/program.helper';
 import {
   deleteProgramFspConfiguration,
   deleteProgramFspConfigurationProperty,
-  getFspProgramProperties,
+  getProgramFspConfigurationProperties,
   getProgramFspConfigurations,
   patchProgramFspConfiguration,
   patchProgramFspConfigurationProperty,
@@ -393,7 +393,7 @@ describe('Manage Fsp configurations', () => {
     // Arrange
     const enumValues = Object.values(FspConfigurationProperties);
     // Act
-    const getVisibleProperties = await getFspProgramProperties({
+    const getVisibleProperties = await getProgramFspConfigurationProperties({
       programId: programIdVisa,
       configName: Fsps.intersolveVisa, //This configuration has visible properties
       accessToken,
@@ -415,7 +415,7 @@ describe('Manage Fsp configurations', () => {
 
   it('Returns masked values for hidden properties of a program Fsp configuration', async () => {
     // Act
-    const getHiddenProperties = await getFspProgramProperties({
+    const getHiddenProperties = await getProgramFspConfigurationProperties({
       programId: programIdVisa,
       configName: Fsps.intersolveVoucherWhatsapp, // This configuration has hidden properties
       accessToken,


### PR DESCRIPTION
[AB#37617](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37617) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Adds GET endpoint that returns only allowed/ visible properties of the FSP program configuration:
1. When visibility set to true: returns name and value
2. When visibility set to false: returns name and '[********]'

Adds integration tests:
1. For Visible properties
2. For Hidden properties

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
