### PR TITLE
Store error without error code as unknown errors when sending a voucher

### DIFF
--- a/services/121-service/src/notifications/message.service.ts
+++ b/services/121-service/src/notifications/message.service.ts
@@ -232,7 +232,9 @@ export class MessageService {
           return;
         },
         (error) => {
-          errorMessage = error;
+          // Twilio errors have a 'code' property if it's not a twilio error we do not want to store the stacktrace as
+          // it can contains credentials and it means nothing to our users
+          errorMessage = !!error.code ? error : `Unknown error occurred`;
         },
       );
     const transactionStep = 2;


### PR DESCRIPTION
AB#37750 <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

- Store error without error code as unknown errors when sending a voucher
- This is needed because else a whole stacktrace can be stored here. Which can contain credentials
- Ideally there would api/unit tests for this. However this is in a part of the platform that is very poorly tests and it is hard time consuming to add something here. So I am tempted to leave it like this 

I tested this manually by: 

1. adding this to the whatsapp service: 
<img width="650" height="600" alt="image" src="https://github.com/user-attachments/assets/b2b1de8d-e79e-4051-ad5f-ea47efebcb27" />
and than the unknown error is logged
2. Using the magic fail number and than the error saved normally in the transaction


@ reviewer. 

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
