### PR TITLE
chore: Remove unused Event-tracking via ApplicationInsights

### DIFF
--- a/interfaces/portal/package-lock.json
+++ b/interfaces/portal/package-lock.json
@@ -45,7 +45,6 @@
         "@angular/compiler-cli": "^20.2.3",
         "@angular/localize": "^20.2.3",
         "@azure/static-web-apps-cli": "^2.0.6",
-        "@microsoft/applicationinsights-debugplugin-js": "^3.3.9",
         "@prettier/plugin-xml": "^3.4.2",
         "@tailwindcss/postcss": "^4.1.12",
         "@tanstack/eslint-plugin-query": "^5.83.1",
@@ -4254,23 +4253,6 @@
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-async": ">= 0.5.4 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": ">= 1.0.0"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-debugplugin-js": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-debugplugin-js/-/applicationinsights-debugplugin-js-3.3.9.tgz",
-      "integrity": "sha512-n3yD+TpGZecU7pD9cOyyARIatazXJqnruSnSqWKSCUiIQ1qUxkmUqmG+uGQa4z1W60kWS8qMqJ5vpIsBrk1T6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/applicationinsights-common": "3.3.9",
-        "@microsoft/applicationinsights-core-js": "3.3.9",
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
       },
       "peerDependencies": {

--- a/interfaces/portal/package.json
+++ b/interfaces/portal/package.json
@@ -72,7 +72,6 @@
     "@angular/compiler-cli": "^20.2.3",
     "@angular/localize": "^20.2.3",
     "@azure/static-web-apps-cli": "^2.0.6",
-    "@microsoft/applicationinsights-debugplugin-js": "^3.3.9",
     "@prettier/plugin-xml": "^3.4.2",
     "@tailwindcss/postcss": "^4.1.12",
     "@tanstack/eslint-plugin-query": "^5.83.1",

--- a/interfaces/portal/src/app/app.component.ts
+++ b/interfaces/portal/src/app/app.component.ts
@@ -15,6 +15,7 @@ import { Subscription } from 'rxjs';
 
 import { AppRoutes } from '~/app.routes';
 import { AuthService } from '~/services/auth.service';
+import { LogService } from '~/services/log.service';
 import { RtlHelperService } from '~/services/rtl-helper.service';
 import { ToastService } from '~/services/toast.service';
 import { environment } from '~environment';
@@ -39,7 +40,11 @@ export class AppComponent implements OnInit, OnDestroy {
   readonly toastPosition = ('top-' +
     this.rtlHelper.createPosition('end')()) as ToastPositionType;
 
+  private readonly logService = inject(LogService);
+
   ngOnInit() {
+    this.logService.setupApplicationInsights();
+
     this.authSubscriptions = this.authService.initializeSubscriptions();
 
     if (!environment.production || isDevMode()) {

--- a/interfaces/portal/src/app/services/auth.service.ts
+++ b/interfaces/portal/src/app/services/auth.service.ts
@@ -7,7 +7,6 @@ import { AppRoutes } from '~/app.routes';
 import { IAuthStrategy } from '~/services/auth/auth-strategy.interface';
 import { BasicAuthStrategy } from '~/services/auth/strategies/basic-auth/basic-auth.strategy';
 import { MsalAuthStrategy } from '~/services/auth/strategies/msal-auth/msal-auth.strategy';
-import { LogEvent, LogService } from '~/services/log.service';
 import {
   getReturnUrlFromLocalStorage,
   getUserFromLocalStorage,
@@ -31,7 +30,6 @@ const VALID_PERMISSIONS = new Set(Object.values(PermissionEnum));
 export class AuthService {
   public static APP_PROVIDERS = AuthStrategy.APP_PROVIDERS;
 
-  private readonly logService = inject(LogService);
   private readonly injector = inject(Injector);
   private readonly router = inject(Router);
 
@@ -96,7 +94,6 @@ export class AuthService {
     credentials: { username: string; password?: string },
     returnUrl?: string,
   ) {
-    this.logService.logEvent(LogEvent.userLogin);
     if (returnUrl) {
       setReturnUrlInLocalStorage(returnUrl);
     }
@@ -108,8 +105,6 @@ export class AuthService {
   }
 
   public async logout(user?: LocalStorageUser | null) {
-    this.logService.logEvent(LogEvent.userLogout);
-
     try {
       await this.authStrategy.logout(user ?? this.user);
     } catch (error) {

--- a/interfaces/portal/src/app/services/log.service.ts
+++ b/interfaces/portal/src/app/services/log.service.ts
@@ -1,13 +1,7 @@
 import { Injectable } from '@angular/core';
 
-import { DebugPlugin } from '@microsoft/applicationinsights-debugplugin-js';
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 import { environment } from 'src/environments/environment';
-
-export enum LogEvent {
-  userLogin = 'user/login',
-  userLogout = 'user/logout',
-}
 
 @Injectable({
   providedIn: 'root',
@@ -16,36 +10,12 @@ export class LogService {
   private appInsights: ApplicationInsights;
   private appInsightsInitialized: boolean;
 
-  constructor() {
-    this.setupApplicationInsights();
-  }
-
-  private setupApplicationInsights() {
+  public setupApplicationInsights() {
     if (
       !environment.applicationinsights_connection_string ||
       this.appInsightsInitialized
     ) {
       return;
-    }
-
-    let debugPluginInstance;
-    let debugPluginConfig: Record<string, unknown> = {};
-
-    if (!environment.production) {
-      debugPluginInstance = new DebugPlugin();
-      debugPluginConfig = {
-        [DebugPlugin.identifier]: {
-          // See: https://github.com/microsoft/ApplicationInsights-JS/tree/main/extensions/applicationinsights-debugplugin-js#basic-usage
-          trackers: [
-            'trackDependencyData',
-            'trackEvent',
-            'trackException',
-            'trackMetric',
-            'trackPageView',
-            'trackTrace',
-          ],
-        },
-      };
     }
 
     this.appInsights = new ApplicationInsights({
@@ -56,18 +26,15 @@ export class LogService {
         autoTrackPageVisitTime: true,
         enableAutoRouteTracking: true,
         enableCorsCorrelation: true,
-        // enableDebug: !environment.production,
         enableRequestHeaderTracking: true,
         enableResponseHeaderTracking: true,
         enableAjaxErrorStatusText: true,
         enableSessionStorageBuffer: true,
         enableUnhandledPromiseRejectionTracking: true,
-        extensions: debugPluginInstance ? [debugPluginInstance] : [],
         loggingLevelConsole: 2,
         loggingLevelTelemetry: 2,
         extensionConfig: {
           ['AppInsightsCfgSyncPlugin']: { cfgUrl: '' },
-          ...debugPluginConfig,
         },
       },
     });
@@ -76,15 +43,8 @@ export class LogService {
     this.appInsightsInitialized = true;
   }
 
-  public logPageView(name?: string): void {
-    if (this.appInsightsInitialized) {
-      this.appInsights.trackPageView({ name });
-    }
-    console.info(`LOG: PageView: "${name ?? ''}"`);
-  }
-
   public logEvent(
-    name: LogEvent,
+    name: string,
     properties?: Record<string, boolean | number | string>,
   ): void {
     if (this.appInsightsInitialized) {


### PR DESCRIPTION
See [AB#37920](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37920)

## Describe your changes

As we won't be using ApplicationInsights for "User-intent/behavior event-tracking", we can get rid of some of the code especially for it.


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [X] Adding tests is unnecessary/irrelevant
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7223.westeurope.3.azurestaticapps.net
