### PR TITLE
feat: move safaricom to new flow

### DIFF
--- a/services/121-service/module-dependencies.md
+++ b/services/121-service/module-dependencies.md
@@ -156,5 +156,6 @@ graph LR
   SafaricomReconciliationModule-->SafaricomModule
   SafaricomReconciliationModule-->RedisModule
   SafaricomReconciliationModule-->TransactionsModule
+  SafaricomReconciliationModule-->TransactionEventsModule
   SafaricomReconciliationModule-->QueuesRegistryModule
 ```

--- a/services/121-service/src/payments/fsp-integration/safaricom/repositories/safaricom-transfer.scoped.repository.ts
+++ b/services/121-service/src/payments/fsp-integration/safaricom/repositories/safaricom-transfer.scoped.repository.ts
@@ -21,7 +21,7 @@ export class SafaricomTransferScopedRepository extends ScopedRepository<Safarico
   ): Promise<SafaricomTransferEntity> {
     const safaricomTransfer = await this.findOne({
       where: { originatorConversationId: Equal(originatorConversationId) },
-      relations: ['transaction'],
+      relations: { transaction: { transactionEvents: true } },
     });
 
     if (!safaricomTransfer) {

--- a/services/121-service/src/payments/reconciliation/safaricom-reconciliation/safaricom-reconciliation.module.ts
+++ b/services/121-service/src/payments/reconciliation/safaricom-reconciliation/safaricom-reconciliation.module.ts
@@ -6,6 +6,7 @@ import { TransferCallbackJobProcessorSafaricom } from '@121-service/src/payments
 import { SafaricomReconciliationController } from '@121-service/src/payments/reconciliation/safaricom-reconciliation/safaricom-reconciliation.controller';
 import { SafaricomReconciliationService as SafaricomReconciliationService } from '@121-service/src/payments/reconciliation/safaricom-reconciliation/safaricom-reconciliation.service';
 import { RedisModule } from '@121-service/src/payments/redis/redis.module';
+import { TransactionEventsModule } from '@121-service/src/payments/transactions/transaction-events/transaction-events.module';
 import { TransactionsModule } from '@121-service/src/payments/transactions/transactions.module';
 import { QueuesRegistryModule } from '@121-service/src/queues-registry/queues-registry.module';
 import { AzureLoggerMiddleware } from '@121-service/src/shared/middleware/azure-logger.middleware';
@@ -15,6 +16,7 @@ import { AzureLoggerMiddleware } from '@121-service/src/shared/middleware/azure-
     SafaricomModule,
     RedisModule,
     TransactionsModule,
+    TransactionEventsModule,
     QueuesRegistryModule,
   ],
   providers: [

--- a/services/121-service/src/payments/reconciliation/safaricom-reconciliation/safaricom-reconciliation.service.ts
+++ b/services/121-service/src/payments/reconciliation/safaricom-reconciliation/safaricom-reconciliation.service.ts
@@ -17,6 +17,9 @@ import {
 } from '@121-service/src/payments/redis/redis-client';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { TransactionScopedRepository } from '@121-service/src/payments/transactions/transaction.scoped.repository';
+import { TransactionEventDescription } from '@121-service/src/payments/transactions/transaction-events/enum/transaction-event-description.enum';
+import { TransactionEventType } from '@121-service/src/payments/transactions/transaction-events/enum/transaction-event-type.enum';
+import { TransactionEventsService } from '@121-service/src/payments/transactions/transaction-events/transaction-events.service';
 import { QueuesRegistryService } from '@121-service/src/queues-registry/queues-registry.service';
 import { JobNames } from '@121-service/src/shared/enum/job-names.enum';
 
@@ -25,6 +28,7 @@ export class SafaricomReconciliationService {
   public constructor(
     private readonly safaricomTransferScopedRepository: SafaricomTransferScopedRepository,
     private readonly transactionScopedRepository: TransactionScopedRepository,
+    private readonly transactionEventsService: TransactionEventsService,
     private readonly queuesService: QueuesRegistryService,
     @Inject(REDIS_CLIENT)
     private readonly redisClient: Redis,
@@ -82,48 +86,51 @@ export class SafaricomReconciliationService {
   public async processSafaricomTransferCallbackJob(
     safaricomTransferCallbackJob: SafaricomTransferCallbackJobDto,
   ): Promise<void> {
-    try {
-      // Find the actual safaricom transfer by originatorConversationId
-      const safaricomTransfer =
-        await this.safaricomTransferScopedRepository.getByOriginatorConversationId(
-          safaricomTransferCallbackJob.originatorConversationId,
-        );
-
-      // Prepare the transaction status based on resultCode from callback
-      let updatedTransactionStatusAndErrorMessage = {};
-      if (safaricomTransferCallbackJob.resultCode === 0) {
-        updatedTransactionStatusAndErrorMessage = {
-          status: TransactionStatusEnum.success,
-        };
-      } else {
-        updatedTransactionStatusAndErrorMessage = {
-          status: TransactionStatusEnum.error,
-          errorMessage: `${safaricomTransferCallbackJob.resultCode} - ${safaricomTransferCallbackJob.resultDescription}`,
-        };
-      }
-
-      // Update safaricom transfer with mpesaTransactionId
-      await this.safaricomTransferScopedRepository.update(
-        { id: safaricomTransfer.id },
-        {
-          mpesaTransactionId: safaricomTransferCallbackJob.mpesaTransactionId,
-          mpesaConversationId: safaricomTransferCallbackJob.mpesaConversationId, // This should already be updated on initial request response, but just in case (e.g 121-service crash)
-        },
+    // Find the actual safaricom transfer by originatorConversationId
+    const safaricomTransfer =
+      await this.safaricomTransferScopedRepository.getByOriginatorConversationId(
+        safaricomTransferCallbackJob.originatorConversationId,
       );
+    const transactionId = safaricomTransfer.transactionId;
+    const programFspConfigurationId =
+      this.getProgramFspConfigIdFromLatestEvent(safaricomTransfer);
 
-      // Update transaction status
-      await this.transactionScopedRepository.update(
-        { id: safaricomTransfer.transaction.id },
-        updatedTransactionStatusAndErrorMessage,
-      );
-    } catch (error) {
-      // This should never happen. This way, if it happens, we receive an alert
-      if (error instanceof NotFoundException) {
-        throw new InternalServerErrorException(error.message);
-      }
-
-      throw error;
+    // Prepare the transaction status based on resultCode from callback
+    let transactionStatus: TransactionStatusEnum;
+    let errorMessage: string | undefined;
+    if (safaricomTransferCallbackJob.resultCode === 0) {
+      transactionStatus = TransactionStatusEnum.success;
+    } else {
+      transactionStatus = TransactionStatusEnum.error;
+      errorMessage = `${safaricomTransferCallbackJob.resultCode} - ${safaricomTransferCallbackJob.resultDescription}`;
     }
+
+    // Update safaricom transfer with mpesaTransactionId
+    await this.safaricomTransferScopedRepository.update(
+      { id: safaricomTransfer.id },
+      {
+        mpesaTransactionId: safaricomTransferCallbackJob.mpesaTransactionId,
+        mpesaConversationId: safaricomTransferCallbackJob.mpesaConversationId, // This should already be updated on initial request response, but just in case (e.g 121-service crash)
+      },
+    );
+
+    // Update transaction status
+    await this.transactionScopedRepository.update(
+      { id: safaricomTransfer.transaction.id },
+      {
+        status: transactionStatus,
+      },
+    );
+
+    // create transaction event
+    await this.transactionEventsService.createEvent({
+      transactionId,
+      userId: null,
+      type: TransactionEventType.processingStep,
+      description: TransactionEventDescription.safaricomCallbackReceived,
+      errorMessage,
+      programFspConfigurationId,
+    });
   }
 
   public async processSafaricomTimeoutCallbackJob(
@@ -135,15 +142,26 @@ export class SafaricomReconciliationService {
         await this.safaricomTransferScopedRepository.getByOriginatorConversationId(
           safaricomTimeoutCallbackJob.originatorConversationId,
         );
+      const transactionId = safaricomTransfer.transactionId;
+      const programFspConfigurationId =
+        this.getProgramFspConfigIdFromLatestEvent(safaricomTransfer);
 
       // Update transaction status
       await this.transactionScopedRepository.update(
         { id: safaricomTransfer.transaction.id },
         {
           status: TransactionStatusEnum.error,
-          errorMessage: 'Transfer timed out',
         },
       );
+      // create transaction event
+      await this.transactionEventsService.createEvent({
+        transactionId,
+        userId: null,
+        type: TransactionEventType.processingStep,
+        description: TransactionEventDescription.safaricomCallbackReceived,
+        errorMessage: 'Transfer timed out',
+        programFspConfigurationId,
+      });
     } catch (error) {
       // This should never happen. This way, if it happens, we receive an alert
       if (error instanceof NotFoundException) {
@@ -152,5 +170,12 @@ export class SafaricomReconciliationService {
 
       throw error;
     }
+  }
+
+  private getProgramFspConfigIdFromLatestEvent(safaricomTransfer) {
+    const latestEvent = [
+      ...safaricomTransfer.transaction.transactionEvents,
+    ].sort((a, b) => b.created.getTime() - a.created.getTime())[0];
+    return latestEvent.programFspConfigurationId;
   }
 }

--- a/services/121-service/src/payments/services/transaction-jobs-creation.service.ts
+++ b/services/121-service/src/payments/services/transaction-jobs-creation.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { v4 as uuid } from 'uuid';
 
 import { FspAttributes } from '@121-service/src/fsps/enums/fsp-attributes.enum';
 import { Fsps } from '@121-service/src/fsps/enums/fsp-name.enum';
@@ -291,7 +290,6 @@ export class TransactionJobsCreationService {
           // FSP-specific additions:
           phoneNumber: registrationView.phoneNumber!, // Phonenumber is a required field if a registration has safaricom as FSP
           idNumber: registrationView[FspAttributes.nationalId],
-          originatorConversationId: uuid(), // REFACTOR: switch to nedbank/onafriq approach for idempotency key
         };
       });
     await this.transactionQueuesService.addSafaricomTransactionJobs(

--- a/services/121-service/src/payments/transactions/transaction-events/enum/transaction-event-description.enum.ts
+++ b/services/121-service/src/payments/transactions/transaction-events/enum/transaction-event-description.enum.ts
@@ -5,4 +5,7 @@ export enum TransactionEventDescription {
   // Onafriq processing-step events
   onafriqRequestSent = 'Onafriq request sent', // ##TODO: separate descriptions for success and error?
   onafriqCallbackReceived = 'Onafriq callback received',
+  // Safaricom processing-step events // ##TODO: these are exactly the same as onafriq, can we generalize?
+  safaricomRequestSent = 'Safaricom request sent',
+  safaricomCallbackReceived = 'Safaricom callback received',
 }

--- a/services/121-service/src/transaction-queues/dto/safaricom-transaction-job.dto.ts
+++ b/services/121-service/src/transaction-queues/dto/safaricom-transaction-job.dto.ts
@@ -1,7 +1,6 @@
 import { SharedTransactionJobDto } from '@121-service/src/transaction-queues/dto/shared-transaction-job.dto';
 
 export interface SafaricomTransactionJobDto extends SharedTransactionJobDto {
-  readonly originatorConversationId: string;
   readonly idNumber: string;
   readonly phoneNumber: string;
 }


### PR DESCRIPTION
[AB#38183](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38183)

## Describe your changes

- Migrates FSP Safaricom to new transaction-events flow
- Along the way also upgrades the idempotency flow to that of Onafriq, as that was on the list to do at some point.
- all existing API-tests pass (includes retry, callback, etc.)

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
