### PR TITLE
adapt logic of which AH vouchers / reminder to send to paymentId refactor

### DIFF
--- a/services/121-service/module-dependencies.md
+++ b/services/121-service/module-dependencies.md
@@ -129,6 +129,7 @@ graph LR
   MessageIncomingModule-->MessageTemplateModule
   MessageIncomingModule-->RegistrationDataModule
   MessageIncomingModule-->QueuesRegistryModule
+  MessageIncomingModule-->TransactionsModule
   NoteModule-->RegistrationsModule
   NoteModule-->UserModule
   ActivitiesModule-->NoteModule

--- a/services/121-service/src/activities/activities.service.ts
+++ b/services/121-service/src/activities/activities.service.ts
@@ -7,7 +7,7 @@ import { NoteScopedRepository } from '@121-service/src/notes/note.repository';
 import { TwilioMessageScopedRepository } from '@121-service/src/notifications/twilio-message.repository';
 import { MessageByRegistrationId } from '@121-service/src/notifications/types/twilio-message-by-registration-id.interface';
 import { GetAuditedTransactionDto } from '@121-service/src/payments/transactions/dto/get-audited-transaction.dto';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { RegistrationEventEntity } from '@121-service/src/registration-events/entities/registration-event.entity';
 import { RegistrationEventScopedRepository } from '@121-service/src/registration-events/registration-event.repository';
 import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';

