### PR TITLE
chore: fix flaky ExportPayments test

### DIFF
--- a/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
+++ b/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
@@ -91,6 +91,7 @@ test('[35621] ExportPayments', async () => {
         const registrationProgramIdIndex = headerCells.indexOf(
           'registrationProgramId',
         );
+        expect(registrationProgramIdIndex).toBeGreaterThan(-1);
         const aId = a[registrationProgramIdIndex];
         const bId = b[registrationProgramIdIndex];
 
@@ -98,7 +99,8 @@ test('[35621] ExportPayments', async () => {
           return parseInt(aId, 10) - parseInt(bId, 10);
         }
 
-        const paymentIdIndex = headerCells.indexOf('payment');
+        const paymentIdIndex = headerCells.indexOf('paymentId');
+        expect(paymentIdIndex).toBeGreaterThan(-1);
         const aPaymentId = a[paymentIdIndex];
         const bPaymentId = b[paymentIdIndex];
 


### PR DESCRIPTION
[AB#38159](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38159)

## Describe your changes

In #7106 the payments export changed the name of the payment ID column from `payment` to `paymentId`.

The snapshot was updated to reflect this change, but a piece of the test code was still relying on sorting the records based on `payment`.

This sort function was silently failing, introducing flakiness on the test.

Besides fixing the sort function, I've also added assertions to make sure that a change in column name would not go unnoticed again.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
