### PR TITLE
chore: merge dependabot angular & linting group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,8 +83,6 @@ updates:
           - 'primeng'
           - 'typescript'
           - 'zone.js'
-      linting:
-        patterns:
           - '*eslint*'
           - '*prettier*'
       AzureMSAL:


### PR DESCRIPTION
[AB#37871](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37871)

I'm having some issues eg. with #7176 and #7178 because the TS versions or angular versions or eslint version are not upgraded together.

I think we'll avoid some headaches by just merging these groups together.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
