### PR TITLE
chore: e2e 12 shards

### DIFF
--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -53,8 +53,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ['1', '2', '3', '4', '5', '6']
-        shardCount: ['6']
+        shard: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']
+        shardCount: ['12']
 
     steps:
       - name: Check out repository code


### PR DESCRIPTION
[AB#38060](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38060)

## Describe your changes

- Increase e2e shards from 6 to 12 to speed up overall time, from ~8 to (hopefully) ~6 minutes.
- Hmm somehow for all shards the nr of tests nicely went down by half. Only shard 7 kept 27 tests (all from one spec file, that's probably why), while shard 8 had 0 tests. Then again, this shard finished relatively early in 5 minutes.
- Overall the last test to finish took 7 minutes, vs 9 minutes before, so I still think it's an improvement.

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
