### PR TITLE
feat: block export fsp instructions while in progress

### DIFF
--- a/interfaces/portal/src/app/components/page-layout-payment/components/import-reconciliation-data/import-reconciliation-data.component.html
+++ b/interfaces/portal/src/app/components/page-layout-payment/components/import-reconciliation-data/import-reconciliation-data.component.html
@@ -3,7 +3,6 @@
     label="Import reconciliation data"
     i18n-label
     (click)="importReconciliationData()"
-    [disabled]="paymentInProgress.isPending()"
     icon="pi pi-download"
     [iconPos]="rtlHelper.createPosition('start')()"
     outlined

--- a/interfaces/portal/src/app/components/page-layout-payment/components/import-reconciliation-data/import-reconciliation-data.component.ts
+++ b/interfaces/portal/src/app/components/page-layout-payment/components/import-reconciliation-data/import-reconciliation-data.component.ts
@@ -9,7 +9,6 @@ import {
 
 import {
   injectMutation,
-  injectQuery,
   QueryClient,
 } from '@tanstack/angular-query-experimental';
 import { ButtonModule } from 'primeng/button';
@@ -48,10 +47,6 @@ export class ImportReconciliationDataComponent {
   private toastService = inject(ToastService);
 
   readonly dialogVisible = model<boolean>(false);
-
-  paymentInProgress = injectQuery(
-    this.paymentApiService.getPaymentStatus(this.projectId),
-  );
 
   readonly canImportReconciliationData = computed(() =>
     this.authService.hasAllPermissions({
@@ -114,16 +109,8 @@ export class ImportReconciliationDataComponent {
       }
     },
   }));
-  importReconciliationData() {
-    if (this.paymentInProgress.data()?.inProgress) {
-      this.toastService.showToast({
-        severity: 'warn',
-        summary: $localize`Import not possible`,
-        detail: $localize`A payment is currently in progress. Please try again later`,
-      });
-      return;
-    }
 
+  importReconciliationData() {
     this.dialogVisible.set(true);
   }
 }

--- a/interfaces/portal/src/app/components/page-layout-payment/components/single-payment-export/single-payment-export.component.ts
+++ b/interfaces/portal/src/app/components/page-layout-payment/components/single-payment-export/single-payment-export.component.ts
@@ -7,10 +7,7 @@ import {
   viewChild,
 } from '@angular/core';
 
-import {
-  injectMutation,
-  injectQuery,
-} from '@tanstack/angular-query-experimental';
+import { injectMutation } from '@tanstack/angular-query-experimental';
 import { MenuItem } from 'primeng/api';
 
 import { ExportType } from '@121-service/src/metrics/enum/export-type.enum';
@@ -18,7 +15,6 @@ import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 
 import { ButtonMenuComponent } from '~/components/button-menu/button-menu.component';
 import { FormDialogComponent } from '~/components/form-dialog/form-dialog.component';
-import { PaymentApiService } from '~/domains/payment/payment.api.service';
 import { AuthService } from '~/services/auth.service';
 import { ExportService } from '~/services/export.service';
 import { ToastService } from '~/services/toast.service';
@@ -44,7 +40,6 @@ export class SinglePaymentExportComponent {
   private exportService = inject(ExportService);
   private toastService = inject(ToastService);
   private trackingService = inject(TrackingService);
-  private paymentApiService = inject(PaymentApiService);
 
   readonly exportFspPaymentListDialog = viewChild.required<FormDialogComponent>(
     'exportFspPaymentListDialog',
@@ -54,10 +49,6 @@ export class SinglePaymentExportComponent {
   );
 
   ExportType = ExportType;
-
-  paymentInProgress = injectQuery(
-    this.paymentApiService.getPaymentStatus(this.projectId),
-  );
 
   readonly fspPaymentListLabel = computed(
     () => $localize`:@@export-fsp-payment-list:Export FSP payment list`,
@@ -92,74 +83,50 @@ export class SinglePaymentExportComponent {
     }),
   );
 
-  readonly exportOptions = computed<MenuItem[]>(() => {
-    const paymentStatus = this.paymentInProgress.data();
-    const paymentInProgress = paymentStatus?.inProgress ?? false;
-
-    return [
-      {
-        label: this.fspPaymentListLabel(),
-        visible:
-          this.canExportPaymentInstructions() &&
-          this.hasExportFileIntegration(),
-        command: () => {
-          this.trackingService.trackEvent({
+  readonly exportOptions = computed<MenuItem[]>(() => [
+    {
+      label: this.fspPaymentListLabel(),
+      visible:
+        this.canExportPaymentInstructions() && this.hasExportFileIntegration(),
+      command: () => {
+        this.trackingService.trackEvent({
+          category: TrackingCategory.export,
+          action: TrackingAction.selectDropdownOption,
+          name: 'fsp-payment-list',
+        });
+        this.exportFspPaymentListDialog().show({
+          trackingEvent: {
             category: TrackingCategory.export,
-            action: TrackingAction.selectDropdownOption,
+            action: TrackingAction.clickProceedButton,
             name: 'fsp-payment-list',
-          });
-          if (this.handlePaymentInProgress(paymentInProgress)) {
-            return;
-          }
-          this.exportFspPaymentListDialog().show({
-            trackingEvent: {
-              category: TrackingCategory.export,
-              action: TrackingAction.clickProceedButton,
-              name: 'fsp-payment-list',
-            },
-          });
-        },
+          },
+        });
       },
-      {
-        label: this.paymentReportLabel(),
-        visible: this.authService.hasAllPermissions({
-          projectId: this.projectId(),
-          requiredPermissions: [
-            PermissionEnum.PaymentREAD,
-            PermissionEnum.PaymentTransactionREAD,
-            PermissionEnum.RegistrationPaymentExport,
-          ],
-        }),
-        command: () => {
-          this.trackingService.trackEvent({
+    },
+    {
+      label: this.paymentReportLabel(),
+      visible: this.authService.hasAllPermissions({
+        projectId: this.projectId(),
+        requiredPermissions: [
+          PermissionEnum.PaymentREAD,
+          PermissionEnum.PaymentTransactionREAD,
+          PermissionEnum.RegistrationPaymentExport,
+        ],
+      }),
+      command: () => {
+        this.trackingService.trackEvent({
+          category: TrackingCategory.export,
+          action: TrackingAction.selectDropdownOption,
+          name: 'payment-report',
+        });
+        this.paymentReportDialog().show({
+          trackingEvent: {
             category: TrackingCategory.export,
-            action: TrackingAction.selectDropdownOption,
+            action: TrackingAction.clickProceedButton,
             name: 'payment-report',
-          });
-          if (this.handlePaymentInProgress(paymentInProgress)) {
-            return;
-          }
-          this.paymentReportDialog().show({
-            trackingEvent: {
-              category: TrackingCategory.export,
-              action: TrackingAction.clickProceedButton,
-              name: 'payment-report',
-            },
-          });
-        },
+          },
+        });
       },
-    ];
-  });
-
-  handlePaymentInProgress(paymentInProgress: boolean): boolean {
-    if (paymentInProgress) {
-      this.toastService.showToast({
-        severity: 'warn',
-        summary: $localize`Export not possible`,
-        detail: $localize`A payment is currently in progress. Please try again later`,
-      });
-      return true;
-    }
-    return false;
-  }
+    },
+  ]);
 }

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -1141,14 +1141,8 @@
       <trans-unit id="495282157937447440" datatype="html">
         <source>Make sure to upload the correct file as this will override the current file.</source>
       </trans-unit>
-      <trans-unit id="5682129577475133431" datatype="html">
-        <source>Import not possible</source>
-      </trans-unit>
       <trans-unit id="581189508098722225" datatype="html">
         <source>Reconciliation data imported successfully.</source>
-      </trans-unit>
-      <trans-unit id="8705310124062464174" datatype="html">
-        <source>A payment is currently in progress. Please try again later</source>
       </trans-unit>
       <trans-unit id="2276030451798485888" datatype="html">
         <source>Amount of money successfully transferred.</source>
@@ -1723,9 +1717,6 @@
       </trans-unit>
       <trans-unit id="5918723526444903137" datatype="html">
         <source>Add user</source>
-      </trans-unit>
-      <trans-unit id="5982069520336655984" datatype="html">
-        <source>Export not possible</source>
       </trans-unit>
     </body>
   </file>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -1724,6 +1724,9 @@
       <trans-unit id="5918723526444903137" datatype="html">
         <source>Add user</source>
       </trans-unit>
+      <trans-unit id="5982069520336655984" datatype="html">
+        <source>Export not possible</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/services/121-service/module-dependencies.md
+++ b/services/121-service/module-dependencies.md
@@ -148,6 +148,7 @@ graph LR
   ExcelReconcilicationModule-->TransactionsModule
   ExcelReconcilicationModule-->ExcelModule
   ExcelReconcilicationModule-->RegistrationsModule
+  ExcelReconcilicationModule-->PaymentsModule
   SafaricomReconciliationModule-->SafaricomModule
   SafaricomReconciliationModule-->RedisModule
   SafaricomReconciliationModule-->TransactionsModule

--- a/services/121-service/src/payments/payments.controller.ts
+++ b/services/121-service/src/payments/payments.controller.ts
@@ -245,6 +245,10 @@ export class PaymentsController {
     description:
       'Get payments instructions for past payment to post in Fsp Portal - NOTE: this endpoint is scoped, depending on program configuration it only returns/modifies data the logged in user has access to.',
   })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'This endpoint cannot be used when a payment is in progress',
+  })
   @Get('programs/:programId/payments/:paymentId/fsp-instructions')
   public async getFspInstructions(
     @Param('programId', ParseIntPipe)

--- a/services/121-service/src/payments/payments.module.ts
+++ b/services/121-service/src/payments/payments.module.ts
@@ -70,6 +70,10 @@ import { createScopedRepositoryProvider } from '@121-service/src/utils/scope/cre
     createScopedRepositoryProvider(RegistrationAttributeDataEntity),
   ],
   controllers: [PaymentsController],
