### PR TITLE
chore: avoid filesize v11 in portal

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -108,7 +108,7 @@ updates:
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
       - dependency-name: 'filesize'
-        versions: ['^10.x'] # See: https://www.npmjs.com/package/ngx-filesize
+        versions: ['^10.x', '^11.x'] # See: https://www.npmjs.com/package/ngx-filesize
       - dependency-name: 'primeng'
         update-types: ['version-update:semver-major']
       - dependency-name: 'tailwindcss' # TODO: AB#33547


### PR DESCRIPTION
AB#37871

To avoid issues like https://github.com/global-121/121-platform/pull/7193

because filesize >9 is not supported by ngx-filesize.

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
