### PR TITLE
fix non nullable registration fields

### DIFF
--- a/services/121-service/src/registration/registration.entity.ts
+++ b/services/121-service/src/registration/registration.entity.ts
@@ -158,7 +158,6 @@ export class RegistrationEntity extends Base121Entity {
 
   // TODO: add some database constraints to make sure that scope is always lowercase
   // TODO: DO not make this nullable but set everything to empty string in migration
-  // Also not use the setting {default: ''} because than we will forget to set it later just one time '' in the migration
   @Index()
   @Column({ nullable: false, default: '' })
   public scope: string;

--- a/services/121-service/src/registration/registration.entity.ts
+++ b/services/121-service/src/registration/registration.entity.ts
@@ -98,7 +98,6 @@ export class RegistrationEntity extends Base121Entity {
   @Index()
   public registrationProgramId: number;
 
-  //TODO: added null
   @Column({ nullable: true, type: 'integer' })
   @IsInt()
   @IsPositive()

--- a/services/121-service/src/registration/registration.entity.ts
+++ b/services/121-service/src/registration/registration.entity.ts
@@ -98,11 +98,12 @@ export class RegistrationEntity extends Base121Entity {
   @Index()
   public registrationProgramId: number;
 
+  //TODO: added null
   @Column({ nullable: true, type: 'integer' })
   @IsInt()
   @IsPositive()
   @IsOptional()
-  public maxPayments?: number;
+  public maxPayments?: number | null;
 
   // This is a count of the number of transactions with a distinct on the paymentId
   // can be failed or successful or waiting transactions

--- a/services/121-service/src/registration/validators/registrations-input-validator.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.ts
@@ -125,7 +125,6 @@ export class RegistrationsInputValidator {
         }
       }
 
-      //TODO: 1
       if (program.enableMaxPayments && row.maxPayments !== undefined) {
         const { errorObj: errorObjMaxPayments, validatedMaxPayments } =
           this.validateMaxPayments({
@@ -156,10 +155,9 @@ export class RegistrationsInputValidator {
         if (errorObjScope) {
           errors.push(errorObjScope);
         } else if (program.enableScope) {
-          // We know that scope is undefined or string, or an error would have occured
-          validatedRegistrationInput.scope = row[AdditionalAttributes.scope] as
-            | undefined
-            | string;
+          validatedRegistrationInput.scope = String(
+            row[AdditionalAttributes.scope] ?? '',
+          );
         }
       }
 

--- a/services/121-service/src/registration/validators/registrations-input-validator.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.ts
@@ -125,6 +125,7 @@ export class RegistrationsInputValidator {
         }
       }
 
+      //TODO: 1
       if (program.enableMaxPayments && row.maxPayments !== undefined) {
         const { errorObj: errorObjMaxPayments, validatedMaxPayments } =
           this.validateMaxPayments({
@@ -135,6 +136,7 @@ export class RegistrationsInputValidator {
         if (errorObjMaxPayments) {
           errors.push(errorObjMaxPayments);
         } else {
+          // is undefined on empty
           validatedRegistrationInput.maxPayments = validatedMaxPayments;
         }
       }
@@ -986,6 +988,7 @@ export class RegistrationsInputValidator {
     return { validatedPaymentAmountMultiplier: +value };
   }
 
+  //TODO: 2
   private validateMaxPayments({
     value,
     originalRegistration,
@@ -996,12 +999,13 @@ export class RegistrationsInputValidator {
     i: number;
   }): {
     errorObj?: ValidateRegistrationErrorObject | undefined;
-    validatedMaxPayments?: number | undefined;
+    validatedMaxPayments?: number | null;
   } {
     // It's always allowed to remove the maxPayments value
     // When you upload a csv file, the value is an empty string
     if (value == null || value === '') {
-      return { validatedMaxPayments: undefined };
+      // returns here on empty
+      return { validatedMaxPayments: null };
     }
     if (isNaN(+value) || +value <= 0) {
       return {

--- a/services/121-service/src/registration/validators/registrations-input-validator.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.ts
@@ -135,7 +135,6 @@ export class RegistrationsInputValidator {
         if (errorObjMaxPayments) {
           errors.push(errorObjMaxPayments);
         } else {
-          // is undefined on empty
           validatedRegistrationInput.maxPayments = validatedMaxPayments;
         }
       }
@@ -986,7 +985,6 @@ export class RegistrationsInputValidator {
     return { validatedPaymentAmountMultiplier: +value };
   }
 
-  //TODO: 2
   private validateMaxPayments({
     value,
     originalRegistration,
@@ -997,12 +995,11 @@ export class RegistrationsInputValidator {
     i: number;
   }): {
     errorObj?: ValidateRegistrationErrorObject | undefined;
-    validatedMaxPayments?: number | null;
+    validatedMaxPayments?: number | undefined | null;
   } {
     // It's always allowed to remove the maxPayments value
     // When you upload a csv file, the value is an empty string
     if (value == null || value === '') {
-      // returns here on empty
       return { validatedMaxPayments: null };
     }
     if (isNaN(+value) || +value <= 0) {


### PR DESCRIPTION
AB#34753

## Describe your changes

For the Max. payments field, I updated its rules for it to accept `null` as a valid value and updated its validator to update the `maxPayment` value to `null` when `undefined` or empty.

Scope cannot be saved as `null`, because the registration query queries for a string in `scope`, so I updated the validator logic to update `scope`s value to an empty string when `null` or `undefined`.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