-  exports: [PaymentsExecutionService, PaymentsReportingService],
+  exports: [
+    PaymentsExecutionService,
+    PaymentsReportingService,
+    PaymentsProgressHelperService,
+  ],
 })
 export class PaymentsModule {}

--- a/services/121-service/src/payments/reconciliation/excel/excel-reconciliation.controller.ts
+++ b/services/121-service/src/payments/reconciliation/excel/excel-reconciliation.controller.ts
@@ -70,6 +70,10 @@ export class ExcelReconciliationController {
     description:
       'Uploaded payment excel reconciliation data - NOTE: this endpoint is scoped, depending on program configuration it only returns/modifies data the logged in user has access to.',
   })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'This endpoint cannot be used when a payment is in progress',
+  })
   @Post('programs/:programId/payments/:paymentId/excel-reconciliation')
   @ApiConsumes('multipart/form-data')
   @ApiBody(FILE_UPLOAD_API_FORMAT)

--- a/services/121-service/src/payments/reconciliation/excel/excel-reconciliation.module.ts
+++ b/services/121-service/src/payments/reconciliation/excel/excel-reconciliation.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ActionsModule } from '@121-service/src/actions/actions.module';
 import { ExcelModule } from '@121-service/src/payments/fsp-integration/excel/excel.module';
