### PR TITLE
fix: Make checks around (error-)status/response-codes easier to read, less error-prone = less (unnecessary) noise in the logs

### DIFF
--- a/services/121-service/src/notifications/dto/twilio.dto.ts
+++ b/services/121-service/src/notifications/dto/twilio.dto.ts
@@ -4,6 +4,9 @@ import { IsOptional, IsString } from 'class-validator';
 import { env } from '@121-service/src/env';
 import { formatWhatsAppNumber } from '@121-service/src/utils/phone-number.helpers';
 
+/**
+ * @link mock-service/src/twilio/twilio.dto.ts - Duplicate hard-copy as we cannot share enums between services yet.
+ */
 export enum TwilioStatus {
   delivered = 'delivered',
   read = 'read',
@@ -13,6 +16,7 @@ export enum TwilioStatus {
   sent = 'sent',
   failed = 'failed',
 }
+
 export class TwilioStatusCallbackDto {
   @ApiProperty({ example: 'SMb677b6846ec347cf80b8a5fd948efb53' })
   @IsString()

--- a/services/121-service/src/notifications/enum/twilio-error-codes.enum.ts
+++ b/services/121-service/src/notifications/enum/twilio-error-codes.enum.ts
@@ -5,6 +5,7 @@
  * Used to handle specific errors from Twilio's API responses.
  *
  * @see https://www.twilio.com/docs/api/errors
+ * @link mock-service/src/twilio/twilio.service.ts - Duplicate hard-copy as we cannot share enums between services yet.
  */
 export const enum TwilioErrorCodes {
   toNumberDoesNotExist = '21211',

--- a/services/121-service/src/notifications/enum/twilio-error-codes.enum.ts
+++ b/services/121-service/src/notifications/enum/twilio-error-codes.enum.ts
@@ -1,7 +1,11 @@
-// Enum for Twilio error codes
-// This enumm contains only error codes that are relevant to the 121 service
-// It is used to handle specific errors from Twilio's API responses
-// Reference: https://www.twilio.com/docs/api/errors
+/**
+ * Twilio error codes
+ *
+ * Only error codes that are relevant to the 121 service.
+ * Used to handle specific errors from Twilio's API responses.
+ *
+ * @see https://www.twilio.com/docs/api/errors
+ */
 export enum TwilioErrorCodes {
   toNumberDoesNotExist = 21211,
   mediaUrlInvalid = 63021,

--- a/services/121-service/src/notifications/enum/twilio-error-codes.enum.ts
+++ b/services/121-service/src/notifications/enum/twilio-error-codes.enum.ts
@@ -6,9 +6,9 @@
  *
  * @see https://www.twilio.com/docs/api/errors
  */
-export enum TwilioErrorCodes {
-  toNumberDoesNotExist = 21211,
-  mediaUrlInvalid = 63021,
-  failedFreeFormMessage = 63016,
-  channelCouldNotFindToAddress = 63003,
+export const enum TwilioErrorCodes {
+  toNumberDoesNotExist = '21211',
+  mediaUrlInvalid = '63021',
+  failedFreeFormMessage = '63016',
+  channelCouldNotFindToAddress = '63003',
 }

--- a/services/121-service/src/notifications/message-incoming/message-incoming.service.ts
+++ b/services/121-service/src/notifications/message-incoming/message-incoming.service.ts
@@ -37,6 +37,7 @@ import { DefaultRegistrationDataAttributeNames } from '@121-service/src/registra
 import { RegistrationDataService } from '@121-service/src/registration/modules/registration-data/registration-data.service';
 import { LanguageEnum } from '@121-service/src/shared/enum/language.enums';
 import { UserEntity } from '@121-service/src/user/entities/user.entity';
+import { isSameStatus } from '@121-service/src/utils/comparison.helper';
 import { maskValueKeepEnd } from '@121-service/src/utils/mask-value.helper';
 import { waitFor } from '@121-service/src/utils/waitFor.helper';
 
@@ -159,7 +160,10 @@ export class MessageIncomingService {
 
     // if we get a faulty 63016 we retry sending a message, and we don't need to update the status
     if (
-      callbackData.ErrorCode === `${TwilioErrorCodes.failedFreeFormMessage}` &&
+      isSameStatus(
+        callbackData.ErrorCode,
+        TwilioErrorCodes.failedFreeFormMessage,
+      ) &&
       [TwilioStatus.undelivered, TwilioStatus.failed].includes(
         callbackData.MessageStatus,
       )
@@ -273,9 +277,11 @@ export class MessageIncomingService {
       );
     }
     if (
-      callbackData.MessageStatus === TwilioStatus.failed &&
-      callbackData.ErrorCode ===
-        `${TwilioErrorCodes.channelCouldNotFindToAddress}`
+      isSameStatus(callbackData.MessageStatus, TwilioStatus.failed) &&
+      isSameStatus(
+        callbackData.ErrorCode,
+        TwilioErrorCodes.channelCouldNotFindToAddress,
+      )
     ) {
       // PA does not have whatsapp
       // Send pending message via sms

--- a/services/121-service/src/notifications/message-incoming/message-incoming.service.ts
+++ b/services/121-service/src/notifications/message-incoming/message-incoming.service.ts
@@ -37,7 +37,7 @@ import { DefaultRegistrationDataAttributeNames } from '@121-service/src/registra
 import { RegistrationDataService } from '@121-service/src/registration/modules/registration-data/registration-data.service';
 import { LanguageEnum } from '@121-service/src/shared/enum/language.enums';
 import { UserEntity } from '@121-service/src/user/entities/user.entity';
-import { isSameStatus } from '@121-service/src/utils/comparison.helper';
+import { isSameAsString } from '@121-service/src/utils/comparison.helper';
 import { maskValueKeepEnd } from '@121-service/src/utils/mask-value.helper';
 import { waitFor } from '@121-service/src/utils/waitFor.helper';
 
@@ -160,7 +160,7 @@ export class MessageIncomingService {
 
     // if we get a faulty 63016 we retry sending a message, and we don't need to update the status
     if (
-      isSameStatus(
+      isSameAsString(
         callbackData.ErrorCode,
         TwilioErrorCodes.failedFreeFormMessage,
       ) &&
@@ -277,8 +277,8 @@ export class MessageIncomingService {
       );
     }
     if (
-      isSameStatus(callbackData.MessageStatus, TwilioStatus.failed) &&
-      isSameStatus(
+      isSameAsString(callbackData.MessageStatus, TwilioStatus.failed) &&
+      isSameAsString(
         callbackData.ErrorCode,
         TwilioErrorCodes.channelCouldNotFindToAddress,
       )

--- a/services/121-service/src/notifications/sms/sms.service.ts
+++ b/services/121-service/src/notifications/sms/sms.service.ts
@@ -53,7 +53,6 @@ export class SmsService {
         messageProcessType,
       });
     } catch (error) {
-      console.log('Error from Twilio:', error);
       await this.storeSendSms({
         message: {
           accountSid: env.TWILIO_SID,

--- a/services/121-service/src/notifications/sms/sms.service.ts
+++ b/services/121-service/src/notifications/sms/sms.service.ts
@@ -15,7 +15,7 @@ import { MessageContentType } from '@121-service/src/notifications/enum/message-
 import { TwilioErrorCodes } from '@121-service/src/notifications/enum/twilio-error-codes.enum';
 import { LastMessageStatusService } from '@121-service/src/notifications/services/last-message-status.service';
 import { twilioClient } from '@121-service/src/notifications/twilio.client';
-import { isSameStatus } from '@121-service/src/utils/comparison.helper';
+import { isSameAsString } from '@121-service/src/utils/comparison.helper';
 import { formatPhoneNumber } from '@121-service/src/utils/phone-number.helpers';
 
 @Injectable()
@@ -70,7 +70,7 @@ export class SmsService {
         messageContentType,
         messageProcessType,
       });
-      if (isSameStatus(error.code, TwilioErrorCodes.toNumberDoesNotExist)) {
+      if (isSameAsString(error.code, TwilioErrorCodes.toNumberDoesNotExist)) {
         console.log(
           `SMS not sent to "${to}". Error: ${error.message}. Twilio-Error code: ${error.code}`,
         );

--- a/services/121-service/src/notifications/sms/sms.service.ts
+++ b/services/121-service/src/notifications/sms/sms.service.ts
@@ -15,6 +15,7 @@ import { MessageContentType } from '@121-service/src/notifications/enum/message-
 import { TwilioErrorCodes } from '@121-service/src/notifications/enum/twilio-error-codes.enum';
 import { LastMessageStatusService } from '@121-service/src/notifications/services/last-message-status.service';
 import { twilioClient } from '@121-service/src/notifications/twilio.client';
+import { isSameStatus } from '@121-service/src/utils/comparison.helper';
 import { formatPhoneNumber } from '@121-service/src/utils/phone-number.helpers';
 
 @Injectable()
@@ -70,12 +71,12 @@ export class SmsService {
         messageContentType,
         messageProcessType,
       });
-      if (error.code !== TwilioErrorCodes.toNumberDoesNotExist) {
-        throw error;
-      } else {
+      if (isSameStatus(error.code, TwilioErrorCodes.toNumberDoesNotExist)) {
         console.log(
-          `SMS not sent to ${to}. Error: ${error.message}. Error code: ${error.code}`,
+          `SMS not sent to "${to}". Error: ${error.message}. Twilio-Error code: ${error.code}`,
         );
+      } else {
+        throw error;
       }
     }
   }

--- a/services/121-service/src/notifications/whatsapp/whatsapp.service.ts
+++ b/services/121-service/src/notifications/whatsapp/whatsapp.service.ts
@@ -23,7 +23,7 @@ import { LastMessageStatusService } from '@121-service/src/notifications/service
 import { twilioClient } from '@121-service/src/notifications/twilio.client';
 import { WhatsappTemplateTestEntity } from '@121-service/src/notifications/whatsapp/whatsapp-template-test.entity';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
-import { isSameStatus } from '@121-service/src/utils/comparison.helper';
+import { isSameAsString } from '@121-service/src/utils/comparison.helper';
 import { formatWhatsAppNumber } from '@121-service/src/utils/phone-number.helpers';
 
 @Injectable()
@@ -113,7 +113,7 @@ export class WhatsappService {
       return messageToStore.sid;
     } catch (error) {
       if (
-        isSameStatus(error.code, TwilioErrorCodes.mediaUrlInvalid) &&
+        isSameAsString(error.code, TwilioErrorCodes.mediaUrlInvalid) &&
         mediaUrl &&
         firstAttempt
       ) {
@@ -153,7 +153,7 @@ export class WhatsappService {
         messageProcessType,
         existingSidToUpdateDueToFailure: existingSidToUpdate,
       });
-      if (isSameStatus(error.code, TwilioErrorCodes.toNumberDoesNotExist)) {
+      if (isSameAsString(error.code, TwilioErrorCodes.toNumberDoesNotExist)) {
         console.log(
           `WhatsApp message not sent to: "${payload.to}". Error: ${error.message}. Twilio-Error code: ${error.code}`,
         );

--- a/services/121-service/src/notifications/whatsapp/whatsapp.service.ts
+++ b/services/121-service/src/notifications/whatsapp/whatsapp.service.ts
@@ -119,7 +119,7 @@ export class WhatsappService {
       ) {
         firstAttempt = false;
         // Retry once due to Twilio bug (error 63021) that randomly occurs when sending messages with mediaUrl
-        // Reference: backlog item 34346
+        // Reference: backlog item AB#34346
         return this.sendWhatsapp({
           message,
           contentSid,

--- a/services/121-service/src/notifications/whatsapp/whatsapp.service.ts
+++ b/services/121-service/src/notifications/whatsapp/whatsapp.service.ts
@@ -23,6 +23,7 @@ import { LastMessageStatusService } from '@121-service/src/notifications/service
 import { twilioClient } from '@121-service/src/notifications/twilio.client';
 import { WhatsappTemplateTestEntity } from '@121-service/src/notifications/whatsapp/whatsapp-template-test.entity';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
+import { isSameStatus } from '@121-service/src/utils/comparison.helper';
 import { formatWhatsAppNumber } from '@121-service/src/utils/phone-number.helpers';
 
 @Injectable()
@@ -112,7 +113,7 @@ export class WhatsappService {
       return messageToStore.sid;
     } catch (error) {
       if (
-        error.code == TwilioErrorCodes.mediaUrlInvalid &&
+        isSameStatus(error.code, TwilioErrorCodes.mediaUrlInvalid) &&
         mediaUrl &&
         firstAttempt
       ) {
@@ -152,12 +153,12 @@ export class WhatsappService {
         messageProcessType,
         existingSidToUpdateDueToFailure: existingSidToUpdate,
       });
-      if (error.code !== TwilioErrorCodes.toNumberDoesNotExist) {
-        throw error;
-      } else {
+      if (isSameStatus(error.code, TwilioErrorCodes.toNumberDoesNotExist)) {
         console.log(
-          `WhatsApp message not sent to ${payload.to}. Error: ${error.message}. Error code: ${error.code}`,
+          `WhatsApp message not sent to: "${payload.to}". Error: ${error.message}. Twilio-Error code: ${error.code}`,
         );
+      } else {
+        throw error;
       }
     }
   }

--- a/services/121-service/src/payments/transactions/repositories/latest-transaction.repository.ts
+++ b/services/121-service/src/payments/transactions/repositories/latest-transaction.repository.ts
@@ -4,6 +4,7 @@ import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity
 
 import { LatestTransactionEntity } from '@121-service/src/payments/transactions/latest-transaction.entity';
 import { TransactionEntity } from '@121-service/src/payments/transactions/transaction.entity';
+import { isSameStatus } from '@121-service/src/utils/comparison.helper';
 
 export class LatestTransactionRepository extends Repository<LatestTransactionEntity> {
   constructor(
@@ -29,8 +30,12 @@ export class LatestTransactionRepository extends Repository<LatestTransactionEnt
       // Try to insert a new LatestTransactionEntity
       await this.baseRepository.insert(latestTransaction);
     } catch (error) {
-      if (error.code === '23505') {
-        // 23505 is the code for unique violation in PostgreSQL
+      if (
+        isSameStatus(
+          error.code,
+          '23505', // 23505 is the error code for unique_violation (see: https://www.postgresql.org/docs/current/errcodes-appendix.html)
+        )
+      ) {
         // If a unique constraint violation occurred, update the existing LatestTransactionEntity
         await this.baseRepository.update(
           {

--- a/services/121-service/src/payments/transactions/repositories/latest-transaction.repository.ts
+++ b/services/121-service/src/payments/transactions/repositories/latest-transaction.repository.ts
@@ -4,7 +4,7 @@ import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity
 
 import { LatestTransactionEntity } from '@121-service/src/payments/transactions/latest-transaction.entity';
 import { TransactionEntity } from '@121-service/src/payments/transactions/transaction.entity';
-import { isSameStatus } from '@121-service/src/utils/comparison.helper';
+import { isSameAsString } from '@121-service/src/utils/comparison.helper';
 
 export class LatestTransactionRepository extends Repository<LatestTransactionEntity> {
   constructor(
@@ -31,7 +31,7 @@ export class LatestTransactionRepository extends Repository<LatestTransactionEnt
       await this.baseRepository.insert(latestTransaction);
     } catch (error) {
       if (
-        isSameStatus(
+        isSameAsString(
           error.code,
           '23505', // 23505 is the error code for unique_violation (see: https://www.postgresql.org/docs/current/errcodes-appendix.html)
         )

--- a/services/121-service/src/payments/transactions/repositories/latest-transaction.repository.ts
+++ b/services/121-service/src/payments/transactions/repositories/latest-transaction.repository.ts
@@ -4,6 +4,7 @@ import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity
 
 import { LatestTransactionEntity } from '@121-service/src/payments/transactions/latest-transaction.entity';
 import { TransactionEntity } from '@121-service/src/payments/transactions/transaction.entity';
+import { PostgresStatusCodes } from '@121-service/src/shared/enum/postgres-status-codes.enum';
 import { isSameAsString } from '@121-service/src/utils/comparison.helper';
 
 export class LatestTransactionRepository extends Repository<LatestTransactionEntity> {
@@ -30,12 +31,7 @@ export class LatestTransactionRepository extends Repository<LatestTransactionEnt
       // Try to insert a new LatestTransactionEntity
       await this.baseRepository.insert(latestTransaction);
     } catch (error) {
-      if (
-        isSameAsString(
-          error.code,
-          '23505', // 23505 is the error code for unique_violation (see: https://www.postgresql.org/docs/current/errcodes-appendix.html)
-        )
-      ) {
+      if (isSameAsString(error.code, PostgresStatusCodes.UNIQUE_VIOLATION)) {
         // If a unique constraint violation occurred, update the existing LatestTransactionEntity
         await this.baseRepository.update(
           {

--- a/services/121-service/src/payments/transactions/transactions.service.ts
+++ b/services/121-service/src/payments/transactions/transactions.service.ts
@@ -13,6 +13,7 @@ import { LatestTransactionEntity } from '@121-service/src/payments/transactions/
 import { TransactionEntity } from '@121-service/src/payments/transactions/transaction.entity';
 import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { RegistrationScopedRepository } from '@121-service/src/registration/repositories/registration-scoped.repository';
+import { isSameStatus } from '@121-service/src/utils/comparison.helper';
 @Injectable()
 export class TransactionsService {
   @InjectRepository(LatestTransactionEntity)
@@ -102,8 +103,12 @@ export class TransactionsService {
       // Try to insert a new LatestTransactionEntity
       await this.latestTransactionRepository.insert(latestTransaction);
     } catch (error) {
-      if (error.code === '23505') {
-        // 23505 is the code for unique violation in PostgreSQL
+      if (
+        isSameStatus(
+          error.code,
+          '23505', // 23505 is the error code for unique_violation (see: https://www.postgresql.org/docs/current/errcodes-appendix.html)
+        )
+      ) {
         // If a unique constraint violation occurred, update the existing LatestTransactionEntity
         await this.latestTransactionRepository.update(
           {

--- a/services/121-service/src/payments/transactions/transactions.service.ts
+++ b/services/121-service/src/payments/transactions/transactions.service.ts
@@ -13,6 +13,7 @@ import { LatestTransactionEntity } from '@121-service/src/payments/transactions/
 import { TransactionEntity } from '@121-service/src/payments/transactions/transaction.entity';
 import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { RegistrationScopedRepository } from '@121-service/src/registration/repositories/registration-scoped.repository';
+import { PostgresStatusCodes } from '@121-service/src/shared/enum/postgres-status-codes.enum';
 import { isSameAsString } from '@121-service/src/utils/comparison.helper';
 @Injectable()
 export class TransactionsService {
@@ -103,12 +104,7 @@ export class TransactionsService {
       // Try to insert a new LatestTransactionEntity
       await this.latestTransactionRepository.insert(latestTransaction);
     } catch (error) {
-      if (
-        isSameAsString(
-          error.code,
-          '23505', // 23505 is the error code for unique_violation (see: https://www.postgresql.org/docs/current/errcodes-appendix.html)
-        )
-      ) {
+      if (isSameAsString(error.code, PostgresStatusCodes.UNIQUE_VIOLATION)) {
         // If a unique constraint violation occurred, update the existing LatestTransactionEntity
         await this.latestTransactionRepository.update(
           {

--- a/services/121-service/src/payments/transactions/transactions.service.ts
+++ b/services/121-service/src/payments/transactions/transactions.service.ts
@@ -13,7 +13,7 @@ import { LatestTransactionEntity } from '@121-service/src/payments/transactions/
 import { TransactionEntity } from '@121-service/src/payments/transactions/transaction.entity';
 import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
 import { RegistrationScopedRepository } from '@121-service/src/registration/repositories/registration-scoped.repository';
-import { isSameStatus } from '@121-service/src/utils/comparison.helper';
+import { isSameAsString } from '@121-service/src/utils/comparison.helper';
 @Injectable()
 export class TransactionsService {
   @InjectRepository(LatestTransactionEntity)
@@ -104,7 +104,7 @@ export class TransactionsService {
       await this.latestTransactionRepository.insert(latestTransaction);
     } catch (error) {
       if (
-        isSameStatus(
+        isSameAsString(
           error.code,
           '23505', // 23505 is the error code for unique_violation (see: https://www.postgresql.org/docs/current/errcodes-appendix.html)
         )

--- a/services/121-service/src/registration/modules/registration-utilts/registration-utils.service.ts
+++ b/services/121-service/src/registration/modules/registration-utilts/registration-utils.service.ts
@@ -47,7 +47,7 @@ export class RegistrationUtilsService {
           '23505', // '23505' is the error code for unique_violation (see: https://www.postgresql.org/docs/current/errcodes-appendix.html)
         ];
         if (
-          errorCodesThatShouldBeRetried.includes(error['code']) &&
+          errorCodesThatShouldBeRetried.includes(String(error['code'])) &&
           saveRetriesCount < 3
         ) {
           saveRetriesCount++;

--- a/services/121-service/src/registration/modules/registration-utilts/registration-utils.service.ts
+++ b/services/121-service/src/registration/modules/registration-utilts/registration-utils.service.ts
@@ -6,6 +6,7 @@ import { ProgramEntity } from '@121-service/src/programs/entities/program.entity
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { RegistrationDataService } from '@121-service/src/registration/modules/registration-data/registration-data.service';
 import { RegistrationScopedRepository } from '@121-service/src/registration/repositories/registration-scoped.repository';
+import { PostgresStatusCodes } from '@121-service/src/shared/enum/postgres-status-codes.enum';
 
 @Injectable()
 export class RegistrationUtilsService {
@@ -43,8 +44,8 @@ export class RegistrationUtilsService {
     } catch (error) {
       if (error instanceof QueryFailedError) {
         const errorCodesThatShouldBeRetried = [
-          '23502', // This is the error code for not null violation (see: https://www.postgresql.org/docs/current/errcodes-appendix.html)
-          '23505', // '23505' is the error code for unique_violation (see: https://www.postgresql.org/docs/current/errcodes-appendix.html)
+          PostgresStatusCodes.NOT_NULL_VIOLATION,
+          PostgresStatusCodes.UNIQUE_VIOLATION,
         ];
         if (
           errorCodesThatShouldBeRetried.includes(String(error['code'])) &&

--- a/services/121-service/src/registration/modules/registration-utilts/registration-utils.service.ts
+++ b/services/121-service/src/registration/modules/registration-utilts/registration-utils.service.ts
@@ -43,12 +43,13 @@ export class RegistrationUtilsService {
       return await this.registrationScopedRepository.save(registration);
     } catch (error) {
       if (error instanceof QueryFailedError) {
-        const errorCodesThatShouldBeRetried = [
+        const errorCodesThatShouldBeRetried: string[] = [
           PostgresStatusCodes.NOT_NULL_VIOLATION,
           PostgresStatusCodes.UNIQUE_VIOLATION,
         ];
         if (
-          errorCodesThatShouldBeRetried.includes(String(error['code'])) &&
+          'code' in error &&
+          errorCodesThatShouldBeRetried.includes(String(error.code)) &&
           saveRetriesCount < 3
         ) {
           saveRetriesCount++;

--- a/services/121-service/src/registration/modules/registration-utilts/registration-utils.service.ts
+++ b/services/121-service/src/registration/modules/registration-utilts/registration-utils.service.ts
@@ -44,7 +44,7 @@ export class RegistrationUtilsService {
       if (error instanceof QueryFailedError) {
         const errorCodesThatShouldBeRetried = [
           '23502', // This is the error code for not null violation (see: https://www.postgresql.org/docs/current/errcodes-appendix.html)
-          '23505', // This is the error code for unique_violation (see: https://www.postgresql.org/docs/current/errcodes-appendix.html)
+          '23505', // '23505' is the error code for unique_violation (see: https://www.postgresql.org/docs/current/errcodes-appendix.html)
         ];
         if (
           errorCodesThatShouldBeRetried.includes(error['code']) &&

--- a/services/121-service/src/shared/enum/postgres-status-codes.enum.ts
+++ b/services/121-service/src/shared/enum/postgres-status-codes.enum.ts
@@ -3,7 +3,7 @@
  *
  * @see https://www.postgresql.org/docs/current/errcodes-appendix.html
  */
-export enum PostgresStatusCodes {
+export const enum PostgresStatusCodes {
   FOREIGN_KEY_VIOLATION = '23503',
   NOT_NULL_VIOLATION = '23502',
   UNIQUE_VIOLATION = '23505',

--- a/services/121-service/src/shared/enum/postgres-status-codes.enum.ts
+++ b/services/121-service/src/shared/enum/postgres-status-codes.enum.ts
@@ -1,0 +1,10 @@
+/**
+ * PostgreSQL status codes
+ *
+ * @see https://www.postgresql.org/docs/current/errcodes-appendix.html
+ */
+export enum PostgresStatusCodes {
+  FOREIGN_KEY_VIOLATION = '23503',
+  NOT_NULL_VIOLATION = '23502',
+  UNIQUE_VIOLATION = '23505',
+}

--- a/services/121-service/src/user/user.service.ts
+++ b/services/121-service/src/user/user.service.ts
@@ -15,6 +15,7 @@ import { ProgramEntity } from '@121-service/src/programs/entities/program.entity
 import { ProgramAidworkerAssignmentEntity } from '@121-service/src/programs/entities/program-aidworker.entity';
 import { CookieNames } from '@121-service/src/shared/enum/cookie.enums';
 import { InterfaceNames } from '@121-service/src/shared/enum/interface-names.enum';
+import { PostgresStatusCodes } from '@121-service/src/shared/enum/postgres-status-codes.enum';
 import {
   CreateProgramAssignmentDto,
   UpdateProgramAssignmentDto,
@@ -43,6 +44,7 @@ import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 import { DefaultUserRole } from '@121-service/src/user/enum/user-role.enum';
 import { UserType } from '@121-service/src/user/enum/user-type-enum';
 import { UserData, UserRO } from '@121-service/src/user/user.interface';
+import { isSameAsString } from '@121-service/src/utils/comparison.helper';
 const tokenExpirationDays = 14;
 
 @Injectable({ scope: Scope.REQUEST })
@@ -497,7 +499,7 @@ export class UserService {
     try {
       return await this.userRepository.remove(user);
     } catch (e) {
-      if (e.code === '23503') {
+      if (isSameAsString(e.code, PostgresStatusCodes.FOREIGN_KEY_VIOLATION)) {
         throw new HttpException(
           'User cannot be removed because it is related to other entities for logging purposes',
           HttpStatus.CONFLICT,

--- a/services/121-service/src/utils/comparison.helper.spec.ts
+++ b/services/121-service/src/utils/comparison.helper.spec.ts
@@ -2,7 +2,7 @@ import { isSameStatus } from '@121-service/src/utils/comparison.helper';
 
 describe('comparison.helper', () => {
   describe('isSameStatus', () => {
-    it('should retun the correct outcome for all values', () => {
+    it('should return the correct outcome for all values', () => {
       // // Arrange
       const testCases = [
         { a: 200, b: 200, is: true },

--- a/services/121-service/src/utils/comparison.helper.spec.ts
+++ b/services/121-service/src/utils/comparison.helper.spec.ts
@@ -1,6 +1,6 @@
 import { isSameStatus } from '@121-service/src/utils/comparison.helper';
 
-describe('comparisson.helper', () => {
+describe('comparison.helper', () => {
   describe('isSameStatus', () => {
     it('should retun the correct outcome for all values', () => {
       // // Arrange

--- a/services/121-service/src/utils/comparison.helper.spec.ts
+++ b/services/121-service/src/utils/comparison.helper.spec.ts
@@ -1,0 +1,52 @@
+import { isSameStatus } from '@121-service/src/utils/comparison.helper';
+
+describe('comparisson.helper', () => {
+  describe('isSameStatus', () => {
+    it('should retun the correct outcome for all values', () => {
+      // // Arrange
+      const testCases = [
+        { a: 200, b: 200, is: true },
+        { a: '404', b: 404, is: true },
+        { a: '500', b: '500', is: true },
+        { a: 301, b: '301', is: true },
+        { a: '403', b: 404, is: false },
+        { a: 301, b: 302, is: false },
+        { a: '500', b: '501', is: false },
+        // Edge-cases:
+        { a: undefined, b: 'ok', is: false },
+        { a: 'ok', b: undefined, is: false },
+        { a: undefined, b: undefined, is: true },
+        { a: 'undefined', b: undefined, is: true },
+        { a: undefined, b: 'undefined', is: true },
+        { a: 'undefined', b: 'undefined', is: true },
+        { a: '', b: '', is: true },
+        { a: 0, b: 'null', is: false },
+        // Weird edge-cases:
+        {
+          a: '1000000000000000000000',
+          b: '1000000000000000000000',
+          is: true,
+        },
+        { a: 1000000000000000000000, b: '1e+21', is: true },
+        {
+          a: '1000000000000000000000',
+          b: 1000000000000000000000,
+          is: false,
+        },
+        {
+          a: 1000000000000000000000,
+          b: 1_000_000_000_000_000_000_000,
+          is: true,
+        },
+      ];
+
+      testCases.forEach((testCase) => {
+        // Act
+        const result = isSameStatus(testCase.a, testCase.b);
+
+        // Assert
+        expect(result).toBe(testCase.is);
+      });
+    });
+  });
+});

--- a/services/121-service/src/utils/comparison.helper.spec.ts
+++ b/services/121-service/src/utils/comparison.helper.spec.ts
@@ -1,7 +1,7 @@
-import { isSameStatus } from '@121-service/src/utils/comparison.helper';
+import { isSameAsString } from '@121-service/src/utils/comparison.helper';
 
 describe('comparison.helper', () => {
-  describe('isSameStatus', () => {
+  describe('isSameAsString', () => {
     it('should return the correct outcome for all values', () => {
       // // Arrange
       const testCases = [
@@ -42,7 +42,7 @@ describe('comparison.helper', () => {
 
       testCases.forEach((testCase) => {
         // Act
-        const result = isSameStatus(testCase.a, testCase.b);
+        const result = isSameAsString(testCase.a, testCase.b);
 
         // Assert
         expect(result).toBe(testCase.is);

--- a/services/121-service/src/utils/comparison.helper.ts
+++ b/services/121-service/src/utils/comparison.helper.ts
@@ -1,8 +1,8 @@
 /**
  * Compares if two (status-) codes are _equivalent_, not taking types into account.
- * @example isSameStatus('200', 200) returns true
+ * @example isSameAsString('200', 200) returns true
  */
-export function isSameStatus(
+export function isSameAsString(
   a: number | string | undefined,
   b: number | string | undefined,
 ): boolean {

--- a/services/121-service/src/utils/comparison.helper.ts
+++ b/services/121-service/src/utils/comparison.helper.ts
@@ -1,0 +1,10 @@
+/**
+ * Compares if two (status-) codes are _equivalent_, not taking types into account.
+ * @example isSameStatus('200', 200) returns true
+ */
+export function isSameStatus(
+  a: number | string | undefined,
+  b: number | string | undefined,
+): boolean {
+  return String(a) === String(b);
+}

--- a/services/121-service/test/registrations/pagination/send-message.test.ts
+++ b/services/121-service/test/registrations/pagination/send-message.test.ts
@@ -219,13 +219,13 @@ describe('send arbitrary messages to set of registrations', () => {
     expect(messageHistory1.length).toBe(1);
     expect(messageHistory1[0].attributes.status).toBe('failed');
     expect(messageHistory1[0].attributes.errorCode).toEqual(
-      `${TwilioErrorCodes.toNumberDoesNotExist}`,
+      String(TwilioErrorCodes.toNumberDoesNotExist),
     );
 
     expect(messageHistory2.length).toBe(1);
     expect(messageHistory2[0].attributes.status).toBe('failed');
     expect(messageHistory2[0].attributes.errorCode).toEqual(
-      `${TwilioErrorCodes.toNumberDoesNotExist}`,
+      String(TwilioErrorCodes.toNumberDoesNotExist),
     );
   });
 });

--- a/services/121-service/test/registrations/pagination/send-message.test.ts
+++ b/services/121-service/test/registrations/pagination/send-message.test.ts
@@ -219,13 +219,13 @@ describe('send arbitrary messages to set of registrations', () => {
     expect(messageHistory1.length).toBe(1);
     expect(messageHistory1[0].attributes.status).toBe('failed');
     expect(messageHistory1[0].attributes.errorCode).toEqual(
-      String(TwilioErrorCodes.toNumberDoesNotExist),
+      TwilioErrorCodes.toNumberDoesNotExist,
     );
 
     expect(messageHistory2.length).toBe(1);
     expect(messageHistory2[0].attributes.status).toBe('failed');
     expect(messageHistory2[0].attributes.errorCode).toEqual(
-      String(TwilioErrorCodes.toNumberDoesNotExist),
+      TwilioErrorCodes.toNumberDoesNotExist,
     );
   });
 });

--- a/services/mock-service/src/twilio/twilio.dto.ts
+++ b/services/mock-service/src/twilio/twilio.dto.ts
@@ -3,6 +3,9 @@ import { IsOptional, IsString, IsUrl } from 'class-validator';
 
 import { formatWhatsAppNumber } from '@mock-service/src/utils/phone-number.helpers';
 
+/**
+ * @link 121-service/src/notifications/dto/twilio.dto.ts - Duplicate hard-copy as we cannot share enums between services yet.
+ */
 export enum TwilioStatus {
   delivered = 'delivered',
   read = 'read',

--- a/services/mock-service/src/twilio/twilio.service.ts
+++ b/services/mock-service/src/twilio/twilio.service.ts
@@ -31,13 +31,14 @@ enum MockPhoneNumbers {
 // See: services/121-service/src/notifications/enum/message-type.enum.ts
 const TemplatedMessages = ['generic-templated', 'payment-templated'];
 
-// This enumm contains only error codes that are relevant to the 121 service
-// It is copy pasted here because we cannot share enums between services
-export enum TwilioErrorCodes {
-  toNumberDoesNotExist = 21211,
-  mediaUrlInvalid = 63021,
-  failedFreeFormMessage = 63016,
-  channelCouldNotFindToAddress = 63003,
+/**
+ * @link 121-service/src/notifications/enum/twilio-error-codes.enum.ts - Duplicate hard-copy as we cannot share enums between services yet.
+ */
+export const enum TwilioErrorCodes {
+  toNumberDoesNotExist = '21211',
+  mediaUrlInvalid = '63021',
+  failedFreeFormMessage = '63016',
+  channelCouldNotFindToAddress = '63003',
 }
 
 @Injectable()
@@ -151,7 +152,7 @@ export class TwilioService {
       !twilioMessagesCreateDto.StatusCallback.includes('templated') // only return this error on non-templated messages
     ) {
       response.status = TwilioStatus.undelivered;
-      response.error_code = `${TwilioErrorCodes.failedFreeFormMessage}`;
+      response.error_code = TwilioErrorCodes.failedFreeFormMessage;
       response.error_message =
         'Failed to send freeform message because you are outside the allowed window. If you are using WhatsApp, please use a Message Template.';
       this.sendDelayedStatusCallback121({
@@ -168,7 +169,7 @@ export class TwilioService {
       twilioMessagesCreateDto.To.includes('whatsapp') // only return this error on whatsapp
     ) {
       response.status = TwilioStatus.failed;
-      response.error_code = `${TwilioErrorCodes.channelCouldNotFindToAddress}`;
+      response.error_code = TwilioErrorCodes.channelCouldNotFindToAddress;
       response.error_message =
         'Channel could not find To address. You have tried to send a message to a To address that is inactive or invalid.';
       this.sendDelayedStatusCallback121({
@@ -184,7 +185,7 @@ export class TwilioService {
       )
     ) {
       response.status = TwilioStatus.failed;
-      response.error_code = `${TwilioErrorCodes.toNumberDoesNotExist}`;
+      response.error_code = TwilioErrorCodes.toNumberDoesNotExist;
       response.error_message = `Channel could not find To address. You have tried to send a message to a To address that is inactive or invalid.`;
       this.sendDelayedStatusCallback121({
         twilioMessagesCreateDto,


### PR DESCRIPTION
[AB#38126](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38126)

## Describe your changes

Add a utility to use when dealing with response/status-codes coming from (insufficiently typed) third-parties.

So the logic is easier to read AND it prevents 'false negatives';
In which case a "don't throw an error for this code" was incorrectly handled and still causing a lot of (unecessary) log-lines.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
