### PR TITLE
fix: Don't wait for result of cron-jobs in API-requests (to keep the logs clean)

### DIFF
--- a/services/121-service/src/cronjob/cronjob.controller.ts
+++ b/services/121-service/src/cronjob/cronjob.controller.ts
@@ -39,8 +39,8 @@ export class CronjobController {
     description: 'Vouchers canceled by refpos',
   })
   @Post('/fsps/intersolve-voucher/cancel')
-  public async cancelByRefPos(): Promise<void> {
-    await this.cronjobExecutionService.cronCancelByRefposIntersolve();
+  public cancelByRefPos() {
+    void this.cronjobExecutionService.cronCancelByRefposIntersolve();
   }
 
   @AuthenticatedUser({ isAdmin: true })
@@ -54,8 +54,8 @@ export class CronjobController {
       'Done retrieving and updating/insterting enquiry data for all registrations in all programs.',
   })
   @Put('fsps/commercial-bank-ethiopia/account-enquiries')
-  public async retrieveAndUpsertAccountEnquiries(): Promise<void> {
-    await this.cronjobExecutionService.cronValidateCommercialBankEthiopiaAccountEnquiries();
+  public retrieveAndUpsertAccountEnquiries() {
+    void this.cronjobExecutionService.cronValidateCommercialBankEthiopiaAccountEnquiries();
   }
 
   @AuthenticatedUser({ isAdmin: true })
@@ -67,8 +67,8 @@ export class CronjobController {
     description: 'Cached unused vouchers',
   })
   @Patch('/fsps/intersolve-voucher/unused-vouchers')
-  public async cronRetrieveAndUpdatedUnusedIntersolveVouchers(): Promise<void> {
-    await this.cronjobExecutionService.cronRetrieveAndUpdatedUnusedIntersolveVouchers();
+  public cronRetrieveAndUpdatedUnusedIntersolveVouchers() {
+    void this.cronjobExecutionService.cronRetrieveAndUpdatedUnusedIntersolveVouchers();
   }
 
   @AuthenticatedUser({ isAdmin: true })
@@ -82,8 +82,8 @@ export class CronjobController {
       'Data retrieved from Intersolve and entities updated for all programs.',
   })
   @Patch('/fsps/intersolve-visa/')
-  public async cronRetrieveAndUpdateVisaData(): Promise<void> {
-    await this.cronjobExecutionService.cronRetrieveAndUpdateVisaData();
+  public cronRetrieveAndUpdateVisaData() {
+    void this.cronjobExecutionService.cronRetrieveAndUpdateVisaData();
   }
 
   @AuthenticatedUser({ isAdmin: true })
@@ -95,8 +95,8 @@ export class CronjobController {
     description: 'Sent WhatsApp reminders',
   })
   @Post('/fsps/intersolve-voucher/send-reminders')
-  public async cronSendWhatsappReminders(): Promise<void> {
-    await this.cronjobExecutionService.cronSendWhatsappReminders();
+  public cronSendWhatsappReminders() {
+    void this.cronjobExecutionService.cronSendWhatsappReminders();
   }
 
   @AuthenticatedUser({ isAdmin: true })
@@ -109,8 +109,8 @@ export class CronjobController {
     description: 'Nedbank vouchers and transaction update process started',
   })
   @Patch('fsps/nedbank')
-  public async cronDoNedbankReconciliation(): Promise<void> {
-    await this.cronjobExecutionService.cronDoNedbankReconciliation();
+  public cronDoNedbankReconciliation() {
+    void this.cronjobExecutionService.cronDoNedbankReconciliation();
   }
 
   @AuthenticatedUser({ isAdmin: true })
@@ -124,8 +124,8 @@ export class CronjobController {
       'Get all exchange rates for all programs and store them in the database',
   })
   @Put('exchange-rates')
-  public async cronGetDailyExchangeRates(): Promise<void> {
-    await this.cronjobExecutionService.cronGetDailyExchangeRates();
+  public cronGetDailyExchangeRates() {
+    void this.cronjobExecutionService.cronGetDailyExchangeRates();
   }
 
   @AuthenticatedUser({ isAdmin: true })
@@ -156,8 +156,8 @@ export class CronjobController {
   })
   @HttpCode(HttpStatus.OK)
   @Post('fsps/onafriq/reconciliation-report')
