### PR TITLE
feat: add payment note and see payment log (front-end)

### DIFF
--- a/e2e/portal/pages/PaymentPage.ts
+++ b/e2e/portal/pages/PaymentPage.ts
@@ -157,7 +157,7 @@ class PaymentPage extends BasePage {
     await expect(createdRow).toBeVisible();
   }
 
-  async validatePaymentNote(expectedNote: string): Promise<void> {
+  async validatePaymentLog(expectedNote: string): Promise<void> {
     await this.navigateToPaymentLog();
     await this.validatePaymentLogEntries(expectedNote);
   }

--- a/e2e/portal/pages/PaymentPage.ts
+++ b/e2e/portal/pages/PaymentPage.ts
@@ -16,6 +16,8 @@ class PaymentPage extends BasePage {
   readonly retryFailedTransfersButton: Locator;
   readonly popupRetryTransferButton: Locator;
   readonly exportButton: Locator;
+  readonly paymentLogTab: Locator;
+  readonly paymentLogTable: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -44,6 +46,8 @@ class PaymentPage extends BasePage {
     this.exportButton = this.page.getByRole('button', {
       name: 'Export',
     });
+    this.paymentLogTab = this.page.getByRole('tab', { name: 'Payment log' });
+    this.paymentLogTable = this.page.getByTestId('payment-log-table');
   }
 
   async waitForPaymentToComplete() {
@@ -135,6 +139,27 @@ class PaymentPage extends BasePage {
     await this.chooseAndUploadFile(filePath);
 
     await this.importFileButton.click();
+  }
+
+  async navigateToPaymentLog(): Promise<void> {
+    await this.paymentLogTab.click();
+    await this.page.waitForURL('**/payment-log');
+  }
+
+  async validatePaymentLogEntries(expectedNote: string): Promise<void> {
+    const rows = this.paymentLogTable.locator('tbody tr');
+    await expect(rows).toHaveCount(2);
+
+    const noteRow = rows.filter({ hasText: expectedNote });
+    const createdRow = rows.filter({ hasText: 'Created' });
+
+    await expect(noteRow).toBeVisible();
+    await expect(createdRow).toBeVisible();
+  }
+
+  async validatePaymentNote(expectedNote: string): Promise<void> {
+    await this.navigateToPaymentLog();
+    await this.validatePaymentLogEntries(expectedNote);
   }
 }
 

--- a/e2e/portal/pages/PaymentsPage.ts
+++ b/e2e/portal/pages/PaymentsPage.ts
@@ -17,6 +17,7 @@ class PaymentsPage extends BasePage {
   readonly exportButton: Locator;
   readonly dateRangeStartInput: Locator;
   readonly dateRangeEndInput: Locator;
+  readonly noteInput: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -48,6 +49,7 @@ class PaymentsPage extends BasePage {
     this.dateRangeEndInput = this.page.getByRole('combobox', {
       name: 'End Date',
     });
+    this.noteInput = this.page.locator('input[formControlName="note"]');
   }
 
   async selectAllRegistrations() {
@@ -82,8 +84,15 @@ class PaymentsPage extends BasePage {
     await this.addToPaymentButton.click();
   }
 
-  async startPayment() {
+  async startPayment(note?: string) {
+    if (note) {
+      await this.addPaymentNote(note);
+    }
     await this.startPaymentButton.click();
+  }
+
+  async addPaymentNote(note: string) {
+    await this.noteInput.fill(note);
   }
 
   async validateInProgressBannerIsPresent() {

--- a/e2e/portal/tests/ViewPayment/PaymentInProgressVisible.spec.ts
+++ b/e2e/portal/tests/ViewPayment/PaymentInProgressVisible.spec.ts
@@ -51,9 +51,12 @@ test('[32296] Show in progress banner and chip when payment is in progress', asy
   await test.step('Do payment', async () => {
     await paymentsPage.createPayment();
     await paymentsPage.startPayment();
+    const paymentId = 1; // First payment in this context, so ID 1
     // Assert redirection to payment overview page
     await page.waitForURL((url) =>
-      url.pathname.startsWith('/en-GB/project/3/payments/1'),
+      url.pathname.startsWith(
+        `/en-GB/project/${programIdOCW}/payments/${paymentId}`,
+      ),
     );
     // Assert payment overview page by payment date/ title
     await paymentPage.validatePaymentsDetailsPageByDate(lastPaymentDate);

--- a/e2e/portal/tests/ViewPayment/ViewPaymentLog.spec.ts
+++ b/e2e/portal/tests/ViewPayment/ViewPaymentLog.spec.ts
@@ -34,7 +34,9 @@ test.beforeEach(async ({ page }) => {
   await loginPage.login();
 });
 
-test('[37781] Add note to payment and view payment log', async ({ page }) => {
+test('[37781] View payment log, including note added to payment', async ({
+  page,
+}) => {
   const paymentPage = new PaymentPage(page);
   const paymentsPage = new PaymentsPage(page);
   const projectTitle = NLRCProgram.titlePortal.en;
@@ -60,7 +62,7 @@ test('[37781] Add note to payment and view payment log', async ({ page }) => {
     await paymentPage.validatePaymentsDetailsPageByDate(lastPaymentDate);
   });
 
-  await test.step('Validate note is visible on payment page', async () => {
-    await paymentPage.validatePaymentNote(note);
+  await test.step('Validate payment log, including note', async () => {
+    await paymentPage.validatePaymentLog(note);
   });
 });

--- a/e2e/portal/tests/ViewPayment/ViewPaymentNote.spec.ts
+++ b/e2e/portal/tests/ViewPayment/ViewPaymentNote.spec.ts
@@ -49,9 +49,12 @@ test('[37781] Add note to payment and view payment log', async ({ page }) => {
   await test.step('Do payment with note', async () => {
     await paymentsPage.createPayment();
     await paymentsPage.startPayment(note);
+    const paymentId = 1; // First payment in this context, so ID 1
     // Assert redirection to payment overview page
     await page.waitForURL((url) =>
-      url.pathname.startsWith('/en-GB/project/3/payments/1'),
+      url.pathname.startsWith(
+        `/en-GB/project/${programIdOCW}/payments/${paymentId}`,
+      ),
     );
     // Assert payment overview page by payment date/ title
     await paymentPage.validatePaymentsDetailsPageByDate(lastPaymentDate);

--- a/e2e/portal/tests/ViewPayment/ViewPaymentNote.spec.ts
+++ b/e2e/portal/tests/ViewPayment/ViewPaymentNote.spec.ts
@@ -1,0 +1,63 @@
+import { test } from '@playwright/test';
+import { format } from 'date-fns';
+
+import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
+import NLRCProgram from '@121-service/src/seed-data/program/program-nlrc-ocw.json';
+import { seedIncludedRegistrations } from '@121-service/test/helpers/registration.helper';
+import {
+  getAccessToken,
+  resetDB,
+} from '@121-service/test/helpers/utility.helper';
+import {
+  programIdOCW,
+  registrationOCW1,
+} from '@121-service/test/registrations/pagination/pagination-data';
+
+import LoginPage from '@121-e2e/portal/pages/LoginPage';
+import PaymentPage from '@121-e2e/portal/pages/PaymentPage';
+import PaymentsPage from '@121-e2e/portal/pages/PaymentsPage';
+
+const note = 'test payment note';
+
+test.beforeEach(async ({ page }) => {
+  await resetDB(SeedScript.nlrcMultiple, __filename);
+  const accessToken = await getAccessToken();
+  await seedIncludedRegistrations(
+    [registrationOCW1],
+    programIdOCW,
+    accessToken,
+  );
+
+  // Login
+  const loginPage = new LoginPage(page);
+  await page.goto('/');
+  await loginPage.login();
+});
+
+test('[37781] Add note to payment and view payment log', async ({ page }) => {
+  const paymentPage = new PaymentPage(page);
+  const paymentsPage = new PaymentsPage(page);
+  const projectTitle = NLRCProgram.titlePortal.en;
+  const lastPaymentDate = `${format(new Date(), 'dd/MM/yyyy')}`;
+
+  await test.step('Navigate to Program payments', async () => {
+    await paymentsPage.selectProgram(projectTitle);
+
+    await paymentsPage.navigateToProgramPage('Payments');
+  });
+
+  await test.step('Do payment with note', async () => {
+    await paymentsPage.createPayment();
+    await paymentsPage.startPayment(note);
+    // Assert redirection to payment overview page
+    await page.waitForURL((url) =>
+      url.pathname.startsWith('/en-GB/project/3/payments/1'),
+    );
+    // Assert payment overview page by payment date/ title
+    await paymentPage.validatePaymentsDetailsPageByDate(lastPaymentDate);
+  });
+
+  await test.step('Validate note is visible on payment page', async () => {
+    await paymentPage.validatePaymentNote(note);
+  });
+});

--- a/interfaces/portal/src/app/app.routes.ts
+++ b/interfaces/portal/src/app/app.routes.ts
@@ -17,6 +17,7 @@ export enum AppRoutes {
   projectMonitoring = 'monitoring',
   projectMonitoringFiles = 'files',
   projectMonitoringPowerBI = 'powerbi',
+  projectPaymentLog = 'payment-log',
   projectPayments = 'payments',
   projectPaymentTransferList = 'transfer-list',
   projectRegistrationActivityLog = 'activity-log',
@@ -239,6 +240,14 @@ export const routes: Routes = [
                   import(
                     '~/pages/project-payment-transfer-list/project-payment-transfer-list.page'
                   ).then((x) => x.ProjectPaymentTransferListPageComponent),
+              },
+              {
+                path: AppRoutes.projectPaymentLog,
+                title: $localize`:@@page-title-project-payment-log:Payment log`,
+                loadComponent: () =>
+                  import(
+                    '~/pages/project-payment-log/project-payment-log.page'
+                  ).then((x) => x.ProjectPaymentLogPageComponent),
               },
               {
                 path: ``,

--- a/interfaces/portal/src/app/components/data-list/data-list.component.html
+++ b/interfaces/portal/src/app/components/data-list/data-list.component.html
@@ -7,7 +7,7 @@
   @for (item of data(); track $index) {
     <p
       [attr.data-testid]="dataTestId() + '-personal-information'"
-      class="border-grey-300 border-b py-4"
+      class="border-grey-300 border-b px-2 py-4"
       [ngClass]="{
         'col-span-2': item.fullWidth,
       }"

--- a/interfaces/portal/src/app/components/page-layout-payment/components/payment-menu/payment-menu.component.ts
+++ b/interfaces/portal/src/app/components/page-layout-payment/components/payment-menu/payment-menu.component.ts
@@ -31,5 +31,10 @@ export class PaymentMenuComponent {
       routerLink: `/${AppRoutes.project}/${this.projectId().toString()}/${AppRoutes.projectPayments}/${this.paymentId().toString()}/${AppRoutes.projectPaymentTransferList}`,
       icon: 'pi pi-table',
     },
+    {
+      label: $localize`:@@page-title-project-payment-log:Payment log`,
+      routerLink: `/${AppRoutes.project}/${this.projectId().toString()}/${AppRoutes.projectPayments}/${this.paymentId().toString()}/${AppRoutes.projectPaymentLog}`,
+      icon: 'pi pi-list',
+    },
   ]);
 }

--- a/interfaces/portal/src/app/domains/payment/payment.api.service.ts
+++ b/interfaces/portal/src/app/domains/payment/payment.api.service.ts
@@ -11,6 +11,7 @@ import { DomainApiService } from '~/domains/domain-api.service';
 import {
   Payment,
   PaymentAggregate,
+  PaymentEventsResponse,
   PaymentStatus,
   PaymentTransaction,
 } from '~/domains/payment/payment.model';
@@ -43,6 +44,23 @@ export class PaymentApiService extends DomainApiService {
   }) {
     return this.generateQueryOptions<PaymentAggregate>({
       path: [...BASE_ENDPOINT(projectId as Signal<number | string>), paymentId],
+      enabled: () => !!projectId() && !!paymentId(),
+    });
+  }
+
+  getPaymentEvents({
+    projectId,
+    paymentId,
+  }: {
+    projectId: Signal<number | string | undefined>;
+    paymentId: Signal<number | string | undefined>;
+  }) {
+    return this.generateQueryOptions<PaymentEventsResponse>({
+      path: [
+        ...BASE_ENDPOINT(projectId as Signal<number | string>),
+        paymentId,
+        'events',
+      ],
       enabled: () => !!projectId() && !!paymentId(),
     });
   }

--- a/interfaces/portal/src/app/domains/payment/payment.helpers.ts
+++ b/interfaces/portal/src/app/domains/payment/payment.helpers.ts
@@ -1,4 +1,5 @@
 import { Fsps } from '@121-service/src/fsps/enums/fsp-name.enum';
+import { PaymentEvent } from '@121-service/src/payments/payment-events/enums/payment-event.enum';
 
 import { AppRoutes } from '~/app.routes';
 
@@ -16,3 +17,14 @@ export const paymentLink = ({
   projectId: number | string;
   paymentId: number | string;
 }) => ['/', AppRoutes.project, projectId, AppRoutes.projectPayments, paymentId];
+
+export const PAYMENT_EVENT_LOG_ITEM_TYPE_LABELS: Record<PaymentEvent, string> =
+  {
+    [PaymentEvent.created]: $localize`:@@payment-event-log-item-type-created:Created`,
+    [PaymentEvent.note]: $localize`:@@payment-event-log-item-type-note:Note`,
+  };
+
+export const PAYMENT_EVENT_LOG_ITEM_TYPE_ICONS: Record<PaymentEvent, string> = {
+  [PaymentEvent.created]: 'pi pi-money-bill',
+  [PaymentEvent.note]: 'pi pi-pen-to-square',
+};

--- a/interfaces/portal/src/app/domains/payment/payment.model.ts
+++ b/interfaces/portal/src/app/domains/payment/payment.model.ts
@@ -1,6 +1,8 @@
 import { GetPaymentsDto } from '@121-service/src/payments/dto/get-payments.dto';
 import { GetTransactionResponseDto } from '@121-service/src/payments/dto/get-transaction-response.dto';
 import { ProgramPaymentsStatusDto } from '@121-service/src/payments/dto/program-payments-status.dto';
+import { PaymentEventsReturnDto } from '@121-service/src/payments/payment-events/dtos/payment-events-return.dto';
+import { PaymentEvent } from '@121-service/src/payments/payment-events/enums/payment-event.enum';
 import { PaymentReturnDto } from '@121-service/src/payments/transactions/dto/get-transaction.dto';
 
 import { Dto } from '~/utils/dto-type';
@@ -9,3 +11,20 @@ export type Payment = Dto<GetPaymentsDto>;
 export type PaymentAggregate = Dto<PaymentReturnDto>;
 export type PaymentStatus = Dto<ProgramPaymentsStatusDto>;
 export type PaymentTransaction = Dto<GetTransactionResponseDto>;
+
+// defined separately as interface instead of getting the DTO from 121-service, as that gave lint errors down the line
+interface PaymentEventInterface {
+  id: string;
+  user: {
+    id?: number;
+    username?: string;
+  };
+  created: Date;
+  type: PaymentEvent;
+  attributes: Record<string, unknown>;
+}
+export type PaymentEventType = Dto<PaymentEventInterface>;
+
+export type PaymentEventsResponse = {
+  data: PaymentEventType[];
+} & Dto<Omit<PaymentEventsReturnDto, 'data'>>;

--- a/interfaces/portal/src/app/pages/project-payment-log/components/table-cell-payment-event-activity.component.ts
+++ b/interfaces/portal/src/app/pages/project-payment-log/components/table-cell-payment-event-activity.component.ts
@@ -1,0 +1,41 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
+
+import { TableCellComponent } from '~/components/query-table/components/table-cell/table-cell.component';
+import {
+  PAYMENT_EVENT_LOG_ITEM_TYPE_ICONS,
+  PAYMENT_EVENT_LOG_ITEM_TYPE_LABELS,
+} from '~/domains/payment/payment.helpers';
+import { PaymentEventType } from '~/domains/payment/payment.model';
+
+@Component({
+  selector: 'app-table-cell-payment-event-activity',
+  imports: [],
+  template: `
+    <span class="inline-flex items-center">
+      <span class="inline w-8 leading-[0]"
+        ><i [class]="icon() + ' text-xl'"></i>
+      </span>
+      <span>{{ label() }}</span>
+    </span>
+  `,
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TableCellPaymentEventActivityComponent
+  implements TableCellComponent<PaymentEventType>
+{
+  readonly value = input.required<PaymentEventType>();
+  readonly context = input<never>();
+
+  readonly label = computed(
+    () => PAYMENT_EVENT_LOG_ITEM_TYPE_LABELS[this.value().type],
+  );
+  readonly icon = computed(
+    () => PAYMENT_EVENT_LOG_ITEM_TYPE_ICONS[this.value().type],
+  );
+}

--- a/interfaces/portal/src/app/pages/project-payment-log/components/table-cell-payment-event-activity.component.ts
+++ b/interfaces/portal/src/app/pages/project-payment-log/components/table-cell-payment-event-activity.component.ts
@@ -17,7 +17,7 @@ import { PaymentEventType } from '~/domains/payment/payment.model';
   imports: [],
   template: `
     <span class="inline-flex items-center">
-      <span class="inline w-8 leading-[0]"
+      <span class="me-4 inline leading-[0]"
         ><i [class]="icon() + ' text-xl'"></i>
       </span>
       <span>{{ label() }}</span>

--- a/interfaces/portal/src/app/pages/project-payment-log/components/table-cell-payment-event-activity.component.ts
+++ b/interfaces/portal/src/app/pages/project-payment-log/components/table-cell-payment-event-activity.component.ts
@@ -15,6 +15,7 @@ import { PaymentEventType } from '~/domains/payment/payment.model';
 @Component({
   selector: 'app-table-cell-payment-event-activity',
   imports: [],
+  // TODO: Come up with elegant solution for naming this component + preventing too much duplication for the template/HTML
   template: `
     <span class="inline-flex items-center">
       <span class="me-4 inline leading-[0]"

--- a/interfaces/portal/src/app/pages/project-payment-log/components/table-cell-payment-event-overview.component.ts
+++ b/interfaces/portal/src/app/pages/project-payment-log/components/table-cell-payment-event-overview.component.ts
@@ -21,7 +21,7 @@ import { PaymentEventType } from '~/domains/payment/payment.model';
   imports: [],
   template: `
     <span class="inline-flex items-center">
-      <span class="inline w-8 leading-[0]"
+      <span class="me-4 inline leading-[0]"
         ><i [class]="icon() + ' text-xl'"></i>
       </span>
       <span>{{ label() }}</span>

--- a/interfaces/portal/src/app/pages/project-payment-log/components/table-cell-payment-event-overview.component.ts
+++ b/interfaces/portal/src/app/pages/project-payment-log/components/table-cell-payment-event-overview.component.ts
@@ -19,6 +19,7 @@ import { PaymentEventType } from '~/domains/payment/payment.model';
 @Component({
   selector: 'app-table-cell-payment-event-overview',
   imports: [],
+  // TODO: Come up with elegant solution for naming this component + preventing too much duplication for the template/HTML
   template: `
     <span class="inline-flex items-center">
       <span class="me-4 inline leading-[0]"

--- a/interfaces/portal/src/app/pages/project-payment-log/components/table-cell-payment-event-overview.component.ts
+++ b/interfaces/portal/src/app/pages/project-payment-log/components/table-cell-payment-event-overview.component.ts
@@ -1,0 +1,57 @@
+import { DatePipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+} from '@angular/core';
+
+import { PaymentEvent } from '@121-service/src/payments/payment-events/enums/payment-event.enum';
+
+import { TableCellComponent } from '~/components/query-table/components/table-cell/table-cell.component';
+import {
+  PAYMENT_EVENT_LOG_ITEM_TYPE_ICONS,
+  PAYMENT_EVENT_LOG_ITEM_TYPE_LABELS,
+} from '~/domains/payment/payment.helpers';
+import { PaymentEventType } from '~/domains/payment/payment.model';
+
+@Component({
+  selector: 'app-table-cell-payment-event-overview',
+  imports: [],
+  template: `
+    <span class="inline-flex items-center">
+      <span class="inline w-8 leading-[0]"
+        ><i [class]="icon() + ' text-xl'"></i>
+      </span>
+      <span>{{ label() }}</span>
+    </span>
+  `,
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [DatePipe],
+})
+export class TableCellPaymentEventOverviewComponent
+  implements TableCellComponent<PaymentEventType>
+{
+  readonly value = input.required<PaymentEventType>();
+  readonly context = input<never>();
+  readonly datePipe = inject(DatePipe);
+
+  readonly label = computed(() => {
+    const event = this.value();
+    const eventType = event.type;
+
+    switch (eventType) {
+      case PaymentEvent.note:
+        return event.attributes.note;
+      case PaymentEvent.created:
+        return `${PAYMENT_EVENT_LOG_ITEM_TYPE_LABELS[eventType]} ${this.datePipe.transform(event.created, 'short') ?? ''}`;
+      default:
+        return PAYMENT_EVENT_LOG_ITEM_TYPE_LABELS[eventType];
+    }
+  });
+  readonly icon = computed(
+    () => PAYMENT_EVENT_LOG_ITEM_TYPE_ICONS[this.value().type],
+  );
+}

--- a/interfaces/portal/src/app/pages/project-payment-log/project-payment-log.page.html
+++ b/interfaces/portal/src/app/pages/project-payment-log/project-payment-log.page.html
@@ -6,9 +6,10 @@
     [items]="paymentEvents()"
     [isPending]="false"
     [columns]="columns()"
-    localStorageKey="activity-log-table"
+    localStorageKey="payment-log-table"
     [tableCellContext]="tableCellContext()"
     [initialSortField]="'created'"
     [initialSortOrder]="-1"
+    data-testid="payment-log-table"
   />
 </app-page-layout-payment>

--- a/interfaces/portal/src/app/pages/project-payment-log/project-payment-log.page.html
+++ b/interfaces/portal/src/app/pages/project-payment-log/project-payment-log.page.html
@@ -1,0 +1,14 @@
+<app-page-layout-payment
+  [projectId]="projectId()"
+  [paymentId]="paymentId()"
+>
+  <app-query-table
+    [items]="paymentEvents()"
+    [isPending]="false"
+    [columns]="columns()"
+    localStorageKey="activity-log-table"
+    [tableCellContext]="tableCellContext()"
+    [initialSortField]="'created'"
+    [initialSortOrder]="-1"
+  />
+</app-page-layout-payment>

--- a/interfaces/portal/src/app/pages/project-payment-log/project-payment-log.page.ts
+++ b/interfaces/portal/src/app/pages/project-payment-log/project-payment-log.page.ts
@@ -1,0 +1,123 @@
+import { CurrencyPipe, DatePipe, DecimalPipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  Signal,
+} from '@angular/core';
+import { Router } from '@angular/router';
+
+import { injectQuery } from '@tanstack/angular-query-experimental';
+import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
+import { SkeletonModule } from 'primeng/skeleton';
+
+import { PageLayoutPaymentComponent } from '~/components/page-layout-payment/page-layout-payment.component';
+import {
+  QueryTableColumn,
+  QueryTableColumnType,
+  QueryTableComponent,
+} from '~/components/query-table/query-table.component';
+import { PaymentApiService } from '~/domains/payment/payment.api.service';
+import { PAYMENT_EVENT_LOG_ITEM_TYPE_LABELS } from '~/domains/payment/payment.helpers';
+import { PaymentEventType } from '~/domains/payment/payment.model';
+import { ProjectApiService } from '~/domains/project/project.api.service';
+import { TableCellPaymentEventActivityComponent } from '~/pages/project-payment-log/components/table-cell-payment-event-activity.component';
+import { TableCellPaymentEventOverviewComponent } from '~/pages/project-payment-log/components/table-cell-payment-event-overview.component';
+import { AuthService } from '~/services/auth.service';
+import { RtlHelperService } from '~/services/rtl-helper.service';
+import { ToastService } from '~/services/toast.service';
+import { TranslatableStringService } from '~/services/translatable-string.service';
+import { getUniqueUserOptions } from '~/utils/unique-users';
+
+interface PaymentLogTableCellContext {
+  projectId: Signal<string>;
+  currencyCode: Signal<string | undefined>;
+}
+
+@Component({
+  selector: 'app-project-payment-log',
+  imports: [
+    PageLayoutPaymentComponent,
+    CardModule,
+    ButtonModule,
+    SkeletonModule,
+    QueryTableComponent,
+  ],
+  templateUrl: './project-payment-log.page.html',
+  styles: ``,
+  providers: [CurrencyPipe, DatePipe, DecimalPipe, ToastService],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProjectPaymentLogPageComponent {
+  // this is injected by the router
+  readonly projectId = input.required<string>();
+  readonly paymentId = input.required<string>();
+
+  readonly authService = inject(AuthService);
+  readonly currencyPipe = inject(CurrencyPipe);
+  readonly paymentApiService = inject(PaymentApiService);
+  readonly projectApiService = inject(ProjectApiService);
+  readonly rtlHelper = inject(RtlHelperService);
+  readonly router = inject(Router);
+  readonly toastService = inject(ToastService);
+  readonly translatableStringService = inject(TranslatableStringService);
+
+  project = injectQuery(this.projectApiService.getProject(this.projectId));
+
+  readonly tableCellContext = computed<PaymentLogTableCellContext>(() => ({
+    projectId: this.projectId,
+    currencyCode: this.currencyCode,
+  }));
+
+  paymentEventLog = injectQuery(
+    this.paymentApiService.getPaymentEvents({
+      projectId: this.projectId,
+      paymentId: this.paymentId,
+    }),
+  );
+
+  readonly paymentEvents = computed(
+    () => this.paymentEventLog.data()?.data ?? [],
+  );
+  readonly availablePaymentEventTypes = computed(
+    () => this.paymentEventLog.data()?.meta.availableTypes ?? [],
+  );
+
+  readonly columns = computed<QueryTableColumn<PaymentEventType>[]>(() => [
+    {
+      field: 'type',
+      header: $localize`Activity`,
+      component: TableCellPaymentEventActivityComponent,
+      type: QueryTableColumnType.MULTISELECT,
+      options: this.availablePaymentEventTypes().map((type) => {
+        const count = this.paymentEventLog.data()?.meta.count[type] ?? 0;
+        return {
+          label:
+            PAYMENT_EVENT_LOG_ITEM_TYPE_LABELS[type] + ` (${String(count)})`,
+          value: type,
+        };
+      }),
+    },
+    {
+      header: $localize`Overview`,
+      field: 'COMPUTED_FIELD',
+      component: TableCellPaymentEventOverviewComponent,
+    },
+    {
+      field: 'user.username',
+      header: $localize`Done by`,
+      type: QueryTableColumnType.MULTISELECT,
+      options: getUniqueUserOptions(this.paymentEvents()),
+    },
+    {
+      field: 'created',
+      header: $localize`Date and time`,
+      type: QueryTableColumnType.DATE,
+    },
+  ]);
+
+  readonly currencyCode = computed(() => this.project.data()?.currency);
+}

--- a/interfaces/portal/src/app/pages/project-payments/components/create-payment/create-payment.component.html
+++ b/interfaces/portal/src/app/pages/project-payments/components/create-payment/create-payment.component.html
@@ -74,10 +74,23 @@
         <p i18n>Review summary and click start payment.</p>
       }
       <p-card class="relative mt-5 block [&_.p-card-body]:py-2">
-        <app-data-list
-          [data]="paymentSummaryData()"
-          [hideBottomBorder]="true"
-        />
+        <app-data-list [data]="paymentSummaryData()" />
+        <div class="pt-4">
+          <form [formGroup]="paymentFormGroup">
+            <app-form-field-wrapper
+              label="Add note"
+              i18n-label
+            >
+              <input
+                class="w-full"
+                formControlName="note"
+                placeholder="Optional"
+                i18n-placeholder
+                pInputText
+              />
+            </app-form-field-wrapper>
+          </form>
+        </div>
         @if (paymentHasIntegratedFsp()) {
           <p-button
             text

--- a/interfaces/portal/src/app/pages/project-payments/components/create-payment/create-payment.component.ts
+++ b/interfaces/portal/src/app/pages/project-payments/components/create-payment/create-payment.component.ts
@@ -9,6 +9,7 @@ import {
   signal,
   viewChild,
 } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 
 import {
@@ -19,6 +20,7 @@ import { MenuItem } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
 import { DialogModule } from 'primeng/dialog';
+import { InputText } from 'primeng/inputtext';
 import { MenuModule } from 'primeng/menu';
 
 import { FspIntegrationType } from '@121-service/src/fsps/fsp-integration-type.enum';
@@ -33,6 +35,7 @@ import {
   DataListComponent,
   DataListItem,
 } from '~/components/data-list/data-list.component';
+import { FormFieldWrapperComponent } from '~/components/form-field-wrapper/form-field-wrapper.component';
 import { FullscreenStepperDialogComponent } from '~/components/fullscreen-stepper-dialog/fullscreen-stepper-dialog.component';
 import { RegistrationsTableComponent } from '~/components/registrations-table/registrations-table.component';
 import { FspConfigurationApiService } from '~/domains/fsp-configuration/fsp-configuration.api.service';
@@ -50,6 +53,7 @@ import { Dto } from '~/utils/dto-type';
 @Component({
   selector: 'app-create-payment',
   imports: [
+    ReactiveFormsModule,
     ButtonModule,
     DialogModule,
     DatePipe,
@@ -59,6 +63,8 @@ import { Dto } from '~/utils/dto-type';
     MenuModule,
     ColoredChipComponent,
     FullscreenStepperDialogComponent,
+    FormFieldWrapperComponent,
+    InputText,
   ],
   templateUrl: './create-payment.component.html',
   styles: ``,
@@ -97,6 +103,11 @@ export class CreatePaymentComponent {
   includedChipData = getChipDataByRegistrationStatus(
     RegistrationStatusEnum.included,
   );
+  paymentFormGroup = new FormGroup({
+    note: new FormControl('', {
+      nonNullable: true,
+    }),
+  });
 
   fspConfigurations = injectQuery(
     this.fspConfigurationApiService.getFspConfigurations(this.projectId),
@@ -148,7 +159,6 @@ export class CreatePaymentComponent {
           value: fspConfig.name,
         })),
         loading: this.fspConfigurations.isPending(),
-        fullWidth: true,
       },
       {
         label: $localize`Registrations`,
@@ -163,6 +173,7 @@ export class CreatePaymentComponent {
           '1.2-2',
         ),
         tooltip: $localize`The total payment amount is calculated by summing up the transfer values of each included registration added to the payment.`,
+        fullWidth: true,
       },
     ];
 
@@ -215,6 +226,7 @@ export class CreatePaymentComponent {
         paginateQuery,
         paymentData: {
           amount: this.paymentAmount(),
+          note: this.paymentFormGroup.value.note,
         },
         dryRun,
       });

--- a/interfaces/portal/src/app/pages/project-registration-activity-log/components/table-cell-activity.component.ts
+++ b/interfaces/portal/src/app/pages/project-registration-activity-log/components/table-cell-activity.component.ts
@@ -17,7 +17,7 @@ import { Activity } from '~/domains/registration/registration.model';
   imports: [],
   template: `
     <span class="inline-flex items-center">
-      <span class="inline w-8 leading-[0]"
+      <span class="me-4 inline leading-[0]"
         ><i [class]="icon() + ' text-xl'"></i>
       </span>
       <span>{{ label() }}</span>

--- a/interfaces/portal/src/app/utils/unique-users.ts
+++ b/interfaces/portal/src/app/utils/unique-users.ts
@@ -1,12 +1,12 @@
 import { unique } from 'radashi';
 
 export const getUniqueUserOptions = (
-  options: { user: { username?: string } }[],
+  options: { user?: { username?: string } }[],
 ) =>
   unique(
     options.map(({ user }) => ({
-      label: user.username ?? $localize`Unknown user`,
-      value: user.username ?? $localize`Unknown user`,
+      label: user?.username ?? $localize`Unknown user`,
+      value: user?.username ?? $localize`Unknown user`,
     })),
     (activity) => activity.value,
   ).sort((a, b) => a.label.localeCompare(b.label));

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -1690,6 +1690,7 @@
       </trans-unit>
       <trans-unit id="8433732438274024544" datatype="html">
         <source>Add note</source>
+      </trans-unit>
       <trans-unit id="page-title-project-payment-log" datatype="html">
         <source>Payment log</source>
       </trans-unit>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -1685,6 +1685,11 @@
       <trans-unit id="page-title-project-transfer-list" datatype="html">
         <source>Transfer list</source>
       </trans-unit>
+      <trans-unit id="3915966149686975421" datatype="html">
+        <source>Optional</source>
+      </trans-unit>
+      <trans-unit id="8433732438274024544" datatype="html">
+        <source>Add note</source>
       <trans-unit id="page-title-project-payment-log" datatype="html">
         <source>Payment log</source>
       </trans-unit>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -1685,6 +1685,15 @@
       <trans-unit id="page-title-project-transfer-list" datatype="html">
         <source>Transfer list</source>
       </trans-unit>
+      <trans-unit id="page-title-project-payment-log" datatype="html">
+        <source>Payment log</source>
+      </trans-unit>
+      <trans-unit id="payment-event-log-item-type-created" datatype="html">
+        <source>Created</source>
+      </trans-unit>
+      <trans-unit id="payment-event-log-item-type-note" datatype="html">
+        <source>Note</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
[AB#37700](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37700)

## Describe your changes

- This PR contains
  - add payment note (front-end) > already approved by @elwinschmitz 
  - view payment log (front-end) > all comments by @elwinschmitz are addressed or reverted to post-merge review task [AB#37776](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37776)
  - e2e test combining both features above > to be reviewed 

For the post-merge review:
- Specific feedback welcome on naming, which I struggled with a bit. This rose partly from the following: the design of this log is exactly equal to the Registration Activities log. That one is called 'activities' because it is a combination of 'registration events' and other things (like payments). In the current case we only have 'payment events' and don't combine it with anything else. Therefore we opted to keep calling the overall thing also 'payment events' and not 'payment activities'. So even though the data return format of GET /registration-activities and /GET payment-events are identical (in line with the identical FE designs), their naming is divergent. This has repercussions in this FE branch. 

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7152.westeurope.3.azurestaticapps.net