+import { PaymentsModule } from '@121-service/src/payments/payments.module';
 import { ExcelReconciliationController } from '@121-service/src/payments/reconciliation/excel/excel-reconciliation.controller';
 import { ExcelReconciliationService } from '@121-service/src/payments/reconciliation/excel/excel-reconciliation.service';
 import { TransactionsModule } from '@121-service/src/payments/transactions/transactions.module';
@@ -19,6 +20,7 @@ import { FileImportService } from '@121-service/src/utils/file-import/file-impor
     TransactionsModule,
     ExcelModule,
     RegistrationsModule,
+    PaymentsModule,
   ],
   providers: [ExcelReconciliationService, FileImportService],
   controllers: [ExcelReconciliationController],

--- a/services/121-service/src/payments/reconciliation/excel/excel-reconciliation.service.spec.ts
+++ b/services/121-service/src/payments/reconciliation/excel/excel-reconciliation.service.spec.ts
@@ -1,0 +1,202 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Equal, Repository } from 'typeorm';
+
+import { AdditionalActionType } from '@121-service/src/actions/action.entity';
+import { ActionsService } from '@121-service/src/actions/actions.service';
+import { Fsps } from '@121-service/src/fsps/enums/fsp-name.enum';
+import { ExcelService } from '@121-service/src/payments/fsp-integration/excel/excel.service';
+import { ExcelReconciliationService } from '@121-service/src/payments/reconciliation/excel/excel-reconciliation.service';
+import { PaymentsProgressHelperService } from '@121-service/src/payments/services/payments-progress.helper.service';
+import { TransactionsService } from '@121-service/src/payments/transactions/transactions.service';
+import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
+import { RegistrationViewScopedRepository } from '@121-service/src/registration/repositories/registration-view-scoped.repository';
+import { RegistrationsPaginationService } from '@121-service/src/registration/services/registrations-pagination.service';
+import { FileImportService } from '@121-service/src/utils/file-import/file-import.service';
+
+describe('ExcelReconciliationService', () => {
+  let service: ExcelReconciliationService;
+  let paymentsProgressHelperService: jest.Mocked<PaymentsProgressHelperService>;
+  let programRepository: jest.Mocked<Repository<ProgramEntity>>;
+  let actionsService: jest.Mocked<ActionsService>;
+  let transactionsService: jest.Mocked<TransactionsService>;
+  let excelService: jest.Mocked<ExcelService>;
+  let registrationsPaginationService: jest.Mocked<RegistrationsPaginationService>;
+  let fileImportService: jest.Mocked<FileImportService>;
+  let registrationViewScopedRepository: jest.Mocked<RegistrationViewScopedRepository>;
+
+  beforeEach(async () => {
+    const mockPaymentsProgressHelperService = {
+      isPaymentInProgress: jest.fn(),
+    };
+
+    const mockProgramRepository = {
+      findOneOrFail: jest.fn(),
+    };
+
+    const mockActionsService = {
+      saveAction: jest.fn(),
+    };
+
+    const mockTransactionsService = {
+      storeReconciliationTransactionsBulk: jest.fn(),
+      getLastTransactions: jest.fn(),
+    };
+
+    const mockExcelService = {
+      getImportMatchColumn: jest.fn(),
+      joinRegistrationsAndTransactions: jest.fn(),
+    };
+
+    const mockRegistrationsPaginationService = {
+      getRegistrationsChunked: jest.fn(),
+    };
+
+    const mockFileImportService = {
+      validateCsv: jest.fn(),
+    };
+
+    const mockRegistrationViewScopedRepository = {
+      getQueryBuilderForFspInstructions: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExcelReconciliationService,
+        {
+          provide: PaymentsProgressHelperService,
+          useValue: mockPaymentsProgressHelperService,
+        },
+        {
+          provide: getRepositoryToken(ProgramEntity),
+          useValue: mockProgramRepository,
+        },
+        {
+          provide: ActionsService,
+          useValue: mockActionsService,
+        },
+        {
+          provide: TransactionsService,
+          useValue: mockTransactionsService,
+        },
+        {
+          provide: ExcelService,
+          useValue: mockExcelService,
+        },
+        {
+          provide: RegistrationsPaginationService,
+          useValue: mockRegistrationsPaginationService,
+        },
+        {
+          provide: FileImportService,
+          useValue: mockFileImportService,
+        },
+        {
+          provide: RegistrationViewScopedRepository,
+          useValue: mockRegistrationViewScopedRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ExcelReconciliationService>(
+      ExcelReconciliationService,
+    );
+    paymentsProgressHelperService = module.get(PaymentsProgressHelperService);
+    programRepository = module.get(getRepositoryToken(ProgramEntity));
+    actionsService = module.get(ActionsService);
+    transactionsService = module.get(TransactionsService);
+    excelService = module.get(ExcelService);
+    registrationsPaginationService = module.get(RegistrationsPaginationService);
+    fileImportService = module.get(FileImportService);
+    registrationViewScopedRepository = module.get(
+      RegistrationViewScopedRepository,
+    );
+  });
+
+  describe('upsertFspReconciliationData', () => {
+    const mockFile = { buffer: Buffer.from('test') } as Express.Multer.File;
+    const programId = 1;
+    const paymentId = 2;
+    const userId = 3;
+
+    it('should throw HttpException when payment is in progress', async () => {
+      paymentsProgressHelperService.isPaymentInProgress.mockResolvedValue(true);
+
+      await expect(
+        service.upsertFspReconciliationData(
+          mockFile,
+          programId,
+          paymentId,
+          userId,
+        ),
+      ).rejects.toThrow(
+        new HttpException(
+          'Cannot import FSP reconciliation data while payment is in progress',
+          HttpStatus.BAD_REQUEST,
+        ),
+      );
+
+      expect(
+        paymentsProgressHelperService.isPaymentInProgress,
+      ).toHaveBeenCalledWith(programId);
+      expect(programRepository.findOneOrFail).not.toHaveBeenCalled();
+      expect(fileImportService.validateCsv).not.toHaveBeenCalled();
+      expect(
+        transactionsService.storeReconciliationTransactionsBulk,
+      ).not.toHaveBeenCalled();
+      expect(actionsService.saveAction).not.toHaveBeenCalled();
+    });
+
+    it('should proceed with reconciliation when payment is not in progress', async () => {
+      paymentsProgressHelperService.isPaymentInProgress.mockResolvedValue(
+        false,
+      );
+      programRepository.findOneOrFail.mockResolvedValue({
+        id: programId,
+        programFspConfigurations: [
+          {
+            id: 1,
+            fspName: Fsps.excel,
+            name: 'Test FSP',
+          },
+        ],
+      } as any);
+      fileImportService.validateCsv.mockResolvedValue([]);
+      excelService.getImportMatchColumn.mockResolvedValue('phoneNumber');
+      registrationViewScopedRepository.getQueryBuilderForFspInstructions.mockReturnValue(
+        {} as any,
+      );
+      registrationsPaginationService.getRegistrationsChunked.mockResolvedValue(
+        [],
+      );
+      transactionsService.getLastTransactions.mockResolvedValue([]);
+
+      const result = await service.upsertFspReconciliationData(
+        mockFile,
+        programId,
+        paymentId,
+        userId,
+      );
+
+      expect(
+        paymentsProgressHelperService.isPaymentInProgress,
+      ).toHaveBeenCalledWith(programId);
+      expect(programRepository.findOneOrFail).toHaveBeenCalledWith({
+        where: { id: Equal(programId) },
+        relations: ['programFspConfigurations'],
+      });
+      expect(fileImportService.validateCsv).toHaveBeenCalledWith(
+        mockFile,
+        10000,
+      );
+      expect(actionsService.saveAction).toHaveBeenCalledWith(
+        userId,
+        programId,
+        AdditionalActionType.importFspReconciliation,
+      );
+      expect(result).toHaveProperty('importResult');
+      expect(result).toHaveProperty('aggregateImportResult');
+    });
+  });
+});

--- a/services/121-service/src/payments/reconciliation/excel/excel-reconciliation.service.spec.ts
+++ b/services/121-service/src/payments/reconciliation/excel/excel-reconciliation.service.spec.ts
@@ -50,7 +50,7 @@ describe('ExcelReconciliationService', () => {
     };
 
     const mockRegistrationsPaginationService = {
-      getRegistrationsChunked: jest.fn(),
+      getRegistrationViewsChunkedByPaginateQuery: jest.fn(),
     };
 
     const mockFileImportService = {
@@ -167,7 +167,7 @@ describe('ExcelReconciliationService', () => {
       registrationViewScopedRepository.getQueryBuilderForFspInstructions.mockReturnValue(
         {} as any,
       );
-      registrationsPaginationService.getRegistrationsChunked.mockResolvedValue(
+      registrationsPaginationService.getRegistrationViewsChunkedByPaginateQuery.mockResolvedValue(
         [],
       );
       transactionsService.getLastTransactions.mockResolvedValue([]);

--- a/services/121-service/src/payments/services/payments-excel-fsp.service.spec.ts
+++ b/services/121-service/src/payments/services/payments-excel-fsp.service.spec.ts
@@ -88,11 +88,6 @@ describe('PaymentsExcelFspService', () => {
         ),
       );
 
-      expect(
-        paymentsProgressHelperService.isPaymentInProgress,
-      ).toHaveBeenCalledWith(programId);
-      expect(transactionsService.getLastTransactions).not.toHaveBeenCalled();
-      expect(programFspConfigurationRepository.find).not.toHaveBeenCalled();
       expect(actionsService.saveAction).not.toHaveBeenCalled();
     });
 
@@ -111,15 +106,6 @@ describe('PaymentsExcelFspService', () => {
           HttpStatus.NOT_FOUND,
         ),
       );
-
-      expect(
-        paymentsProgressHelperService.isPaymentInProgress,
-      ).toHaveBeenCalledWith(programId);
-      expect(transactionsService.getLastTransactions).toHaveBeenCalledWith({
-        programId,
-        paymentId,
-      });
-      expect(programFspConfigurationRepository.find).toHaveBeenCalled();
     });
   });
 });

