### PR TITLE
Make commerical bank of ethiopia mock more strict

### DIFF
--- a/services/121-service/src/payments/fsp-integration/commercial-bank-ethiopia/services/commercial-bank-ethiopia.service.ts
+++ b/services/121-service/src/payments/fsp-integration/commercial-bank-ethiopia/services/commercial-bank-ethiopia.service.ts
@@ -4,7 +4,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import Redis from 'ioredis';
 import { Repository } from 'typeorm';
 
-import { env } from '@121-service/src/env';
 import { FspAttributes } from '@121-service/src/fsps/enums/fsp-attributes.enum';
 import { Fsps } from '@121-service/src/fsps/enums/fsp-name.enum';
 import { PaPaymentDataDto } from '@121-service/src/payments/dto/pa-payment-data.dto';
@@ -223,9 +222,7 @@ export class CommercialBankEthiopiaService implements FspIntegrationInterface {
       } else if ((data.fieldName = 'debitTheirRef')) {
         // This is a test code which is used in mock mode to simulate a transfer credit that is duplicated
         // The mock service checks if the debitTheirRef starts with 'duplicate-' and if so, will simulate a duplicate transfer flow
-        debitTheirRefRetry = env.MOCK_COMMERCIAL_BANK_ETHIOPIA
-          ? `duplicate-${data.value}`
-          : data.value;
+        debitTheirRefRetry = data.value;
       }
     });
 

--- a/services/121-service/test/payment/do-payment-fsp-commercial-bank-ethiopia.test.ts
+++ b/services/121-service/test/payment/do-payment-fsp-commercial-bank-ethiopia.test.ts
@@ -8,7 +8,10 @@ import {
   retryPayment,
   waitForPaymentTransactionsToComplete,
 } from '@121-service/test/helpers/program.helper';
-import { seedIncludedRegistrations } from '@121-service/test/helpers/registration.helper';
+import {
+  seedIncludedRegistrations,
+  updateRegistration,
+} from '@121-service/test/helpers/registration.helper';
 import {
   getAccessToken,
   resetDB,
@@ -222,6 +225,19 @@ describe('Do payment with FSP: Commercial Bank of Ethiopia', () => {
     );
     expect(getTransactionsBody.body[0].status).toBe(
       TransactionStatusEnum.error,
+    );
+
+    // Ensure that the duplicate transaction flow is used by settings registrationsname to duplicate
+    // First the credit transfer API call should return a duplicated transaction error
+    // And than the get transaction status API call should return a success response
+    await updateRegistration(
+      programId,
+      registrationCbe.referenceId,
+      {
+        fullName: `duplicate-${registrationCbe.referenceId}`,
+      },
+      'test-reason',
+      accessToken,
     );
 
     // Act

--- a/services/mock-service/src/fsp-integration/commercial-bank-ethiopia/commercial-bank-ethiopia.mock.service.ts
+++ b/services/mock-service/src/fsp-integration/commercial-bank-ethiopia/commercial-bank-ethiopia.mock.service.ts
@@ -164,7 +164,7 @@ export class CommercialBankEthiopiaMockService {
     let status;
     if (missingFields.length > 0) {
       status = this.buildStatusObject('missing', missingFields);
-    } else if (debitTheirRef?.includes('duplicate-')) {
+    } else if (beneficiaryName?.includes('duplicate-')) {
       status = this.buildStatusObject('duplicate');
     } else if (beneficiaryName === 'error') {
       status = this.buildStatusObject('error');
@@ -298,7 +298,15 @@ export class CommercialBankEthiopiaMockService {
 
   private getMissingFields(fields: Record<string, unknown>): string[] {
     return Object.entries(fields)
-      .filter(([, value]) => value === undefined || value === null)
+      .filter(
+        ([, value]) =>
+          value === undefined ||
+          value === null ||
+          value === 'undefined' || // The xml2js conversion does not replace null and undefined properly
+          value === 'null' || // The xml2js conversion does not replace null and undefined properly
+          value === '' ||
+          String(value).includes('${'), // This means the value in the template is not replaced
+      )
       .map(([key]) => key);
   }
 


### PR DESCRIPTION
[AB#37914](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37914) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

I made the mock-service of CBE a bit more scrict. It now returns an error if any of the dynamic values are missing. The idea behind this is that this seems a good ROI to increase our test coverage. As in this esnures that the output of our transfer call stays the same when we refactor our CBE related code

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