--- a/services/121-service/src/migration/1755852548143-VoucherPaymentRelation.ts
+++ b/services/121-service/src/migration/1755852548143-VoucherPaymentRelation.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class VoucherPaymentRelation1755852548143 implements MigrationInterface {
+  name = 'VoucherPaymentRelation1755852548143';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c67b949a993d791ba90557fa7b" ON "121-service"."intersolve_voucher" ("paymentId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "121-service"."intersolve_voucher" ADD CONSTRAINT "FK_c67b949a993d791ba90557fa7be" FOREIGN KEY ("paymentId") REFERENCES "121-service"."payment"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "121-service"."intersolve_voucher" DROP CONSTRAINT "FK_c67b949a993d791ba90557fa7be"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "121-service"."IDX_c67b949a993d791ba90557fa7b"`,
+    );
+  }
+}

--- a/services/121-service/src/notifications/message-incoming/message-incoming.module.ts
+++ b/services/121-service/src/notifications/message-incoming/message-incoming.module.ts
@@ -21,6 +21,7 @@ import { WhatsappPendingMessageEntity } from '@121-service/src/notifications/wha
 import { IntersolveVoucherModule } from '@121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-voucher.module';
 import { ImageCodeModule } from '@121-service/src/payments/imagecode/image-code.module';
 import { TransactionEntity } from '@121-service/src/payments/transactions/transaction.entity';
+import { TransactionsModule } from '@121-service/src/payments/transactions/transactions.module';
 import { ProgramEntity } from '@121-service/src/programs/program.entity';
 import { QueuesRegistryModule } from '@121-service/src/queues-registry/queues-registry.module';
 import { RegistrationDataModule } from '@121-service/src/registration/modules/registration-data/registration-data.module';
@@ -48,6 +49,7 @@ import { UserModule } from '@121-service/src/user/user.module';
     MessageTemplateModule,
     RegistrationDataModule,
     QueuesRegistryModule,
+    TransactionsModule,
   ],
   providers: [
     MessageIncomingService,

--- a/services/121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-voucher.entity.ts
+++ b/services/121-service/src/payments/fsp-integration/intersolve-voucher/intersolve-voucher.entity.ts
@@ -9,11 +9,15 @@ import {
 } from 'typeorm';
 
 import { Base121Entity } from '@121-service/src/base.entity';
+import { PaymentEntity } from '@121-service/src/payments/entities/payment.entity';
 import { ImageCodeExportVouchersEntity } from '@121-service/src/payments/imagecode/image-code-export-vouchers.entity';
 import { UserEntity } from '@121-service/src/user/user.entity';
-
 @Entity('intersolve_voucher')
 export class IntersolveVoucherEntity extends Base121Entity {
+  @ManyToOne(() => PaymentEntity, { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'paymentId' })
+  public payment: Relation<PaymentEntity>;
+  @Index()
   @Column({ type: 'integer', nullable: true })
   public paymentId: number | null;
 

--- a/services/121-service/src/payments/fsp-integration/intersolve-voucher/services/intersolve-voucher-cron.service.ts
+++ b/services/121-service/src/payments/fsp-integration/intersolve-voucher/services/intersolve-voucher-cron.service.ts
@@ -119,9 +119,9 @@ export class IntersolveVoucherCronService {
     let totalWhatsappReminders = 0;
     const sixteenHours = 16 * 60 * 60 * 1000;
     const sixteenHoursAgo = new Date(Date.now() - sixteenHours);
-    // We only want to send reminders for vouchers that are not older than 4 weeks
-    const fourWeeks = 4 * 7 * 24 * 60 * 60 * 1000;
-    const fourWeeksAgo = new Date(Date.now() - fourWeeks);
+    // We only want to send reminders for vouchers that are not older than 2 weeks
+    const twoWeeks = 2 * 7 * 24 * 60 * 60 * 1000;
+    const twoWeeksAgo = new Date(Date.now() - twoWeeks);
 
     const programs = await this.programRepository.find();
     for (const program of programs) {
@@ -142,8 +142,8 @@ export class IntersolveVoucherCronService {
         .andWhere('payment.created < :sixteenHoursAgo', {
           sixteenHoursAgo,
         })
-        .andWhere('payment.created > :fourWeeksAgo', {
-          fourWeeksAgo,
+        .andWhere('payment.created > :twoWeeksAgo', {
+          twoWeeksAgo,
         })
         .andWhere('"whatsappPhoneNumber" is not NULL')
         .andWhere('registration.programId = :programId', {

--- a/services/121-service/src/payments/fsp-integration/intersolve-voucher/services/intersolve-voucher-cron.service.ts
+++ b/services/121-service/src/payments/fsp-integration/intersolve-voucher/services/intersolve-voucher-cron.service.ts
@@ -119,20 +119,12 @@ export class IntersolveVoucherCronService {
     let totalWhatsappReminders = 0;
     const sixteenHours = 16 * 60 * 60 * 1000;
     const sixteenHoursAgo = new Date(Date.now() - sixteenHours);
+    // We only want to send reminders for vouchers that are not older than 4 weeks
+    const fourWeeks = 4 * 7 * 24 * 60 * 60 * 1000;
+    const fourWeeksAgo = new Date(Date.now() - fourWeeks);
+
     const programs = await this.programRepository.find();
     for (const program of programs) {
-      // Don't send more then 3 vouchers, so no vouchers of more than 2 payments ago
-      const lastPayment = await this.transactionRepository
-        .createQueryBuilder('transaction')
-        .select('MAX(transaction."paymentId")', 'max')
-        .addSelect('transaction.userId', 'userId')
-        .leftJoin('transaction.payment', 'payment')
-        .where('payment.programId = :programId', { programId: program.id })
-        .groupBy('transaction.userId')
-        .orderBy('max', 'DESC')
-        .getRawOne();
-      const minimumPayment = lastPayment ? lastPayment.max - 2 : 0;
-
       const unsentIntersolveVouchers = await this.intersolveVoucherRepository
         .createQueryBuilder('voucher')
         .select([
@@ -141,17 +133,19 @@ export class IntersolveVoucherCronService {
           'registration."referenceId" AS "referenceId"',
           'amount',
           '"reminderCount"',
+          'voucher."userId" AS "userId"',
         ])
         .leftJoin('voucher.image', 'image')
         .leftJoin('image.registration', 'registration')
+        .leftJoin('voucher.payment', 'payment')
         .where('send = false')
-        .andWhere('voucher.created < :sixteenHoursAgo', {
+        .andWhere('payment.created < :sixteenHoursAgo', {
           sixteenHoursAgo,
         })
-        .andWhere('"whatsappPhoneNumber" is not NULL')
-        .andWhere('voucher."paymentId" >= :minimumPayment', {
-          minimumPayment,
+        .andWhere('payment.created > :fourWeeksAgo', {
+          fourWeeksAgo,
         })
+        .andWhere('"whatsappPhoneNumber" is not NULL')
         .andWhere('registration.programId = :programId', {
           programId: program.id,
         })
@@ -190,7 +184,7 @@ export class IntersolveVoucherCronService {
           messageContentType: MessageContentType.paymentReminder,
           messageProcessType:
             MessageProcessType.whatsappTemplateVoucherReminder,
-          userId: lastPayment.userId,
+          userId: unsentIntersolveVoucher.userId,
         });
         const reminderVoucher =
           await this.intersolveVoucherRepository.findOneOrFail({

--- a/services/121-service/src/payments/reconciliation/nedbank-reconciliation/nedbank-reconciliation.service.ts
+++ b/services/121-service/src/payments/reconciliation/nedbank-reconciliation/nedbank-reconciliation.service.ts
@@ -6,7 +6,7 @@ import { NedbankVoucherStatus } from '@121-service/src/payments/fsp-integration/
 import { NedbankService } from '@121-service/src/payments/fsp-integration/nedbank/nedbank.service';
 import { NedbankVoucherScopedRepository } from '@121-service/src/payments/fsp-integration/nedbank/repositories/nedbank-voucher.scoped.repository';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 
 @Injectable()
 export class NedbankReconciliationService {

--- a/services/121-service/src/payments/reconciliation/onafriq-reconciliation/onafriq-reconciliation.service.ts
+++ b/services/121-service/src/payments/reconciliation/onafriq-reconciliation/onafriq-reconciliation.service.ts
@@ -20,7 +20,7 @@ import {
 } from '@121-service/src/payments/redis/redis-client';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { TransactionEntity } from '@121-service/src/payments/transactions/transaction.entity';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { QueuesRegistryService } from '@121-service/src/queues-registry/queues-registry.service';
 import { ScopedRepository } from '@121-service/src/scoped.repository';
 import { JobNames } from '@121-service/src/shared/enum/job-names.enum';

--- a/services/121-service/src/payments/reconciliation/safaricom-reconciliation/safaricom-reconciliation.service.spec.ts
+++ b/services/121-service/src/payments/reconciliation/safaricom-reconciliation/safaricom-reconciliation.service.spec.ts
@@ -9,7 +9,7 @@ import {
   getRedisSetName,
   REDIS_CLIENT,
 } from '@121-service/src/payments/redis/redis-client';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { QueuesRegistryService } from '@121-service/src/queues-registry/queues-registry.service';
 import { JobNames } from '@121-service/src/shared/enum/job-names.enum';
 

--- a/services/121-service/src/payments/reconciliation/safaricom-reconciliation/safaricom-reconciliation.service.ts
+++ b/services/121-service/src/payments/reconciliation/safaricom-reconciliation/safaricom-reconciliation.service.ts
@@ -16,7 +16,7 @@ import {
   REDIS_CLIENT,
 } from '@121-service/src/payments/redis/redis-client';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { QueuesRegistryService } from '@121-service/src/queues-registry/queues-registry.service';
 import { JobNames } from '@121-service/src/shared/enum/job-names.enum';
 

--- a/services/121-service/src/payments/services/payments.service.spec.ts
+++ b/services/121-service/src/payments/services/payments.service.spec.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 import { PaymentsHelperService } from '@121-service/src/payments/services/payments.helper.service';
 import { PaymentsService } from '@121-service/src/payments/services/payments.service';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { ProgramEntity } from '@121-service/src/programs/program.entity';
 import { ProgramRegistrationAttributeRepository } from '@121-service/src/programs/repositories/program-registration-attribute.repository';
 import { MappedPaginatedRegistrationDto } from '@121-service/src/registration/dto/mapped-paginated-registration.dto';

--- a/services/121-service/src/payments/services/payments.service.ts
+++ b/services/121-service/src/payments/services/payments.service.ts
@@ -45,7 +45,7 @@ import {
 } from '@121-service/src/payments/transactions/dto/get-transaction.dto';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { TransactionEntity } from '@121-service/src/payments/transactions/transaction.entity';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { TransactionsService } from '@121-service/src/payments/transactions/transactions.service';
 import { ProgramFspConfigurationEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration.entity';
 import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';

--- a/services/121-service/src/payments/transactions/transaction.repository.ts
+++ b/services/121-service/src/payments/transactions/transaction.repository.ts
@@ -1,197 +1,34 @@
-import { Inject } from '@nestjs/common';
-import { REQUEST } from '@nestjs/core';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
-import { GetAuditedTransactionDto } from '@121-service/src/payments/transactions/dto/get-audited-transaction.dto';
-import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { TransactionEntity } from '@121-service/src/payments/transactions/transaction.entity';
-import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
-import {
-  ScopedQueryBuilder,
-  ScopedRepository,
-} from '@121-service/src/scoped.repository';
-import { ScopedUserRequest } from '@121-service/src/shared/scoped-user-request';
-import { EntityClass } from '@121-service/src/shared/types/entity-class.type';
 
-export class TransactionScopedRepository extends ScopedRepository<TransactionEntity> {
+export class TransactionRepository extends Repository<TransactionEntity> {
   constructor(
-    @Inject(REQUEST) request: ScopedUserRequest,
     @InjectRepository(TransactionEntity)
-    repository: Repository<TransactionEntity>,
+    private baseRepository: Repository<TransactionEntity>,
   ) {
-    super(request, repository);
+    super(
+      baseRepository.target,
+      baseRepository.manager,
+      baseRepository.queryRunner,
+    );
   }
 
-  async getLatestTransactionsByRegistrationIdAndProgramId(
+  public async getLastThreePaymentIdsForRegistration(
     registrationId: number,
-    programId: number,
-  ) {
-    const query = this.getLastTransactionsQuery({
-      programId,
-      registrationId,
-    })
-      .leftJoin('transaction.user', 'user')
-      .addSelect('user.id', 'userId')
-      .addSelect('user.username', 'username');
-    return await query.getRawMany<GetAuditedTransactionDto>(); // Leaving this as getRawMany for now, as it is not a plain entity. It's a concatenation of multiple entities.
-  }
+  ): Promise<number[]> {
+    const lastThreePaymentIds = await this.baseRepository
+      .createQueryBuilder('transaction')
+      .select('DISTINCT transaction."paymentId"', 'paymentId')
+      .addSelect('MAX(payment.created)', 'maxCreated')
+      .leftJoin('transaction.payment', 'payment')
+      .where('transaction.registrationId = :registrationId', { registrationId })
+      .groupBy('transaction."paymentId"')
+      .orderBy('"maxCreated"', 'DESC')
+      .limit(3)
+      .getRawMany();
 
-  public async getTransactions({
-    programId,
-    paymentId,
-    fromDate,
-    toDate,
-    fspSpecificJoinFields,
-  }: {
-    programId: number;
-    paymentId?: number;
-    fromDate?: Date;
-    toDate?: Date;
-    fspSpecificJoinFields?: {
-      entityJoinedToTransaction: EntityClass<any>;
-      attribute: string;
-      alias: string;
-    }[];
-  }): Promise<
-    ({
-      paymentId: number;
-      id: number;
-      paymentDate: Date;
-      created: Date;
-      updated: Date;
-      registrationProgramId: number;
-      registrationReferenceId: string;
-      registrationId: number;
-      status: TransactionStatusEnum;
-      registrationStatus: RegistrationStatusEnum;
-      amount: number;
-      errorMessage: string | null;
-      programFspConfigurationName: string;
-    } & Record<string, unknown>)[]
-  > {
-    const query = this.createQueryBuilder('transaction')
-      .select([
-        'transaction.paymentId AS "paymentId"',
-        'p.created AS "paymentDate"',
-        'transaction.id AS "id"',
-        'transaction.created AS "created"',
-        'transaction.updated AS "updated"',
-        'r."registrationProgramId"',
-        'r."referenceId" as "registrationReferenceId"',
-        'r."id" as "registrationId"',
-        'r."registrationStatus"',
-        'transaction.status AS "status"',
-        'transaction.amount AS "amount"',
-        'transaction.errorMessage as "errorMessage"',
-        'fspconfig.name as "programFspConfigurationName"',
-      ])
-      .leftJoin('transaction.programFspConfiguration', 'fspconfig')
-      .leftJoin('transaction.registration', 'r')
-      .leftJoin('transaction.payment', 'p')
-      .innerJoin('transaction.latestTransaction', 'lt')
-      .andWhere('p."programId" = :programId', {
-        programId,
-      });
-
-    if (paymentId !== undefined && paymentId !== null) {
-      query.andWhere('transaction.paymentId = :paymentId', { paymentId });
-    }
-    if (fromDate) {
-      query.andWhere('p.created >= :fromDate', { fromDate });
-    }
-    if (toDate) {
-      query.andWhere('p.created <= :toDate', { toDate });
-    }
-
-    if (!fspSpecificJoinFields) {
-      return query.getRawMany();
-    }
-
-    for (const field of fspSpecificJoinFields) {
-      const joinTableAlias = `joinTable${field.entityJoinedToTransaction.name}${field.attribute}`;
-      query.leftJoin(
-        field.entityJoinedToTransaction,
-        joinTableAlias,
-        `transaction.id = ${joinTableAlias}.transactionId`,
-      );
-      query.addSelect(
-        `"${joinTableAlias}"."${field.attribute}" as "${field.alias}"`,
-      );
-    }
-
-    return query.getRawMany();
-  }
-
-  // Make this private when all 'querying code' has been moved to this repository
-  public getLastTransactionsQuery({
-    programId,
-    paymentId,
-    registrationId,
-    referenceId,
-    status,
-    programFspConfigId,
-  }: {
-    programId: number;
-    paymentId?: number;
-    registrationId?: number;
-    referenceId?: string;
-    status?: TransactionStatusEnum;
-    programFspConfigId?: number;
-  }): ScopedQueryBuilder<TransactionEntity> {
-    let transactionQuery = this.createQueryBuilder('transaction')
-      .select([
-        'transaction.created AS "paymentDate"',
-        'transaction.updated AS updated',
-        'transaction.paymentId AS "paymentId"',
-        'r."referenceId"',
-        'status',
-        'amount',
-        'transaction.errorMessage as "errorMessage"',
-        'transaction.customData as "customData"',
-        'fspconfig.fspName as "fspName"',
-        'transaction.programFspConfigurationId as "programFspConfigurationId"',
-        'fspconfig.label as "programFspConfigurationLabel"',
-        'fspconfig.name as "programFspConfigurationName"',
-      ])
-      .leftJoin('transaction.programFspConfiguration', 'fspconfig')
-      .leftJoin('transaction.registration', 'r')
-      .leftJoin('transaction.payment', 'p')
-      .innerJoin('transaction.latestTransaction', 'lt')
-      .andWhere('p."programId" = :programId', {
-        programId,
-      });
-    if (paymentId) {
-      transactionQuery = transactionQuery.andWhere(
-        'transaction.paymentId = :paymentId',
-        { paymentId },
-      );
-    }
-    if (referenceId) {
-      transactionQuery = transactionQuery.andWhere(
-        'r."referenceId" = :referenceId',
-        { referenceId },
-      );
-    }
-    if (registrationId) {
-      transactionQuery = transactionQuery.andWhere('r."id" = :registrationId', {
-        registrationId,
-      });
-    }
-    if (status) {
-      transactionQuery = transactionQuery.andWhere(
-        'transaction.status = :status',
-        { status },
-      );
-    }
-    if (programFspConfigId) {
-      transactionQuery = transactionQuery.andWhere(
-        'fspconfig.id = :programFspConfigId',
-        {
-          programFspConfigId,
-        },
-      );
-    }
-    return transactionQuery;
+    return lastThreePaymentIds.map((payment) => payment.paymentId);
   }
 }

--- a/services/121-service/src/payments/transactions/transaction.scoped.repository.ts
+++ b/services/121-service/src/payments/transactions/transaction.scoped.repository.ts
@@ -1,0 +1,182 @@
+import { Inject } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
+import { TransactionEntity } from '@121-service/src/payments/transactions/transaction.entity';
+import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
+import {
+  ScopedQueryBuilder,
+  ScopedRepository,
+} from '@121-service/src/scoped.repository';
+import { ScopedUserRequest } from '@121-service/src/shared/scoped-user-request';
+import { EntityClass } from '@121-service/src/shared/types/entity-class.type';
+
+export class TransactionScopedRepository extends ScopedRepository<TransactionEntity> {
+  constructor(
+    @Inject(REQUEST) request: ScopedUserRequest,
+    @InjectRepository(TransactionEntity)
+    repository: Repository<TransactionEntity>,
+  ) {
+    super(request, repository);
+  }
+
+  public async getTransactions({
+    programId,
+    paymentId,
+    fromDate,
+    toDate,
+    fspSpecificJoinFields,
+  }: {
+    programId: number;
+    paymentId?: number;
+    fromDate?: Date;
+    toDate?: Date;
+    fspSpecificJoinFields?: {
+      entityJoinedToTransaction: EntityClass<any>;
+      attribute: string;
+      alias: string;
+    }[];
+  }): Promise<
+    ({
+      paymentId: number;
+      id: number;
+      paymentDate: Date;
+      created: Date;
+      updated: Date;
+      registrationProgramId: number;
+      registrationReferenceId: string;
+      registrationId: number;
+      status: TransactionStatusEnum;
+      registrationStatus: RegistrationStatusEnum;
+      amount: number;
+      errorMessage: string | null;
+      programFspConfigurationName: string;
+    } & Record<string, unknown>)[]
+  > {
+    const query = this.createQueryBuilder('transaction')
+      .select([
+        'transaction.paymentId AS "paymentId"',
+        'p.created AS "paymentDate"',
+        'transaction.id AS "id"',
+        'transaction.created AS "created"',
+        'transaction.updated AS "updated"',
+        'r."registrationProgramId"',
+        'r."referenceId" as "registrationReferenceId"',
+        'r."id" as "registrationId"',
+        'r."registrationStatus"',
+        'transaction.status AS "status"',
+        'transaction.amount AS "amount"',
+        'transaction.errorMessage as "errorMessage"',
+        'fspconfig.name as "programFspConfigurationName"',
+      ])
+      .leftJoin('transaction.programFspConfiguration', 'fspconfig')
+      .leftJoin('transaction.registration', 'r')
+      .leftJoin('transaction.payment', 'p')
+      .innerJoin('transaction.latestTransaction', 'lt')
+      .andWhere('p."programId" = :programId', {
+        programId,
+      });
+
+    if (paymentId !== undefined && paymentId !== null) {
+      query.andWhere('transaction.paymentId = :paymentId', { paymentId });
+    }
+    if (fromDate) {
+      query.andWhere('p.created >= :fromDate', { fromDate });
+    }
+    if (toDate) {
+      query.andWhere('p.created <= :toDate', { toDate });
+    }
+
+    if (!fspSpecificJoinFields) {
+      return query.getRawMany();
+    }
+
+    for (const field of fspSpecificJoinFields) {
+      const joinTableAlias = `joinTable${field.entityJoinedToTransaction.name}${field.attribute}`;
+      query.leftJoin(
+        field.entityJoinedToTransaction,
+        joinTableAlias,
+        `transaction.id = ${joinTableAlias}.transactionId`,
+      );
+      query.addSelect(
+        `"${joinTableAlias}"."${field.attribute}" as "${field.alias}"`,
+      );
+    }
+
+    return query.getRawMany();
+  }
+
+  // Make this private when all 'querying code' has been moved to this repository
+  public getLastTransactionsQuery({
+    programId,
+    paymentId,
+    registrationId,
+    referenceId,
+    status,
+    programFspConfigId,
+  }: {
+    programId: number;
+    paymentId?: number;
+    registrationId?: number;
+    referenceId?: string;
+    status?: TransactionStatusEnum;
+    programFspConfigId?: number;
+  }): ScopedQueryBuilder<TransactionEntity> {
+    let transactionQuery = this.createQueryBuilder('transaction')
+      .select([
+        'transaction.created AS "paymentDate"',
+        'transaction.updated AS updated',
+        'transaction.paymentId AS "paymentId"',
+        'r."referenceId"',
+        'status',
+        'amount',
+        'transaction.errorMessage as "errorMessage"',
+        'transaction.customData as "customData"',
+        'fspconfig.fspName as "fspName"',
+        'transaction.programFspConfigurationId as "programFspConfigurationId"',
+        'fspconfig.label as "programFspConfigurationLabel"',
+        'fspconfig.name as "programFspConfigurationName"',
+      ])
+      .leftJoin('transaction.programFspConfiguration', 'fspconfig')
+      .leftJoin('transaction.registration', 'r')
+      .leftJoin('transaction.payment', 'p')
+      .innerJoin('transaction.latestTransaction', 'lt')
+      .andWhere('p."programId" = :programId', {
+        programId,
+      });
+    if (paymentId) {
+      transactionQuery = transactionQuery.andWhere(
+        'transaction.paymentId = :paymentId',
+        { paymentId },
+      );
+    }
+    if (referenceId) {
+      transactionQuery = transactionQuery.andWhere(
+        'r."referenceId" = :referenceId',
+        { referenceId },
+      );
+    }
+    if (registrationId) {
+      transactionQuery = transactionQuery.andWhere('r."id" = :registrationId', {
+        registrationId,
+      });
+    }
+    if (status) {
+      transactionQuery = transactionQuery.andWhere(
+        'transaction.status = :status',
+        { status },
+      );
+    }
+    if (programFspConfigId) {
+      transactionQuery = transactionQuery.andWhere(
+        'fspconfig.id = :programFspConfigId',
+        {
+          programFspConfigId,
+        },
+      );
+    }
+    return transactionQuery;
+  }
+}

--- a/services/121-service/src/payments/transactions/transaction.scoped.repository.ts
+++ b/services/121-service/src/payments/transactions/transaction.scoped.repository.ts
@@ -3,6 +3,7 @@ import { REQUEST } from '@nestjs/core';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
+import { GetAuditedTransactionDto } from '@121-service/src/payments/transactions/dto/get-audited-transaction.dto';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { TransactionEntity } from '@121-service/src/payments/transactions/transaction.entity';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
@@ -20,6 +21,20 @@ export class TransactionScopedRepository extends ScopedRepository<TransactionEnt
     repository: Repository<TransactionEntity>,
   ) {
     super(request, repository);
+  }
+
+  async getLatestTransactionsByRegistrationIdAndProgramId(
+    registrationId: number,
+    programId: number,
+  ) {
+    const query = this.getLastTransactionsQuery({
+      programId,
+      registrationId,
+    })
+      .leftJoin('transaction.user', 'user')
+      .addSelect('user.id', 'userId')
+      .addSelect('user.username', 'username');
+    return await query.getRawMany<GetAuditedTransactionDto>(); // Leaving this as getRawMany for now, as it is not a plain entity. It's a concatenation of multiple entities.
   }
 
   public async getTransactions({

--- a/services/121-service/src/payments/transactions/transactions.module.ts
+++ b/services/121-service/src/payments/transactions/transactions.module.ts
@@ -9,7 +9,8 @@ import { TwilioMessageEntity } from '@121-service/src/notifications/twilio.entit
 import { LatestTransactionEntity } from '@121-service/src/payments/transactions/latest-transaction.entity';
 import { LatestTransactionRepository } from '@121-service/src/payments/transactions/repositories/latest-transaction.repository';
 import { TransactionEntity } from '@121-service/src/payments/transactions/transaction.entity';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { TransactionsService } from '@121-service/src/payments/transactions/transactions.service';
 import { ProgramEntity } from '@121-service/src/programs/program.entity';
 import { RegistrationUtilsModule } from '@121-service/src/registration/modules/registration-utilts/registration-utils.module';
@@ -38,6 +39,7 @@ import { createScopedRepositoryProvider } from '@121-service/src/utils/scope/cre
   providers: [
     TransactionsService,
     TransactionScopedRepository,
+    TransactionRepository,
     RegistrationScopedRepository,
     createScopedRepositoryProvider(TransactionEntity),
     LatestTransactionRepository,
@@ -45,6 +47,7 @@ import { createScopedRepositoryProvider } from '@121-service/src/utils/scope/cre
   exports: [
     TransactionsService,
     TransactionScopedRepository,
+    TransactionRepository,
     LatestTransactionRepository,
   ],
 })

--- a/services/121-service/src/payments/transactions/transactions.service.ts
+++ b/services/121-service/src/payments/transactions/transactions.service.ts
@@ -18,7 +18,7 @@ import { TransactionReturnDto } from '@121-service/src/payments/transactions/dto
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { LatestTransactionEntity } from '@121-service/src/payments/transactions/latest-transaction.entity';
 import { TransactionEntity } from '@121-service/src/payments/transactions/transaction.entity';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { ProgramEntity } from '@121-service/src/programs/program.entity';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { RegistrationUtilsService } from '@121-service/src/registration/modules/registration-utilts/registration-utils.service';

--- a/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.spec.ts
+++ b/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.spec.ts
@@ -7,7 +7,7 @@ import {
   FspConfigurationProperties,
   Fsps,
 } from '@121-service/src/fsps/enums/fsp-name.enum';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { CreateProgramFspConfigurationDto } from '@121-service/src/program-fsp-configurations/dtos/create-program-fsp-configuration.dto';
 import { CreateProgramFspConfigurationPropertyDto } from '@121-service/src/program-fsp-configurations/dtos/create-program-fsp-configuration-property.dto';
 import { UpdateProgramFspConfigurationDto } from '@121-service/src/program-fsp-configurations/dtos/update-program-fsp-configuration.dto';

--- a/services/121-service/src/transaction-jobs/services/transaction-jobs-airtel.service.spec.ts
+++ b/services/121-service/src/transaction-jobs/services/transaction-jobs-airtel.service.spec.ts
@@ -2,7 +2,7 @@ import { AirtelService } from '@121-service/src/payments/fsp-integration/airtel/
 import { AirtelDisbursementResultEnum } from '@121-service/src/payments/fsp-integration/airtel/enums/airtel-disbursement-result.enum';
 import { AirtelError } from '@121-service/src/payments/fsp-integration/airtel/errors/airtel.error';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { TransactionJobsAirtelService } from '@121-service/src/transaction-jobs/services/transaction-jobs-airtel.service';
 import { TransactionJobsHelperService } from '@121-service/src/transaction-jobs/services/transaction-jobs-helper.service';
 import { AirtelTransactionJobDto } from '@121-service/src/transaction-queues/dto/airtel-transaction-job.dto';

--- a/services/121-service/src/transaction-jobs/services/transaction-jobs-airtel.service.ts
+++ b/services/121-service/src/transaction-jobs/services/transaction-jobs-airtel.service.ts
@@ -7,7 +7,7 @@ import { AirtelService } from '@121-service/src/payments/fsp-integration/airtel/
 import { AirtelDisbursementResultEnum } from '@121-service/src/payments/fsp-integration/airtel/enums/airtel-disbursement-result.enum';
 import { AirtelError } from '@121-service/src/payments/fsp-integration/airtel/errors/airtel.error';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { TransactionJobsHelperService } from '@121-service/src/transaction-jobs/services/transaction-jobs-helper.service';
 import { AirtelTransactionJobDto } from '@121-service/src/transaction-queues/dto/airtel-transaction-job.dto';
 

--- a/services/121-service/src/transaction-jobs/services/transaction-jobs-helper.service.spec.ts
+++ b/services/121-service/src/transaction-jobs/services/transaction-jobs-helper.service.spec.ts
@@ -8,7 +8,7 @@ import { MessageTemplateEntity } from '@121-service/src/notifications/message-te
 import { MessageTemplateService } from '@121-service/src/notifications/message-template/message-template.service';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { LatestTransactionRepository } from '@121-service/src/payments/transactions/repositories/latest-transaction.repository';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { ProgramRepository } from '@121-service/src/programs/repositories/program.repository';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { RegistrationEntity } from '@121-service/src/registration/registration.entity';

--- a/services/121-service/src/transaction-jobs/services/transaction-jobs-helper.service.ts
+++ b/services/121-service/src/transaction-jobs/services/transaction-jobs-helper.service.ts
@@ -8,7 +8,7 @@ import { MessageTemplateService } from '@121-service/src/notifications/message-t
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { LatestTransactionRepository } from '@121-service/src/payments/transactions/repositories/latest-transaction.repository';
 import { TransactionEntity } from '@121-service/src/payments/transactions/transaction.entity';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { ProgramRepository } from '@121-service/src/programs/repositories/program.repository';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { RegistrationEntity } from '@121-service/src/registration/registration.entity';

--- a/services/121-service/src/transaction-jobs/services/transaction-jobs-nedbank.service.spec.ts
+++ b/services/121-service/src/transaction-jobs/services/transaction-jobs-nedbank.service.spec.ts
@@ -6,7 +6,7 @@ import { NedbankError } from '@121-service/src/payments/fsp-integration/nedbank/
 import { NedbankService } from '@121-service/src/payments/fsp-integration/nedbank/nedbank.service';
 import { NedbankVoucherScopedRepository } from '@121-service/src/payments/fsp-integration/nedbank/repositories/nedbank-voucher.scoped.repository';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';
 import { TransactionJobsHelperService } from '@121-service/src/transaction-jobs/services/transaction-jobs-helper.service';
 import { TransactionJobsNedbankService } from '@121-service/src/transaction-jobs/services/transaction-jobs-nedbank.service';

--- a/services/121-service/src/transaction-jobs/services/transaction-jobs-nedbank.service.ts
+++ b/services/121-service/src/transaction-jobs/services/transaction-jobs-nedbank.service.ts
@@ -8,7 +8,7 @@ import { NedbankError } from '@121-service/src/payments/fsp-integration/nedbank/
 import { NedbankService } from '@121-service/src/payments/fsp-integration/nedbank/nedbank.service';
 import { NedbankVoucherScopedRepository } from '@121-service/src/payments/fsp-integration/nedbank/repositories/nedbank-voucher.scoped.repository';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';
 import { TransactionJobsHelperService } from '@121-service/src/transaction-jobs/services/transaction-jobs-helper.service';
 import { NedbankTransactionJobDto } from '@121-service/src/transaction-queues/dto/nedbank-transaction-job.dto';

--- a/services/121-service/src/transaction-jobs/services/transaction-jobs-onafriq.service.spec.ts
+++ b/services/121-service/src/transaction-jobs/services/transaction-jobs-onafriq.service.spec.ts
@@ -1,6 +1,6 @@
 import { OnafriqTransactionEntity } from '@121-service/src/payments/fsp-integration/onafriq/entities/onafriq-transaction.entity';
 import { OnafriqService } from '@121-service/src/payments/fsp-integration/onafriq/onafriq.service';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { ScopedRepository } from '@121-service/src/scoped.repository';
 import { TransactionJobsHelperService } from '@121-service/src/transaction-jobs/services/transaction-jobs-helper.service';
 import { TransactionJobsOnafriqService } from '@121-service/src/transaction-jobs/services/transaction-jobs-onafriq.service';

--- a/services/121-service/src/transaction-jobs/services/transaction-jobs-onafriq.service.ts
+++ b/services/121-service/src/transaction-jobs/services/transaction-jobs-onafriq.service.ts
@@ -6,7 +6,7 @@ import { OnafriqApiResponseStatusType } from '@121-service/src/payments/fsp-inte
 import { OnafriqError } from '@121-service/src/payments/fsp-integration/onafriq/errors/onafriq.error';
 import { OnafriqService } from '@121-service/src/payments/fsp-integration/onafriq/onafriq.service';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { ScopedRepository } from '@121-service/src/scoped.repository';
 import { TransactionJobsHelperService } from '@121-service/src/transaction-jobs/services/transaction-jobs-helper.service';
 import { OnafriqTransactionJobDto } from '@121-service/src/transaction-queues/dto/onafriq-transaction-job.dto';

--- a/services/121-service/src/transaction-jobs/services/transaction-jobs-safaricom.service.spec.ts
+++ b/services/121-service/src/transaction-jobs/services/transaction-jobs-safaricom.service.spec.ts
@@ -4,7 +4,7 @@ import { UpdateResult } from 'typeorm';
 import { SafaricomApiError } from '@121-service/src/payments/fsp-integration/safaricom/errors/safaricom-api.error';
 import { SafaricomTransferScopedRepository } from '@121-service/src/payments/fsp-integration/safaricom/repositories/safaricom-transfer.scoped.repository';
 import { SafaricomService } from '@121-service/src/payments/fsp-integration/safaricom/safaricom.service';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { TransactionJobsHelperService } from '@121-service/src/transaction-jobs/services/transaction-jobs-helper.service';
 import { TransactionJobsSafaricomService } from '@121-service/src/transaction-jobs/services/transaction-jobs-safaricom.service';
 import { SafaricomTransactionJobDto } from '@121-service/src/transaction-queues/dto/safaricom-transaction-job.dto';

--- a/services/121-service/src/transaction-jobs/services/transaction-jobs-safaricom.service.ts
+++ b/services/121-service/src/transaction-jobs/services/transaction-jobs-safaricom.service.ts
@@ -7,7 +7,7 @@ import { SafaricomApiError } from '@121-service/src/payments/fsp-integration/saf
 import { SafaricomTransferScopedRepository } from '@121-service/src/payments/fsp-integration/safaricom/repositories/safaricom-transfer.scoped.repository';
 import { SafaricomService } from '@121-service/src/payments/fsp-integration/safaricom/safaricom.service';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
-import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.repository';
+import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { TransactionJobsHelperService } from '@121-service/src/transaction-jobs/services/transaction-jobs-helper.service';
 import { SafaricomTransactionJobDto } from '@121-service/src/transaction-queues/dto/safaricom-transaction-job.dto';
 


### PR DESCRIPTION
[AB#37678](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37678)

## Describe your changes

- change logic of which unsent voucher to reply to incoming message to last 3 paymentIds for a registration (instead of using generic paymentId, which no longer worked)
- change logic of unsent voucher reminders to send to last 2 weeks instead of on generic minimum paymentId, which no longer worked.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