-  public async generateReconciliationReport(): Promise<void> {
-    return await this.cronjobExecutionService.cronSendOnafriqReconciliationReport();
+  public generateReconciliationReport() {
+    void this.cronjobExecutionService.cronSendOnafriqReconciliationReport();
   }
 
   @ApiOperation({

--- a/services/121-service/src/cronjob/services/cronjob-execution-helper.service.ts
+++ b/services/121-service/src/cronjob/services/cronjob-execution-helper.service.ts
@@ -17,22 +17,19 @@ export class CronjobExecutionHelperService {
     this.azureLogService.consoleLogAndTraceAzure(startMessage);
 
     try {
-      // Execute the cron job function and await its result
       const batchSize = await fn();
 
-      // Handle the result and log the end message
       const cronjobResultMessage = this.createCronjobResultMessage({
         methodName,
         batchSize,
         isError: false,
       });
       this.azureLogService.consoleLogAndTraceAzure(cronjobResultMessage);
+
       return batchSize;
     } catch (error) {
-      // 1. Log the stack trace to the Node logs
       console.error(`Error executing cron job ${methodName}:`, error);
 
-      // 2. Log the cronjob end message to Azure Application Insights and trigger an alert
       const cronjobResultMessage = this.createCronjobResultMessage({
         methodName,
         isError: true,
@@ -51,15 +48,19 @@ export class CronjobExecutionHelperService {
     const { methodName, batchSize, isError } = cronjobResults;
     let message = `[CRON END] ${env.ENV_NAME} - ${methodName} finished at ${new Date().toISOString()}`;
     const details: string[] = [];
+
     if (typeof batchSize === 'number') {
       details.push(`batchSize=${batchSize}`);
     }
+
     if (isError) {
       details.push('isError=true');
     }
+
     if (details.length > 0) {
       message += ` (${details.join(', ')})`;
     }
+
     return message;
   }
 }

--- a/services/121-service/src/cronjob/services/cronjob-execution.service.ts
+++ b/services/121-service/src/cronjob/services/cronjob-execution.service.ts
@@ -24,60 +24,60 @@ export class CronjobExecutionService {
     private readonly cronjobExecutionHelperService: CronjobExecutionHelperService,
   ) {}
 
-  public async cronCancelByRefposIntersolve(): Promise<void> {
-    await this.cronjobExecutionHelperService.executeWithLogging(
+  public cronCancelByRefposIntersolve() {
+    void this.cronjobExecutionHelperService.executeWithLogging(
       'cronCancelByRefposIntersolve',
       () => this.intersolveVoucherCronService.cancelByRefposIntersolve(),
     );
   }
 
-  public async cronValidateCommercialBankEthiopiaAccountEnquiries(): Promise<void> {
-    await this.cronjobExecutionHelperService.executeWithLogging(
+  public cronValidateCommercialBankEthiopiaAccountEnquiries() {
+    void this.cronjobExecutionHelperService.executeWithLogging(
       'cronValidateCommercialBankEthiopiaAccountEnquiries',
       () =>
         this.commercialBankEthiopiaReconciliationService.retrieveAndUpsertAccountEnquiries(),
     );
   }
 
-  public async cronRetrieveAndUpdatedUnusedIntersolveVouchers(): Promise<void> {
-    await this.cronjobExecutionHelperService.executeWithLogging(
+  public cronRetrieveAndUpdatedUnusedIntersolveVouchers() {
+    void this.cronjobExecutionHelperService.executeWithLogging(
       'cronRetrieveAndUpdatedUnusedIntersolveVouchers',
       () =>
         this.intersolveVoucherReconciliationService.cronRetrieveAndUpdatedUnusedIntersolveVouchers(),
     );
   }
 
-  public async cronRetrieveAndUpdateVisaData(): Promise<void> {
-    await this.cronjobExecutionHelperService.executeWithLogging(
+  public cronRetrieveAndUpdateVisaData() {
+    void this.cronjobExecutionHelperService.executeWithLogging(
       'cronRetrieveAndUpdateVisaData',
       () =>
         this.intersolveVisaReconciliationService.retrieveAndUpdateAllWalletsAndCards(),
     );
   }
 
-  public async cronSendWhatsappReminders(): Promise<void> {
-    await this.cronjobExecutionHelperService.executeWithLogging(
+  public cronSendWhatsappReminders() {
+    void this.cronjobExecutionHelperService.executeWithLogging(
       'cronSendWhatsappReminders',
       () => this.intersolveVoucherCronService.sendWhatsappReminders(),
     );
   }
 
-  public async cronDoNedbankReconciliation(): Promise<void> {
-    await this.cronjobExecutionHelperService.executeWithLogging(
+  public cronDoNedbankReconciliation() {
+    void this.cronjobExecutionHelperService.executeWithLogging(
       'cronDoNedbankReconciliation',
       () => this.nedbankReconciliationService.doNedbankReconciliation(),
     );
   }
 
-  public async cronSendOnafriqReconciliationReport(): Promise<void> {
-    await this.cronjobExecutionHelperService.executeWithLogging(
+  public cronSendOnafriqReconciliationReport() {
+    void this.cronjobExecutionHelperService.executeWithLogging(
       'cronSendOnafriqReconciliationReport',
       () => this.onafriqReconciliationService.sendReconciliationReport(),
     );
   }
 
-  public async cronGetDailyExchangeRates(): Promise<void> {
-    await this.cronjobExecutionHelperService.executeWithLogging(
+  public cronGetDailyExchangeRates() {
+    void this.cronjobExecutionHelperService.executeWithLogging(
       'cronGetDailyExchangeRates',
       () => this.exchangeRatesService.retrieveAndStoreAllExchangeRates(),
     );


### PR DESCRIPTION
[AB#37639](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37639)

## Description

The API-requests that trigger the actual jobs, will not wait(and timeout);

The one job that _did_ return a value, I've left alone. Because it wasn't causing any noise in the logs.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] Adding tests is unnecessary/irrelevant
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
