### PR TITLE
test: API-test if voucher messages are tied to transactions

### DIFF
--- a/services/121-service/src/activities/activities.mapper.ts
+++ b/services/121-service/src/activities/activities.mapper.ts
@@ -152,6 +152,7 @@ export class ActivitiesMapper {
         contentType: message.contentType,
         errorCode: message.errorCode,
         notificationType: message.type,
+        transactionId: message.transactionId ?? undefined,
       },
     }));
   }

--- a/services/121-service/src/activities/interfaces/message-activity.interface.ts
+++ b/services/121-service/src/activities/interfaces/message-activity.interface.ts
@@ -15,5 +15,6 @@ export interface MessageActivity extends BaseActivity {
     contentType: MessageContentType;
     errorCode: string | null;
     notificationType: NotificationType;
+    transactionId?: number | null;
   };
 }

--- a/services/121-service/src/notifications/twilio-message.repository.ts
+++ b/services/121-service/src/notifications/twilio-message.repository.ts
@@ -81,6 +81,7 @@ export class TwilioMessageScopedRepository extends ScopedRepository<TwilioMessag
         mediaUrl: true,
         contentType: true,
         errorCode: true,
+        transactionId: true,
       },
     });
 

--- a/services/121-service/test/payment/__snapshots__/do-payment-fsp-voucher.test.ts.snap
+++ b/services/121-service/test/payment/__snapshots__/do-payment-fsp-voucher.test.ts.snap
@@ -1,4 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`Do payment to 1 PA with FSP: Intersolve Voucher WhatsApp should fail pay-out due to invalid phone number 1`] = `"Magic fail (ErrorCode: 1)"`;
 
 exports[`Do payment to 1 PA with FSP: Intersolve Voucher WhatsApp should succesfully pay-out 1`] = `
@@ -44,6 +45,7 @@ Do you have questions? Send us a message on WhatsApp: https://wa.me/319701028696
       "notificationType": "whatsapp",
       "status": "read",
       "to": "whatsapp:+14155238886",
+      "transactionId": 2,
     },
     "id": "message1",
     "type": "message",
@@ -68,6 +70,7 @@ Please reply “yes” to this message in order to receive:
       "notificationType": "whatsapp",
       "status": "read",
       "to": "whatsapp:+14155238886",
+      "transactionId": 1,
     },
     "id": "message2",
     "type": "message",

--- a/services/121-service/test/payment/do-payment-fsp-voucher.test.ts
+++ b/services/121-service/test/payment/do-payment-fsp-voucher.test.ts
@@ -1,6 +1,7 @@
 import { HttpStatus } from '@nestjs/common';
 
 import { Fsps } from '@121-service/src/fsps/enums/fsp-name.enum';
+import { MessageContentType } from '@121-service/src/notifications/enum/message-type.enum';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { LanguageEnum } from '@121-service/src/shared/enum/language.enums';
@@ -113,7 +114,7 @@ describe('Do payment to 1 PA', () => {
         const createdDate = new Date(message.created);
         expect(createdDate.toString()).not.toBe('Invalid Date');
 
-        // Remove the "created" and "from" fields from the messages
+        // Remove the "created" field from the messages
         // @ts-expect-error don't care about deleting non-optional properties
         delete message.created;
 
@@ -125,6 +126,18 @@ describe('Do payment to 1 PA', () => {
           message.attributes.mediaUrl = mediaUrlPath + 'imageCode/secret';
         }
       });
+
+      // Assert that both initial and voucher message are tied to a transaction
+      const initialMessage = messages.find(
+        (msg) =>
+          msg.attributes.contentType === MessageContentType.paymentTemplated,
+      );
+      expect(initialMessage?.attributes.transactionId).not.toBeNull();
+      const voucherMessage = messages.find(
+        (msg) =>
+          msg.attributes.contentType === MessageContentType.paymentTemplated,
+      );
+      expect(voucherMessage?.attributes.transactionId).not.toBeNull();
 
       // Assert the modified messages against the snapshot
       expect(messages).toMatchSnapshot();


### PR DESCRIPTION
AB#38007

## Describe your changes

Add assertion on voucher messages being tied to transactions in do-payment-fsp-voucher api test.

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
