### PR TITLE
feat: Airtel - add (static) payee.name in payload

### DIFF
--- a/services/121-service/src/payments/fsp-integration/airtel/dtos/airtel-api-disbursement-request-body.dto.ts
+++ b/services/121-service/src/payments/fsp-integration/airtel/dtos/airtel-api-disbursement-request-body.dto.ts
@@ -2,6 +2,7 @@ export interface AirtelApiDisbursementRequestBodyDto {
   readonly payee: {
     readonly currency: string;
     readonly msisdn: string;
+    readonly name: string;
   };
   reference: string;
   readonly pin: string;

--- a/services/121-service/src/payments/fsp-integration/airtel/services/__snapshots__/airtel.api.service.spec.ts.snap
+++ b/services/121-service/src/payments/fsp-integration/airtel/services/__snapshots__/airtel.api.service.spec.ts.snap
@@ -29,6 +29,7 @@ exports[`AirtelApiService disburse authenticated correctly calls disburse endpoi
     "payee": {
       "currency": "ZMW",
       "msisdn": "000000000",
+      "name": "3132312D706C6174666F726D",
     },
     "pin": "mock-encrypted-pin",
     "reference": "1234",

--- a/services/121-service/src/payments/fsp-integration/airtel/services/airtel.api.service.ts
+++ b/services/121-service/src/payments/fsp-integration/airtel/services/airtel.api.service.ts
@@ -96,6 +96,12 @@ export class AirtelApiService {
       payee: {
         currency: this.currencyCode,
         msisdn: phoneNumberWithoutCountryCode,
+        // This value can be the same for all subscribers.
+        // Subscribers probably don't see this.
+        // The official Airtel docs say this value is optional, but Airtel told
+        // us it's not.
+        // "121-platform" in hexadecimal.
+        name: '3132312D706C6174666F726D',
       },
       // The docs say "Reference for service / goods purchased."
       // We can just use a static non-relevant value here. Needs to be alphanumeric and 4 - 64 characters long.


### PR DESCRIPTION
[AB#37747](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37747) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

For the Airtel FSP integration, the disbursement payload apparently needs a value for `payee.name`.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