--- a/services/121-service/src/payments/services/payments-excel-fsp.service.spec.ts
+++ b/services/121-service/src/payments/services/payments-excel-fsp.service.spec.ts
@@ -1,0 +1,125 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ActionsService } from '@121-service/src/actions/actions.service';
+import { ExcelService } from '@121-service/src/payments/fsp-integration/excel/excel.service';
+import { PaymentsExcelFspService } from '@121-service/src/payments/services/payments-excel-fsp.service';
+import { PaymentsProgressHelperService } from '@121-service/src/payments/services/payments-progress.helper.service';
+import { TransactionsService } from '@121-service/src/payments/transactions/transactions.service';
+import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';
+
+describe('PaymentsExcelFspService', () => {
+  let service: PaymentsExcelFspService;
+  let paymentsProgressHelperService: jest.Mocked<PaymentsProgressHelperService>;
+  let transactionsService: jest.Mocked<TransactionsService>;
+  let programFspConfigurationRepository: jest.Mocked<ProgramFspConfigurationRepository>;
+  let actionsService: jest.Mocked<ActionsService>;
+
+  beforeEach(async () => {
+    const mockPaymentsProgressHelperService = {
+      isPaymentInProgress: jest.fn(),
+    };
+
+    const mockTransactionsService = {
+      getLastTransactions: jest.fn(),
+    };
+
+    const mockProgramFspConfigurationRepository = {
+      find: jest.fn(),
+    };
+
+    const mockExcelService = {
+      getFspInstructions: jest.fn(),
+    };
+
+    const mockActionsService = {
+      saveAction: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentsExcelFspService,
+        {
+          provide: PaymentsProgressHelperService,
+          useValue: mockPaymentsProgressHelperService,
+        },
+        {
+          provide: TransactionsService,
+          useValue: mockTransactionsService,
+        },
+        {
+          provide: ProgramFspConfigurationRepository,
+          useValue: mockProgramFspConfigurationRepository,
+        },
+        {
+          provide: ExcelService,
+          useValue: mockExcelService,
+        },
+        {
+          provide: ActionsService,
+          useValue: mockActionsService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<PaymentsExcelFspService>(PaymentsExcelFspService);
+    paymentsProgressHelperService = module.get(PaymentsProgressHelperService);
+    transactionsService = module.get(TransactionsService);
+    programFspConfigurationRepository = module.get(
+      ProgramFspConfigurationRepository,
+    );
+    actionsService = module.get(ActionsService);
+  });
+
+  describe('getFspInstructions', () => {
+    const programId = 1;
+    const paymentId = 2;
+    const userId = 3;
+
+    it('should throw HttpException when payment is in progress', async () => {
+      paymentsProgressHelperService.isPaymentInProgress.mockResolvedValue(true);
+
+      await expect(
+        service.getFspInstructions(programId, paymentId, userId),
+      ).rejects.toThrow(
+        new HttpException(
+          'Cannot export FSP instructions while payment is in progress',
+          HttpStatus.BAD_REQUEST,
+        ),
+      );
+
+      expect(
+        paymentsProgressHelperService.isPaymentInProgress,
+      ).toHaveBeenCalledWith(programId);
+      expect(transactionsService.getLastTransactions).not.toHaveBeenCalled();
+      expect(programFspConfigurationRepository.find).not.toHaveBeenCalled();
+      expect(actionsService.saveAction).not.toHaveBeenCalled();
+    });
+
+    it('should proceed with FSP instructions when payment is not in progress', async () => {
+      paymentsProgressHelperService.isPaymentInProgress.mockResolvedValue(
+        false,
+      );
+      transactionsService.getLastTransactions.mockResolvedValue([]);
+      programFspConfigurationRepository.find.mockResolvedValue([]);
+
+      await expect(
+        service.getFspInstructions(programId, paymentId, userId),
+      ).rejects.toThrow(
+        new HttpException(
+          'No transactions found for this payment with FSPs that require to download payment instructions.',
+          HttpStatus.NOT_FOUND,
+        ),
+      );
+
+      expect(
+        paymentsProgressHelperService.isPaymentInProgress,
+      ).toHaveBeenCalledWith(programId);
+      expect(transactionsService.getLastTransactions).toHaveBeenCalledWith({
+        programId,
+        paymentId,
+      });
+      expect(programFspConfigurationRepository.find).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
[AB#37922](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37922)

## Describe your changes

- Now that payment with excel FSP is done via queue we don't await the initial storing of transactions any more like before.
- ~~To mitigate this, I block the 'export fsp instructions' while still in progress. I do this in the same way as was already done for import-reconciliation data.~~
- ~~It made sense to me to also block 'payment report' during this same time.~~
- After discussion, I changed this validation to back-end. The resulting back-end error is handled out of the box nicely in the front-end. 
- I removed the FE validation again and also the pre-existing one on import-reconciliation.
- I decided not to put any validation now on the 'export payment report', as it is in quite a different location in the BE. Also, this check prohibits when any payment is in progress, which is maybe too strict for this feature.
- FYI tested by setting the limiter in queue-registry temporarily low.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7233.westeurope.3.azurestaticapps.net
