### PR TITLE
Post merge review niels small changes

### DIFF
--- a/services/121-service/src/metrics/metrics.controller.ts
+++ b/services/121-service/src/metrics/metrics.controller.ts
@@ -102,18 +102,11 @@ export class MetricsController {
     @Req() req: ScopedUserRequest,
     @Res() res: Response,
   ): Promise<Response | void> {
-    if (!Object.values(ExportType).includes(exportType)) {
-      throw new HttpException(
-        `Invalid export type: ${exportType}. Valid types are: ${Object.values(ExportType).join(', ')}`,
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-
     const userId = RequestHelper.getUserId(req);
     if (queryParams['search']) {
       paginationQuery.search = queryParams['search'];
     }
-    const result = await this.metricsService.getExportList({
+    const result = await this.metricsService.getExport({
       programId,
       type: exportType,
       userId,

--- a/services/121-service/src/payments/services/__snapshots__/payments-reporting.service.spec.ts.snap
+++ b/services/121-service/src/payments/services/__snapshots__/payments-reporting.service.spec.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PaymentsReportingService - getTransactions geTransactionsByPaymentId should throw 404 if payment does not exist 1`] = `[HttpException: Payment with ID 999 not found in program 1]`;
+exports[`PaymentsReportingService - getTransactions getTransactionsByPaymentId should throw 404 if payment does not exist 1`] = `[HttpException: Payment with ID 999 not found in program 1]`;
 
 exports[`PaymentsReportingService - getTransactions getPaymentEvents should throw 404 if payment does not exist 1`] = `[HttpException: Payment with ID 999 not found in program 1]`;

--- a/services/121-service/src/payments/services/payments-reporting.service.spec.ts
+++ b/services/121-service/src/payments/services/payments-reporting.service.spec.ts
@@ -80,7 +80,7 @@ describe('PaymentsReportingService - getTransactions', () => {
     jest.spyOn(paymentRepository, 'findOne').mockResolvedValue({});
   });
 
-  describe('geTransactionsByPaymentId', () => {
+  describe('getTransactionsByPaymentId', () => {
     it('should return transactions with names', async () => {
       // Arrange
       const programId = 1;

--- a/services/121-service/src/payments/services/payments-reporting.service.ts
+++ b/services/121-service/src/payments/services/payments-reporting.service.ts
@@ -230,7 +230,7 @@ export class PaymentsReportingService {
       registrationViews.map((item) => [item.referenceId, item]),
     );
 
-    const result = transactions.map((transaction) => {
+    const transactionsEnriched = transactions.map((transaction) => {
       const registrationView = registrationViewMap.get(
         transaction.registrationReferenceId,
       );
@@ -247,7 +247,7 @@ export class PaymentsReportingService {
       };
     });
 
-    return result;
+    return transactionsEnriched;
   }
 
   public async getPaymentEvents({

--- a/services/121-service/src/registration/mappers/registration-views.mapper.spec.ts
+++ b/services/121-service/src/registration/mappers/registration-views.mapper.spec.ts
@@ -1,6 +1,7 @@
 import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/program-registration-attribute.entity';
 import { RegistrationViewsMapper } from '@121-service/src/registration/mappers/registration-views.mapper';
 
+// TODO: Add more unit tests for this mapper class
 describe('RegistrationViewsMapper', () => {
   describe('replaceDropdownValuesWithEnglishLabel', () => {
     it('should replace dropdown values with English label', () => {

--- a/services/121-service/src/registration/mappers/registration-views.mapper.ts
+++ b/services/121-service/src/registration/mappers/registration-views.mapper.ts
@@ -10,7 +10,6 @@ import { RegistrationViewEntity } from '@121-service/src/registration/registrati
 
 type RegistrationViewWithoutData = Omit<RegistrationViewEntity, 'data'>;
 
-// TODO: Add unit tests for this mapper class
 export class RegistrationViewsMapper {
   static selectRegistrationRootFields({
     registration,


### PR DESCRIPTION
[AB#37684](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37684) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

> We check for correct export type in both the metrics controller and the metrics service probably better to do that once.

Done

> `metrics.service:getRegistrationsList` is now only used by `getAllPeopleAffectedList`, no longer should be a separate method

I renamed the method names a bit. I think it's still valuable to have a seperate method

> `getRegistrationsGenericFields` should be moved under `getAllPeopleAffectedList` it's now in a weird position in the class

Done

> `etRegistrationsGenericFields` is called by only one function so it does not need to receive `exportType` (as it's always `registrations`), the conditional inside that function can then also be simplified

Done


in `metrics.service` the 3 args `filter`, `search` and `select` are passed down together and unchanged, probably better to keep as `paginateQuery` and then override some pagination settings that all the way down in `getRegistrationsGenericFields`

> Done

*   in `services/121-service/src/payments
    *   `geTransactionsByPaymentId` has a typo in the name

> This was already half done. The type was stil in .spec file and is now fixed


I think the variable name `result` should only be used in small scopes, `getTransactions` is too big, suggestions: reuse `transactions` or something like `transactionsEnriched`.

> Done


`services/121-service/src/registration/mappers/registration-views.mapper.ts` the comment "// TODO: Add unit tests for this mapper class" can be amended to "add more"

> Done and moved the comment to the spec file
## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
