### PR TITLE
feat: logout on deprecated permissions

### DIFF
--- a/interfaces/portal/src/app/services/auth.service.spec.ts
+++ b/interfaces/portal/src/app/services/auth.service.spec.ts
@@ -40,7 +40,7 @@ describe('AuthService - hasDeprecatedPermissions', () => {
       isUserExpired: jasmine.createSpy<() => boolean>('isUserExpired'),
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- Did not manage to get test working otherwise
     mockInjector.get.and.returnValue(mockAuthStrategy);
 
     TestBed.configureTestingModule({

--- a/interfaces/portal/src/app/services/auth.service.spec.ts
+++ b/interfaces/portal/src/app/services/auth.service.spec.ts
@@ -1,0 +1,103 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { Injector } from '@angular/core';
+
+import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
+
+import { AuthService } from './auth.service';
+import { LogService } from '~/services/log.service';
+import { LocalStorageUser } from '~/utils/local-storage';
+
+describe('AuthService - hasDeprecatedPermissions', () => {
+  let service: AuthService;
+  let mockRouter: jasmine.SpyObj<Router>;
+  let mockLogService: jasmine.SpyObj<LogService>;
+  let mockInjector: jasmine.SpyObj<Injector>;
+  let mockAuthStrategy: jasmine.SpyObj<{ isUserExpired: any; logout: any }>;
+
+  const createMockUser = (
+    permissions: Record<number, PermissionEnum[]>,
+  ): LocalStorageUser => ({
+    username: 'testuser',
+    isAdmin: false,
+    isOrganizationAdmin: false,
+    permissions,
+  });
+
+  beforeEach(() => {
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockLogService = jasmine.createSpyObj('LogService', ['logEvent']);
+    mockAuthStrategy = jasmine.createSpyObj('AuthStrategy', [
+      'logout',
+      'isUserExpired',
+    ]);
+    mockInjector = jasmine.createSpyObj('Injector', ['get']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        AuthService,
+        { provide: Router, useValue: mockRouter },
+        { provide: LogService, useValue: mockLogService },
+        { provide: Injector, useValue: mockInjector },
+      ],
+    });
+
+    mockInjector.get.and.returnValue(mockAuthStrategy);
+    service = TestBed.inject(AuthService);
+  });
+
+  describe('user getter with deprecated permissions', () => {
+    let localStorageGetItemSpy: jasmine.Spy;
+    beforeEach(() => {
+      localStorageGetItemSpy = spyOn(localStorage, 'getItem').and.returnValue(
+        null,
+      );
+      spyOn(localStorage, 'removeItem');
+      mockAuthStrategy.isUserExpired = jasmine
+        .createSpy()
+        .and.returnValue(false);
+      mockAuthStrategy.logout = jasmine
+        .createSpy()
+        .and.returnValue(Promise.resolve());
+      mockRouter.navigate.and.returnValue(Promise.resolve(true));
+    });
+
+    it('should trigger logout when user has deprecated permissions', () => {
+      const userWithDeprecatedPermissions = createMockUser({
+        1: [
+          PermissionEnum.RegistrationREAD,
+          'DEPRECATED_PERMISSION' as PermissionEnum,
+        ],
+      });
+
+      localStorageGetItemSpy.and.returnValue(
+        JSON.stringify(userWithDeprecatedPermissions),
+      );
+      spyOn(service, 'logout').and.returnValue(Promise.resolve());
+
+      const result = service.user;
+
+      expect(result).toBeNull();
+      expect(service.logout).toHaveBeenCalledWith(
+        userWithDeprecatedPermissions,
+      );
+    });
+
+    it('should return user when permissions are valid', () => {
+      const userWithValidPermissions = createMockUser({
+        1: [
+          PermissionEnum.RegistrationREAD,
+          PermissionEnum.RegistrationBulkUPDATE,
+        ],
+      });
+
+      localStorageGetItemSpy.and.returnValue(
+        JSON.stringify(userWithValidPermissions),
+      );
+
+      const result = service.user;
+
+      expect(result).toEqual(userWithValidPermissions);
+    });
+  });
+});

--- a/interfaces/portal/src/app/services/auth.service.spec.ts
+++ b/interfaces/portal/src/app/services/auth.service.spec.ts
@@ -68,6 +68,7 @@ describe('AuthService - hasDeprecatedPermissions', () => {
     });
 
     it('should trigger logout when user has deprecated permissions', () => {
+      // Arrange
       const userWithDeprecatedPermissions = createMockUser({
         1: [
           PermissionEnum.RegistrationREAD,
@@ -82,13 +83,16 @@ describe('AuthService - hasDeprecatedPermissions', () => {
         Promise.resolve(),
       );
 
+      // Act - the user getter is called
       const result = service.user;
 
+      // Assert
       expect(result).toBeNull();
       expect(logoutSpy).toHaveBeenCalledWith(userWithDeprecatedPermissions);
     });
 
     it('should return user when permissions are valid', () => {
+      // Arrange
       const userWithValidPermissions = createMockUser({
         1: [
           PermissionEnum.RegistrationREAD,
@@ -100,8 +104,10 @@ describe('AuthService - hasDeprecatedPermissions', () => {
         JSON.stringify(userWithValidPermissions),
       );
 
+      // Act - the user getter is called
       const result = service.user;
 
+      // Assert
       expect(result).toEqual(userWithValidPermissions);
     });
   });

--- a/interfaces/portal/src/app/services/auth.service.ts
+++ b/interfaces/portal/src/app/services/auth.service.ts
@@ -77,6 +77,14 @@ export class AuthService {
       return null;
     }
 
+    // If user has deprecated permissions (e.g. after a deploy), force to re-login
+    if (this.hasDeprecatedPermissions(user)) {
+      console.warn(
+        'AuthService: Deprecated permission found. Forcing re-login',
+      );
+      return null;
+    }
+
     return user;
   }
 
@@ -179,9 +187,22 @@ export class AuthService {
       }),
     );
   }
+
   public handleAuthCallback() {
     const returnUrl = getReturnUrlFromLocalStorage();
 
     this.authStrategy.handleAuthCallback(returnUrl ?? '/');
+  }
+
+  public hasDeprecatedPermissions(user: LocalStorageUser): boolean {
+    const validPermissions = new Set(Object.values(PermissionEnum));
+    for (const projectId of Object.keys(user.permissions)) {
+      for (const permission of user.permissions[Number(projectId)]) {
+        if (!validPermissions.has(permission)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 }

--- a/interfaces/portal/src/app/services/auth.service.ts
+++ b/interfaces/portal/src/app/services/auth.service.ts
@@ -23,6 +23,7 @@ const AuthStrategy = environment.use_sso_azure_entra
   : BasicAuthStrategy;
 
 export const AUTH_ERROR_IN_STATE_KEY = 'AUTH_ERROR';
+const VALID_PERMISSIONS = new Set(Object.values(PermissionEnum));
 
 @Injectable({
   providedIn: 'root',
@@ -195,10 +196,9 @@ export class AuthService {
   }
 
   public hasDeprecatedPermissions(user: LocalStorageUser): boolean {
-    const validPermissions = new Set(Object.values(PermissionEnum));
     for (const projectId of Object.keys(user.permissions)) {
       for (const permission of user.permissions[Number(projectId)]) {
-        if (!validPermissions.has(permission)) {
+        if (!VALID_PERMISSIONS.has(permission)) {
           return true;
         }
       }

--- a/interfaces/portal/src/app/services/auth.service.ts
+++ b/interfaces/portal/src/app/services/auth.service.ts
@@ -70,11 +70,13 @@ export class AuthService {
 
     if (!user?.username) {
       console.warn('AuthService: No valid user');
+      void this.logout(user);
       return null;
     }
 
     if (this.authStrategy.isUserExpired(user)) {
       console.warn('AuthService: Expired token');
+      void this.logout(user);
       return null;
     }
 
@@ -83,6 +85,7 @@ export class AuthService {
       console.warn(
         'AuthService: Deprecated permission found. Forcing re-login',
       );
+      void this.logout(user);
       return null;
     }
 
@@ -104,11 +107,11 @@ export class AuthService {
     return this.router.navigate(['/', AppRoutes.authCallback]);
   }
 
-  public async logout() {
+  public async logout(user?: LocalStorageUser | null) {
     this.logService.logEvent(LogEvent.userLogout);
 
     try {
-      await this.authStrategy.logout(this.user);
+      await this.authStrategy.logout(user ?? this.user);
     } catch (error) {
       console.error('AuthService: Error logging out', error);
     }


### PR DESCRIPTION
[AB#37836](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37836)

## Describe your changes

- This change came out of the program-to-project rename work, where permissions (e.g. 'program:metrics.read) were also renamed. For logged in users after deploy, this would lead to portal where certain things are not visible (Monitoring page menu-item) or not work.
- After discussion [here](https://teams.microsoft.com/l/message/19:ce634fd37f34477d9f98391f70e1f0ef@thread.skype/1756730859255?tenantId=d3ab9790-6ae2-4bd8-aa5e-02864483e7c7&groupId=55f2fa49-7d9b-4c63-b616-b986f3136c3a&parentMessageId=1756730859255&teamName=510%20-%20CVA&channelName=121%20Development&createdTime=1756730859255) I in the end arrived at the 'force manual re-login' option. 
- I looked into the option of directly calling GET /user/current as well, but I think it's more complicated, a.o. because there is a risk of an infinite loop involved. I am happy to create a follow-up somehow (item/spike/SA parking lot) to improve on this iteratively in the future.
- For now, Letting the user do one manual re-login is fine I think, given the scope of this refactor.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7186.westeurope.3.azurestaticapps.net
