### PR TITLE
chore: refactor project forms

### DIFF
--- a/interfaces/portal/src/app/components/import-file-dialog/import-file-dialog.component.ts
+++ b/interfaces/portal/src/app/components/import-file-dialog/import-file-dialog.component.ts
@@ -23,7 +23,7 @@ import { FileUploadControlComponent } from '~/components/file-upload-control/fil
 import { FormErrorComponent } from '~/components/form-error/form-error.component';
 import {
   generateFieldErrors,
-  genericFieldIsRequiredValidationMessage,
+  genericValidationMessage,
 } from '~/utils/form-validation';
 
 export type ImportFileDialogFormGroup =
@@ -63,7 +63,7 @@ export class ImportFileDialogComponent {
   formFieldErrors = generateFieldErrors<ImportFileDialogFormGroup>(
     this.formGroup,
     {
-      file: genericFieldIsRequiredValidationMessage,
+      file: genericValidationMessage,
     },
   );
 

--- a/interfaces/portal/src/app/components/page-layout-registration/components/add-note-dialog/add-note-dialog.component.ts
+++ b/interfaces/portal/src/app/components/page-layout-registration/components/add-note-dialog/add-note-dialog.component.ts
@@ -23,7 +23,7 @@ import { RegistrationApiService } from '~/domains/registration/registration.api.
 import { ToastService } from '~/services/toast.service';
 import {
   generateFieldErrors,
-  genericFieldIsRequiredValidationMessage,
+  genericValidationMessage,
 } from '~/utils/form-validation';
 
 type AddNoteFormGroup =
@@ -69,7 +69,7 @@ export class AddNoteDialogComponent {
   });
 
   formFieldErrors = generateFieldErrors<AddNoteFormGroup>(this.formGroup, {
-    note: genericFieldIsRequiredValidationMessage,
+    note: genericValidationMessage,
   });
 
   addNoteMutation = injectMutation(() => ({

--- a/interfaces/portal/src/app/components/page-layout-registration/components/ignore-duplicates-dialog/ignore-duplication-dialog.component.ts
+++ b/interfaces/portal/src/app/components/page-layout-registration/components/ignore-duplicates-dialog/ignore-duplication-dialog.component.ts
@@ -26,7 +26,7 @@ import { MetricApiService } from '~/domains/metric/metric.api.service';
 import { RegistrationApiService } from '~/domains/registration/registration.api.service';
 import {
   generateFieldErrors,
-  genericFieldIsRequiredValidationMessage,
+  genericValidationMessage,
 } from '~/utils/form-validation';
 
 type IgnoreDuplicationFormGroup =
@@ -87,7 +87,7 @@ export class IgnoreDuplicationDialogComponent {
   formFieldErrors = generateFieldErrors<IgnoreDuplicationFormGroup>(
     this.formGroup,
     {
-      reason: genericFieldIsRequiredValidationMessage,
+      reason: genericValidationMessage,
     },
   );
 

--- a/interfaces/portal/src/app/components/project-form-budget/project-form-budget.component.html
+++ b/interfaces/portal/src/app/components/project-form-budget/project-form-budget.component.html
@@ -17,7 +17,7 @@
       label="Currency"
       i18n-label
       [errorMessage]="formFieldErrors()('currency')"
-      [labelTooltip]="tooltipCurrency"
+      [labelTooltip]="PROJECT_FORM_TOOLTIPS.currency"
       [isRequired]="true"
     >
       <p-select
@@ -46,7 +46,7 @@
     label="Default transfers per registration"
     i18n-label
     [errorMessage]="formFieldErrors()('distributionDuration')"
-    [labelTooltip]="tooltipDistributionDuration"
+    [labelTooltip]="PROJECT_FORM_TOOLTIPS.distributionDuration"
   >
     <input
       pInputText

--- a/interfaces/portal/src/app/components/project-form-budget/project-form-budget.component.html
+++ b/interfaces/portal/src/app/components/project-form-budget/project-form-budget.component.html
@@ -1,0 +1,73 @@
+<ng-container [formGroup]="formGroup">
+  <div class="flex w-full flex-row gap-4 [&>*]:w-1/2">
+    <app-form-field-wrapper
+      label="Funds available"
+      i18n-label
+      [errorMessage]="formFieldErrors()('budget')"
+    >
+      <input
+        pInputText
+        type="number"
+        formControlName="budget"
+        placeholder="Funds available"
+        i18n-placeholder
+      />
+    </app-form-field-wrapper>
+    <app-form-field-wrapper
+      label="Currency"
+      i18n-label
+      [errorMessage]="formFieldErrors()('currency')"
+      [labelTooltip]="tooltipCurrency"
+      [isRequired]="true"
+    >
+      <p-select
+        [options]="currencies"
+        formControlName="currency"
+        [showClear]="false"
+        class="w-full"
+        [filter]="true"
+      />
+    </app-form-field-wrapper>
+  </div>
+  <app-form-field-wrapper
+    label="Payment frequency"
+    i18n-label
+    [errorMessage]="formFieldErrors()('distributionFrequency')"
+  >
+    <input
+      pInputText
+      type="text"
+      formControlName="distributionFrequency"
+      placeholder="Payment frequency"
+      i18n-placeholder
+    />
+  </app-form-field-wrapper>
+  <app-form-field-wrapper
+    label="Default transfers per registration"
+    i18n-label
+    [errorMessage]="formFieldErrors()('distributionDuration')"
+    [labelTooltip]="tooltipDistributionDuration"
+  >
+    <input
+      pInputText
+      type="number"
+      formControlName="distributionDuration"
+      placeholder="Default transfers per registration"
+      i18n-placeholder
+    />
+  </app-form-field-wrapper>
+  <app-form-field-wrapper
+    label="Fixed transfer value"
+    i18n-label
+    [errorMessage]="formFieldErrors()('fixedTransferValue')"
+    [isRequired]="true"
+  >
+    <input
+      pInputText
+      type="number"
+      formControlName="fixedTransferValue"
+      placeholder="Fixed transfer value"
+      i18n-placeholder
+    />
+  </app-form-field-wrapper>
+</ng-container>

--- a/interfaces/portal/src/app/components/project-form-budget/project-form-budget.component.ts
+++ b/interfaces/portal/src/app/components/project-form-budget/project-form-budget.component.ts
@@ -21,7 +21,7 @@ import { PROJECT_FORM_TOOLTIPS } from '~/domains/project/project.helper';
 import { Project } from '~/domains/project/project.model';
 import {
   generateFieldErrors,
-  genericFieldIsRequiredValidationMessage,
+  genericValidationMessage,
 } from '~/utils/form-validation';
 
 export type ProjectBudgetFormGroup =
@@ -77,26 +77,11 @@ export class ProjectFormBudgetComponent {
   formFieldErrors = generateFieldErrors<ProjectBudgetFormGroup>(
     this.formGroup,
     {
-      budget: (control) => {
-        if (control.errors?.min) {
-          return $localize`This needs to be at least 0.`;
-        }
-        return;
-      },
-      currency: genericFieldIsRequiredValidationMessage,
-      distributionFrequency: genericFieldIsRequiredValidationMessage,
-      distributionDuration: (control) => {
-        if (control.errors?.min) {
-          return $localize`This needs to be at least 0.`;
-        }
-        return;
-      },
-      fixedTransferValue: (control) => {
-        if (control.errors?.min) {
-          return $localize`This needs to be at least 0.`;
-        }
-        return genericFieldIsRequiredValidationMessage(control);
-      },
+      budget: genericValidationMessage,
+      currency: genericValidationMessage,
+      distributionFrequency: genericValidationMessage,
+      distributionDuration: genericValidationMessage,
+      fixedTransferValue: genericValidationMessage,
     },
   );
 

--- a/interfaces/portal/src/app/components/project-form-budget/project-form-budget.component.ts
+++ b/interfaces/portal/src/app/components/project-form-budget/project-form-budget.component.ts
@@ -1,0 +1,122 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  input,
+} from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+
+import { InputTextModule } from 'primeng/inputtext';
+import { SelectModule } from 'primeng/select';
+
+import { CurrencyCode } from '@121-service/src/exchange-rates/enums/currency-code.enum';
+
+import { FormFieldWrapperComponent } from '~/components/form-field-wrapper/form-field-wrapper.component';
+import { PROJECT_FORM_TOOLTIPS } from '~/domains/project/project.helper';
+import { Project } from '~/domains/project/project.model';
+import {
+  generateFieldErrors,
+  genericFieldIsRequiredValidationMessage,
+} from '~/utils/form-validation';
+
+export type ProjectBudgetFormGroup =
+  (typeof ProjectFormBudgetComponent)['prototype']['formGroup'];
+
+@Component({
+  selector: 'app-project-form-budget',
+  imports: [
+    FormFieldWrapperComponent,
+    ReactiveFormsModule,
+    InputTextModule,
+    SelectModule,
+  ],
+  templateUrl: './project-form-budget.component.html',
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProjectFormBudgetComponent {
+  readonly project = input<Project>();
+
+  readonly currencies = Object.values(CurrencyCode)
+    .map((code) => ({
+      label: code,
+      value: code,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+
+  formGroup = new FormGroup({
+    budget: new FormControl<number | undefined>(undefined, {
+      nonNullable: true,
+      validators: [Validators.min(0)],
+    }),
+    currency: new FormControl<CurrencyCode | undefined>(undefined, {
+      nonNullable: true,
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- https://github.com/typescript-eslint/typescript-eslint/issues/1929#issuecomment-618695608
+      validators: [Validators.required],
+    }),
+    distributionFrequency: new FormControl<string | undefined>(undefined, {
+      nonNullable: true,
+      validators: [],
+    }),
+    distributionDuration: new FormControl<number | undefined>(undefined, {
+      nonNullable: true,
+      validators: [Validators.min(0)],
+    }),
+    fixedTransferValue: new FormControl(0, {
+      nonNullable: true,
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- https://github.com/typescript-eslint/typescript-eslint/issues/1929#issuecomment-618695608
+      validators: [Validators.required, Validators.min(0)],
+    }),
+  });
+
+  formFieldErrors = generateFieldErrors<ProjectBudgetFormGroup>(
+    this.formGroup,
+    {
+      budget: (control) => {
+        if (control.errors?.min) {
+          return $localize`This needs to be at least 0.`;
+        }
+        return;
+      },
+      currency: genericFieldIsRequiredValidationMessage,
+      distributionFrequency: genericFieldIsRequiredValidationMessage,
+      distributionDuration: (control) => {
+        if (control.errors?.min) {
+          return $localize`This needs to be at least 0.`;
+        }
+        return;
+      },
+      fixedTransferValue: (control) => {
+        if (control.errors?.min) {
+          return $localize`This needs to be at least 0.`;
+        }
+        return genericFieldIsRequiredValidationMessage(control);
+      },
+    },
+  );
+
+  updateFormGroup = effect(() => {
+    const projectData = this.project();
+
+    if (!projectData) {
+      return;
+    }
+
+    this.formGroup.setValue({
+      budget: projectData.budget,
+      currency: projectData.currency,
+      distributionFrequency: projectData.distributionFrequency ?? undefined,
+      distributionDuration: projectData.distributionDuration,
+      fixedTransferValue: projectData.fixedTransferValue ?? 0,
+    });
+  });
+
+  readonly tooltipCurrency = PROJECT_FORM_TOOLTIPS.currency;
+  readonly tooltipDistributionDuration =
+    PROJECT_FORM_TOOLTIPS.distributionDuration;
+}

--- a/interfaces/portal/src/app/components/project-form-budget/project-form-budget.component.ts
+++ b/interfaces/portal/src/app/components/project-form-budget/project-form-budget.component.ts
@@ -101,7 +101,5 @@ export class ProjectFormBudgetComponent {
     });
   });
 
-  readonly tooltipCurrency = PROJECT_FORM_TOOLTIPS.currency;
-  readonly tooltipDistributionDuration =
-    PROJECT_FORM_TOOLTIPS.distributionDuration;
+  readonly PROJECT_FORM_TOOLTIPS = PROJECT_FORM_TOOLTIPS;
 }

--- a/interfaces/portal/src/app/components/project-form-information/project-form-information.component.html
+++ b/interfaces/portal/src/app/components/project-form-information/project-form-information.component.html
@@ -38,7 +38,7 @@
     i18n-label
     [errorMessage]="formFieldErrors()('targetNrRegistrations')"
     [isRequired]="true"
-    [labelTooltip]="tooltipTargetRegistrations"
+    [labelTooltip]="PROJECT_FORM_TOOLTIPS.targetRegistrations"
   >
     <input
       pInputText
@@ -59,7 +59,7 @@
       i18n
       >Use "validation" in this project</label
     >
-    <app-info-tooltip [message]="tooltipValidationProcess" />
+    <app-info-tooltip [message]="PROJECT_FORM_TOOLTIPS.validationProcess" />
   </div>
   <div class="mt-4 flex justify-items-center">
     <p-toggleSwitch
@@ -72,6 +72,6 @@
       i18n
       >Use "scope" in this project</label
     >
-    <app-info-tooltip [message]="tooltipEnableScope" />
+    <app-info-tooltip [message]="PROJECT_FORM_TOOLTIPS.enableScope" />
   </div>
 </ng-container>

--- a/interfaces/portal/src/app/components/project-form-information/project-form-information.component.html
+++ b/interfaces/portal/src/app/components/project-form-information/project-form-information.component.html
@@ -1,0 +1,77 @@
+<ng-container [formGroup]="formGroup">
+  <div class="flex w-full flex-row gap-4 [&>*]:w-1/2">
+    <app-form-field-wrapper
+      label="Start Date"
+      i18n-label
+    >
+      <p-datepicker
+        formControlName="startDate"
+        appendTo="body"
+      />
+    </app-form-field-wrapper>
+
+    <app-form-field-wrapper
+      label="End Date"
+      i18n-label
+    >
+      <p-datepicker
+        formControlName="endDate"
+        appendTo="body"
+      />
+    </app-form-field-wrapper>
+  </div>
+  <app-form-field-wrapper
+    label="Location"
+    i18n-label
+    [errorMessage]="formFieldErrors()('location')"
+  >
+    <input
+      pInputText
+      type="text"
+      formControlName="location"
+      placeholder="Location"
+      i18n-placeholder
+    />
+  </app-form-field-wrapper>
+  <app-form-field-wrapper
+    label="Target registrations"
+    i18n-label
+    [errorMessage]="formFieldErrors()('targetNrRegistrations')"
+    [isRequired]="true"
+    [labelTooltip]="tooltipTargetRegistrations"
+  >
+    <input
+      pInputText
+      type="number"
+      formControlName="targetNrRegistrations"
+      placeholder="Target registrations"
+      i18n-placeholder
+    />
+  </app-form-field-wrapper>
+  <div class="mt-4 flex justify-items-center">
+    <p-toggleSwitch
+      inputId="validation"
+      formControlName="validation"
+    />
+    <label
+      class="ms-2 me-1"
+      for="validation"
+      i18n
+      >Use "validation" in this project</label
+    >
+    <app-info-tooltip [message]="tooltipValidationProcess" />
+  </div>
+  <div class="mt-4 flex justify-items-center">
+    <p-toggleSwitch
+      inputId="enableScope"
+      formControlName="enableScope"
+    />
+    <label
+      class="ms-2 me-1"
+      for="enableScope"
+      i18n
+      >Use "scope" in this project</label
+    >
+    <app-info-tooltip [message]="tooltipEnableScope" />
+  </div>
+</ng-container>

--- a/interfaces/portal/src/app/components/project-form-information/project-form-information.component.ts
+++ b/interfaces/portal/src/app/components/project-form-information/project-form-information.component.ts
@@ -94,8 +94,5 @@ export class ProjectFormInformationComponent {
     });
   });
 
-  readonly tooltipTargetRegistrations =
-    PROJECT_FORM_TOOLTIPS.targetRegistrations;
-  readonly tooltipValidationProcess = PROJECT_FORM_TOOLTIPS.validationProcess;
-  readonly tooltipEnableScope = PROJECT_FORM_TOOLTIPS.enableScope;
+  readonly PROJECT_FORM_TOOLTIPS = PROJECT_FORM_TOOLTIPS;
 }

--- a/interfaces/portal/src/app/components/project-form-information/project-form-information.component.ts
+++ b/interfaces/portal/src/app/components/project-form-information/project-form-information.component.ts
@@ -1,0 +1,101 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  input,
+} from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+
+import { DatePickerModule } from 'primeng/datepicker';
+import { InputTextModule } from 'primeng/inputtext';
+import { ToggleSwitchModule } from 'primeng/toggleswitch';
+
+import { FormFieldWrapperComponent } from '~/components/form-field-wrapper/form-field-wrapper.component';
+import { InfoTooltipComponent } from '~/components/info-tooltip/info-tooltip.component';
+import { PROJECT_FORM_TOOLTIPS } from '~/domains/project/project.helper';
+import { Project } from '~/domains/project/project.model';
+import {
+  generateFieldErrors,
+  genericFieldIsRequiredValidationMessage,
+} from '~/utils/form-validation';
+
+export type ProjectInformationFormGroup =
+  (typeof ProjectFormInformationComponent)['prototype']['formGroup'];
+
+@Component({
+  selector: 'app-project-form-information',
+  imports: [
+    FormFieldWrapperComponent,
+    ReactiveFormsModule,
+    InputTextModule,
+    DatePickerModule,
+    ToggleSwitchModule,
+    InfoTooltipComponent,
+  ],
+  templateUrl: './project-form-information.component.html',
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProjectFormInformationComponent {
+  readonly project = input<Project>();
+
+  formGroup = new FormGroup({
+    startDate: new FormControl<Date | undefined>(undefined, {
+      nonNullable: true,
+    }),
+    endDate: new FormControl<Date | undefined>(undefined, {
+      nonNullable: true,
+    }),
+    location: new FormControl<string | undefined>(undefined, {
+      nonNullable: true,
+    }),
+    targetNrRegistrations: new FormControl(0, {
+      nonNullable: true,
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- https://github.com/typescript-eslint/typescript-eslint/issues/1929#issuecomment-618695608
+      validators: [Validators.required, Validators.min(1)],
+    }),
+    validation: new FormControl(false, { nonNullable: true }),
+    enableScope: new FormControl(false, { nonNullable: true }),
+  });
+
+  formFieldErrors = generateFieldErrors<ProjectInformationFormGroup>(
+    this.formGroup,
+    {
+      startDate: genericFieldIsRequiredValidationMessage,
+      endDate: genericFieldIsRequiredValidationMessage,
+      location: genericFieldIsRequiredValidationMessage,
+      targetNrRegistrations: genericFieldIsRequiredValidationMessage,
+      validation: genericFieldIsRequiredValidationMessage,
+      enableScope: genericFieldIsRequiredValidationMessage,
+    },
+  );
+
+  updateFormGroup = effect(() => {
+    const projectData = this.project();
+
+    if (!projectData) {
+      return;
+    }
+
+    const { startDate, endDate } = projectData;
+
+    this.formGroup.setValue({
+      startDate: startDate ? new Date(startDate) : undefined,
+      endDate: endDate ? new Date(endDate) : undefined,
+      location: projectData.location,
+      targetNrRegistrations: projectData.targetNrRegistrations ?? 0,
+      validation: projectData.validation,
+      enableScope: projectData.enableScope,
+    });
+  });
+
+  readonly tooltipTargetRegistrations =
+    PROJECT_FORM_TOOLTIPS.targetRegistrations;
+  readonly tooltipValidationProcess = PROJECT_FORM_TOOLTIPS.validationProcess;
+  readonly tooltipEnableScope = PROJECT_FORM_TOOLTIPS.enableScope;
+}

--- a/interfaces/portal/src/app/components/project-form-information/project-form-information.component.ts
+++ b/interfaces/portal/src/app/components/project-form-information/project-form-information.component.ts
@@ -21,7 +21,7 @@ import { PROJECT_FORM_TOOLTIPS } from '~/domains/project/project.helper';
 import { Project } from '~/domains/project/project.model';
 import {
   generateFieldErrors,
-  genericFieldIsRequiredValidationMessage,
+  genericValidationMessage,
 } from '~/utils/form-validation';
 
 export type ProjectInformationFormGroup =
@@ -66,12 +66,12 @@ export class ProjectFormInformationComponent {
   formFieldErrors = generateFieldErrors<ProjectInformationFormGroup>(
     this.formGroup,
     {
-      startDate: genericFieldIsRequiredValidationMessage,
-      endDate: genericFieldIsRequiredValidationMessage,
-      location: genericFieldIsRequiredValidationMessage,
-      targetNrRegistrations: genericFieldIsRequiredValidationMessage,
-      validation: genericFieldIsRequiredValidationMessage,
-      enableScope: genericFieldIsRequiredValidationMessage,
+      startDate: genericValidationMessage,
+      endDate: genericValidationMessage,
+      location: genericValidationMessage,
+      targetNrRegistrations: genericValidationMessage,
+      validation: genericValidationMessage,
+      enableScope: genericValidationMessage,
     },
   );
 

--- a/interfaces/portal/src/app/components/project-form-name/project-form-name.component.html
+++ b/interfaces/portal/src/app/components/project-form-name/project-form-name.component.html
@@ -1,0 +1,30 @@
+<ng-container [formGroup]="formGroup">
+  <app-form-field-wrapper
+    label="Project name"
+    i18n-label
+    [errorMessage]="formFieldErrors()('name')"
+    [isRequired]="true"
+  >
+    <input
+      pInputText
+      type="text"
+      formControlName="name"
+      placeholder="Project name"
+      i18n-placeholder
+    />
+  </app-form-field-wrapper>
+  <app-form-field-wrapper
+    label="Project description"
+    i18n-label
+    [errorMessage]="formFieldErrors()('description')"
+  >
+    <textarea
+      rows="5"
+      pTextarea
+      formControlName="description"
+      autocomplete="off"
+      placeholder="Hint text..."
+      i18n-placeholder
+    ></textarea>
+  </app-form-field-wrapper>
+</ng-container>

--- a/interfaces/portal/src/app/components/project-form-name/project-form-name.component.html
+++ b/interfaces/portal/src/app/components/project-form-name/project-form-name.component.html
@@ -22,7 +22,6 @@
       rows="5"
       pTextarea
       formControlName="description"
-      autocomplete="off"
       placeholder="Hint text..."
       i18n-placeholder
     ></textarea>

--- a/interfaces/portal/src/app/components/project-form-name/project-form-name.component.ts
+++ b/interfaces/portal/src/app/components/project-form-name/project-form-name.component.ts
@@ -18,7 +18,7 @@ import { FormFieldWrapperComponent } from '~/components/form-field-wrapper/form-
 import { Project } from '~/domains/project/project.model';
 import {
   generateFieldErrors,
-  genericFieldIsRequiredValidationMessage,
+  genericValidationMessage,
 } from '~/utils/form-validation';
 
 export type ProjectNameFormGroup =
@@ -51,8 +51,8 @@ export class ProjectFormNameComponent {
   });
 
   formFieldErrors = generateFieldErrors<ProjectNameFormGroup>(this.formGroup, {
-    name: genericFieldIsRequiredValidationMessage,
-    description: genericFieldIsRequiredValidationMessage,
+    name: genericValidationMessage,
+    description: genericValidationMessage,
   });
 
   updateFormGroup = effect(() => {

--- a/interfaces/portal/src/app/components/project-form-name/project-form-name.component.ts
+++ b/interfaces/portal/src/app/components/project-form-name/project-form-name.component.ts
@@ -1,0 +1,70 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  input,
+} from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+
+import { InputTextModule } from 'primeng/inputtext';
+import { TextareaModule } from 'primeng/textarea';
+
+import { FormFieldWrapperComponent } from '~/components/form-field-wrapper/form-field-wrapper.component';
+import { Project } from '~/domains/project/project.model';
+import {
+  generateFieldErrors,
+  genericFieldIsRequiredValidationMessage,
+} from '~/utils/form-validation';
+
+export type ProjectNameFormGroup =
+  (typeof ProjectFormNameComponent)['prototype']['formGroup'];
+
+@Component({
+  selector: 'app-project-form-name',
+  imports: [
+    FormFieldWrapperComponent,
+    ReactiveFormsModule,
+    InputTextModule,
+    TextareaModule,
+  ],
+  templateUrl: './project-form-name.component.html',
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProjectFormNameComponent {
+  readonly project = input<Project>();
+
+  formGroup = new FormGroup({
+    name: new FormControl('', {
+      nonNullable: true,
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- https://github.com/typescript-eslint/typescript-eslint/issues/1929#issuecomment-618695608
+      validators: [Validators.required],
+    }),
+    description: new FormControl<string | undefined>(undefined, {
+      nonNullable: true,
+    }),
+  });
+
+  formFieldErrors = generateFieldErrors<ProjectNameFormGroup>(this.formGroup, {
+    name: genericFieldIsRequiredValidationMessage,
+    description: genericFieldIsRequiredValidationMessage,
+  });
+
+  updateFormGroup = effect(() => {
+    const projectData = this.project();
+
+    if (!projectData) {
+      return;
+    }
+
+    this.formGroup.setValue({
+      name: projectData.titlePortal?.en ?? '',
+      description: projectData.description?.en,
+    });
+  });
+}

--- a/interfaces/portal/src/app/domains/project/project.helper.ts
+++ b/interfaces/portal/src/app/domains/project/project.helper.ts
@@ -83,8 +83,8 @@ export const PROJECT_ATTACHMENT_FILE_TYPE_ICONS: Record<
 };
 
 export const PROJECT_FORM_TOOLTIPS = {
-  targetRegistrations: $localize`The amount of people/ households your project wishes to reach.`,
-  validationProcess: $localize`Turning on the validation option enables an additional registration status: "${REGISTRATION_STATUS_LABELS[RegistrationStatusEnum.validated]}".`,
+  targetRegistrations: $localize`The amount of people/households your project plans to reach.`,
+  validationProcess: $localize`This enables an additional registration status: "${REGISTRATION_STATUS_LABELS[RegistrationStatusEnum.validated]}".`,
   enableScope: $localize`Scope allows you to control which team members have access to specific registrations, based on the scope they are assigned to in the project team's page.
 
 To use this feature, make sure scope is defined in your integrated Kobo form or Excel table.`,

--- a/interfaces/portal/src/app/domains/project/project.helper.ts
+++ b/interfaces/portal/src/app/domains/project/project.helper.ts
@@ -1,4 +1,5 @@
 import { FspIntegrationType } from '@121-service/src/fsps/enums/fsp-integration-type.enum';
+import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 
 import { getFspSettingByName } from '~/domains/fsp/fsp.helper';
 import {
@@ -9,6 +10,7 @@ import {
   Project,
   ProjectAttachmentFileType,
 } from '~/domains/project/project.model';
+import { REGISTRATION_STATUS_LABELS } from '~/domains/registration/registration.helper';
 
 export const projectHasVoucherSupport = (project?: Project): boolean =>
   project?.programFspConfigurations.some((fsp) =>
@@ -78,4 +80,14 @@ export const PROJECT_ATTACHMENT_FILE_TYPE_ICONS: Record<
   [ProjectAttachmentFileType.IMAGE]: 'pi pi-image text-purple-600',
   [ProjectAttachmentFileType.DOCUMENT]: 'pi pi-file-word text-blue-500',
   [ProjectAttachmentFileType.PDF]: 'pi pi-file-pdf text-red-500',
+};
+
+export const PROJECT_FORM_TOOLTIPS = {
+  targetRegistrations: $localize`The amount of people/ households your project wishes to reach.`,
+  validationProcess: $localize`Turning on the validation option enables an additional registration status: "${REGISTRATION_STATUS_LABELS[RegistrationStatusEnum.validated]}".`,
+  enableScope: $localize`Scope allows you to control which team members have access to specific registrations, based on the scope they are assigned to in the project team's page.
+
+To use this feature, make sure scope is defined in your integrated Kobo form or Excel table.`,
+  currency: $localize`Should be an ISO 4217 currency code (full list available on Wikipedia).`,
+  distributionDuration: $localize`The number of times each registration will receive transfers in the project as a default.`,
 };

--- a/interfaces/portal/src/app/domains/project/project.helper.ts
+++ b/interfaces/portal/src/app/domains/project/project.helper.ts
@@ -89,5 +89,5 @@ export const PROJECT_FORM_TOOLTIPS = {
 
 To use this feature, make sure scope is defined in your integrated Kobo form or Excel table.`,
   currency: $localize`Should be an ISO 4217 currency code (full list available on Wikipedia).`,
-  distributionDuration: $localize`The number of times each registration will receive transfers in the project as a default.`,
+  distributionDuration: $localize`The number of times a registration will receive transfers in the project by default.`,
 };

--- a/interfaces/portal/src/app/pages/project-monitoring-files/components/monitoring-upload-file-dialog/monitoring-upload-file-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/project-monitoring-files/components/monitoring-upload-file-dialog/monitoring-upload-file-dialog.component.ts
@@ -26,7 +26,7 @@ import { RtlHelperService } from '~/services/rtl-helper.service';
 import { ToastService } from '~/services/toast.service';
 import {
   generateFieldErrors,
-  genericFieldIsRequiredValidationMessage,
+  genericValidationMessage,
 } from '~/utils/form-validation';
 
 type UploadFileFormGroup =
@@ -66,7 +66,7 @@ export class MonitoringUploadFileDialogComponent {
   uploadFileFormFieldErrors = generateFieldErrors<UploadFileFormGroup>(
     this.uploadFileFormGroup,
     {
-      filename: genericFieldIsRequiredValidationMessage,
+      filename: genericValidationMessage,
     },
   );
 

--- a/interfaces/portal/src/app/pages/project-monitoring-files/project-monitoring-files.page.ts
+++ b/interfaces/portal/src/app/pages/project-monitoring-files/project-monitoring-files.page.ts
@@ -48,7 +48,7 @@ import { DownloadService } from '~/services/download.service';
 import { ToastService } from '~/services/toast.service';
 import {
   generateFieldErrors,
-  genericFieldIsRequiredValidationMessage,
+  genericValidationMessage,
 } from '~/utils/form-validation';
 import { getUniqueUserOptions } from '~/utils/unique-users';
 
@@ -101,7 +101,7 @@ export class ProjectMonitoringFilesPageComponent {
   deleteFileFormFieldErrors = generateFieldErrors<DeleteFileFormGroup>(
     this.deleteFileFormGroup,
     {
-      confirmAction: genericFieldIsRequiredValidationMessage,
+      confirmAction: genericValidationMessage,
     },
   );
 

--- a/interfaces/portal/src/app/pages/project-registration-personal-information/components/edit-personal-information/edit-personal-information.component.ts
+++ b/interfaces/portal/src/app/pages/project-registration-personal-information/components/edit-personal-information/edit-personal-information.component.ts
@@ -45,7 +45,7 @@ import { RtlHelperService } from '~/services/rtl-helper.service';
 import { ToastService } from '~/services/toast.service';
 import {
   generateFieldErrors,
-  genericFieldIsRequiredValidationMessage,
+  genericValidationMessage,
 } from '~/utils/form-validation';
 
 type EditPersonalInformationFormGroup =
@@ -128,7 +128,7 @@ export class EditPersonalInformationComponent
   dialogFormFieldErrors = generateFieldErrors<DialogFormGroup>(
     this.dialogFormGroup,
     {
-      reason: genericFieldIsRequiredValidationMessage,
+      reason: genericValidationMessage,
     },
   );
 

--- a/interfaces/portal/src/app/pages/project-registrations/components/send-message-dialog/send-message-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/project-registrations/components/send-message-dialog/send-message-dialog.component.ts
@@ -42,7 +42,7 @@ import {
 import { ToastService } from '~/services/toast.service';
 import {
   generateFieldErrors,
-  genericFieldIsRequiredValidationMessage,
+  genericValidationMessage,
 } from '~/utils/form-validation';
 
 type SendMessageFormGroup =
@@ -105,8 +105,8 @@ export class SendMessageDialogComponent
   });
 
   formFieldErrors = generateFieldErrors<SendMessageFormGroup>(this.formGroup, {
-    messageType: genericFieldIsRequiredValidationMessage,
-    messageTemplateKey: genericFieldIsRequiredValidationMessage,
+    messageType: genericValidationMessage,
+    messageTemplateKey: genericValidationMessage,
     customMessage: (control) => {
       if (control.errors?.required) {
         return $localize`:@@generic-required-field:This field is required.`;

--- a/interfaces/portal/src/app/pages/project-registrations/components/update-registrations/update-registrations.component.ts
+++ b/interfaces/portal/src/app/pages/project-registrations/components/update-registrations/update-registrations.component.ts
@@ -48,7 +48,7 @@ import { ToastService } from '~/services/toast.service';
 import { TranslatableStringService } from '~/services/translatable-string.service';
 import {
   generateFieldErrors,
-  genericFieldIsRequiredValidationMessage,
+  genericValidationMessage,
 } from '~/utils/form-validation';
 
 type ExportCSVFormGroup =
@@ -122,7 +122,7 @@ export class UpdateRegistrationsComponent {
   exportCSVFormFieldErrors = generateFieldErrors<ExportCSVFormGroup>(
     this.exportCSVFormGroup,
     {
-      fields: genericFieldIsRequiredValidationMessage,
+      fields: genericValidationMessage,
     },
   );
 
@@ -150,8 +150,8 @@ export class UpdateRegistrationsComponent {
     generateFieldErrors<UpdateRegistrationsFormGroup>(
       this.updateRegistrationsFormGroup,
       {
-        reason: genericFieldIsRequiredValidationMessage,
-        confirmAction: genericFieldIsRequiredValidationMessage,
+        reason: genericValidationMessage,
+        confirmAction: genericValidationMessage,
       },
     );
 

--- a/interfaces/portal/src/app/pages/project-settings-information/components/project-settings-basic-information/project-settings-basic-information.component.html
+++ b/interfaces/portal/src/app/pages/project-settings-information/components/project-settings-basic-information/project-settings-basic-information.component.html
@@ -5,9 +5,9 @@
   i18n-editPencilTitle
   [canEdit]="canEdit()"
   [(isEditing)]="isEditing"
-  [formGroup]="formGroup"
+  [formGroup]="formGroup()"
   [mutation]="updateProjectMutation"
-  [mutationData]="formGroup.getRawValue()"
+  [mutationData]="formGroup()?.getRawValue()"
 >
   <p
     i18n
@@ -23,110 +23,13 @@
       data-testid="project-basic-information-data-list"
     />
   } @else {
-    <ng-container [formGroup]="formGroup">
-      <app-form-field-wrapper
-        label="Project name"
-        i18n-label
-        [errorMessage]="formFieldErrors()('name')"
-        [isRequired]="true"
-      >
-        <input
-          pInputText
-          type="text"
-          formControlName="name"
-          placeholder="Project name"
-          i18n-placeholder
-        />
-      </app-form-field-wrapper>
-      <app-form-field-wrapper
-        label="Project description"
-        i18n-label
-        [errorMessage]="formFieldErrors()('description')"
-      >
-        <textarea
-          rows="5"
-          pTextarea
-          formControlName="description"
-          autocomplete="off"
-          placeholder="Hint text..."
-          i18n-placeholder
-        ></textarea>
-      </app-form-field-wrapper>
-      <div class="flex w-full flex-row gap-4 [&>*]:w-1/2">
-        <app-form-field-wrapper
-          label="Start Date"
-          i18n-label
-        >
-          <p-datepicker
-            formControlName="startDate"
-            appendTo="body"
-          />
-        </app-form-field-wrapper>
-
-        <app-form-field-wrapper
-          label="End Date"
-          i18n-label
-        >
-          <p-datepicker
-            formControlName="endDate"
-            appendTo="body"
-          />
-        </app-form-field-wrapper>
-      </div>
-      <app-form-field-wrapper
-        label="Location"
-        i18n-label
-        [errorMessage]="formFieldErrors()('location')"
-      >
-        <input
-          pInputText
-          type="text"
-          formControlName="location"
-          placeholder="Location"
-          i18n-placeholder
-        />
-      </app-form-field-wrapper>
-      <app-form-field-wrapper
-        label="Target registrations"
-        i18n-label
-        [errorMessage]="formFieldErrors()('targetNrRegistrations')"
-        [isRequired]="true"
-        [labelTooltip]="tooltipTargetRegistrations"
-      >
-        <input
-          pInputText
-          type="number"
-          formControlName="targetNrRegistrations"
-          placeholder="Target registrations"
-          i18n-placeholder
-        />
-      </app-form-field-wrapper>
-      <div class="mt-4 flex justify-items-center">
-        <p-toggleSwitch
-          inputId="validation"
-          formControlName="validation"
-        />
-        <label
-          class="ms-2 me-1"
-          for="validation"
-          i18n
-          >Use "validation" in this project</label
-        >
-        <app-info-tooltip [message]="tooltipValidationProcess" />
-      </div>
-      <div class="mt-4 flex justify-items-center">
-        <p-toggleSwitch
-          inputId="enableScope"
-          formControlName="enableScope"
-        />
-        <label
-          class="ms-2 me-1"
-          for="enableScope"
-          i18n
-          >Use "scope" in this project</label
-        >
-        <app-info-tooltip [message]="tooltipEnableScope" />
-      </div>
-    </ng-container>
+    <app-project-form-name
+      #projectFormName
+      [project]="project.data()"
+    />
+    <app-project-form-information
+      #projectFormInformation
+      [project]="project.data()"
+    />
   }
 </app-card-editable>

--- a/interfaces/portal/src/app/pages/project-settings-information/components/project-settings-basic-information/project-settings-basic-information.component.ts
+++ b/interfaces/portal/src/app/pages/project-settings-information/components/project-settings-basic-information/project-settings-basic-information.component.ts
@@ -73,6 +73,8 @@ export class ProjectSettingsBasicInformationComponent {
     'projectFormInformation',
   );
 
+  // These are two separate components/formGroups because they are also
+  // used separately in the project creation flow
   readonly formGroup = computed(() => {
     const nameGroup = this.projectFormName()?.formGroup;
     const informationGroup = this.projectFormInformation()?.formGroup;

--- a/interfaces/portal/src/app/pages/project-settings-information/components/project-settings-basic-information/project-settings-basic-information.component.ts
+++ b/interfaces/portal/src/app/pages/project-settings-information/components/project-settings-basic-information/project-settings-basic-information.component.ts
@@ -2,28 +2,18 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  effect,
   inject,
   input,
   signal,
+  viewChild,
 } from '@angular/core';
-import {
-  FormControl,
-  FormGroup,
-  ReactiveFormsModule,
-  Validators,
-} from '@angular/forms';
+import { FormGroup } from '@angular/forms';
 
 import {
   injectMutation,
   injectQuery,
 } from '@tanstack/angular-query-experimental';
-import { DatePickerModule } from 'primeng/datepicker';
-import { InputTextModule } from 'primeng/inputtext';
-import { TextareaModule } from 'primeng/textarea';
-import { ToggleSwitchModule } from 'primeng/toggleswitch';
 
-import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 
 import { CardEditableComponent } from '~/components/card-editable/card-editable.component';
@@ -31,33 +21,27 @@ import {
   DataListComponent,
   DataListItem,
 } from '~/components/data-list/data-list.component';
-import { FormFieldWrapperComponent } from '~/components/form-field-wrapper/form-field-wrapper.component';
-import { InfoTooltipComponent } from '~/components/info-tooltip/info-tooltip.component';
+import {
+  ProjectFormInformationComponent,
+  ProjectInformationFormGroup,
+} from '~/components/project-form-information/project-form-information.component';
+import {
+  ProjectFormNameComponent,
+  ProjectNameFormGroup,
+} from '~/components/project-form-name/project-form-name.component';
 import { ProjectApiService } from '~/domains/project/project.api.service';
-import { REGISTRATION_STATUS_LABELS } from '~/domains/registration/registration.helper';
+import { PROJECT_FORM_TOOLTIPS } from '~/domains/project/project.helper';
 import { AuthService } from '~/services/auth.service';
 import { RegistrationsTableColumnService } from '~/services/registrations-table-column.service';
 import { ToastService } from '~/services/toast.service';
-import {
-  generateFieldErrors,
-  genericFieldIsRequiredValidationMessage,
-} from '~/utils/form-validation';
-
-type ProjectSettingsBasicInformationFormGroup =
-  (typeof ProjectSettingsBasicInformationComponent)['prototype']['formGroup'];
 
 @Component({
   selector: 'app-project-settings-basic-information',
   imports: [
     CardEditableComponent,
-    FormFieldWrapperComponent,
-    ReactiveFormsModule,
-    InputTextModule,
-    TextareaModule,
+    ProjectFormNameComponent,
+    ProjectFormInformationComponent,
     DataListComponent,
-    DatePickerModule,
-    ToggleSwitchModule,
-    InfoTooltipComponent,
   ],
   templateUrl: './project-settings-basic-information.component.html',
   providers: [ToastService],
@@ -83,78 +67,43 @@ export class ProjectSettingsBasicInformationComponent {
     }),
   );
 
-  formGroup = new FormGroup({
-    name: new FormControl('', {
-      nonNullable: true,
-      // eslint-disable-next-line @typescript-eslint/unbound-method -- https://github.com/typescript-eslint/typescript-eslint/issues/1929#issuecomment-618695608
-      validators: [Validators.required],
-    }),
-    description: new FormControl<string | undefined>(undefined, {
-      nonNullable: true,
-    }),
-    startDate: new FormControl<Date | undefined>(undefined, {
-      nonNullable: true,
-    }),
-    endDate: new FormControl<Date | undefined>(undefined, {
-      nonNullable: true,
-    }),
-    location: new FormControl<string | undefined>(undefined, {
-      nonNullable: true,
-    }),
-    targetNrRegistrations: new FormControl(0, {
-      nonNullable: true,
-      // eslint-disable-next-line @typescript-eslint/unbound-method -- https://github.com/typescript-eslint/typescript-eslint/issues/1929#issuecomment-618695608
-      validators: [Validators.required],
-    }),
-    validation: new FormControl(false, { nonNullable: true }),
-    enableScope: new FormControl(false, { nonNullable: true }),
-  });
+  readonly projectFormName =
+    viewChild<ProjectFormNameComponent>('projectFormName');
+  readonly projectFormInformation = viewChild<ProjectFormInformationComponent>(
+    'projectFormInformation',
+  );
 
-  formFieldErrors =
-    generateFieldErrors<ProjectSettingsBasicInformationFormGroup>(
-      this.formGroup,
-      {
-        name: genericFieldIsRequiredValidationMessage,
-        description: genericFieldIsRequiredValidationMessage,
-        startDate: genericFieldIsRequiredValidationMessage,
-        endDate: genericFieldIsRequiredValidationMessage,
-        location: genericFieldIsRequiredValidationMessage,
-        targetNrRegistrations: genericFieldIsRequiredValidationMessage,
-        validation: genericFieldIsRequiredValidationMessage,
-        enableScope: genericFieldIsRequiredValidationMessage,
-      },
-    );
+  readonly formGroup = computed(() => {
+    const nameGroup = this.projectFormName()?.formGroup;
+    const informationGroup = this.projectFormInformation()?.formGroup;
 
-  updateFormGroup = effect(() => {
-    if (!this.project.isSuccess()) {
-      return;
+    if (!nameGroup || !informationGroup) {
+      return undefined;
     }
 
-    const { startDate, endDate } = this.project.data();
-
-    this.formGroup.setValue({
-      name: this.project.data().titlePortal?.en ?? '',
-      description: this.project.data().description?.en,
-      startDate: startDate ? new Date(startDate) : undefined,
-      endDate: endDate ? new Date(endDate) : undefined,
-      location: this.project.data().location,
-      targetNrRegistrations: this.project.data().targetNrRegistrations ?? 0,
-      validation: this.project.data().validation,
-      enableScope: this.project.data().enableScope,
+    return new FormGroup({
+      nameGroup,
+      informationGroup,
     });
   });
 
   updateProjectMutation = injectMutation(() => ({
     mutationFn: async ({
-      name,
-      description,
-      startDate,
-      endDate,
-      location,
-      targetNrRegistrations,
-      validation,
-      enableScope,
-    }: ReturnType<ProjectSettingsBasicInformationFormGroup['getRawValue']>) =>
+      nameGroup: { name, description },
+      informationGroup: {
+        startDate,
+        endDate,
+        location,
+        targetNrRegistrations,
+        validation,
+        enableScope,
+      },
+    }: ReturnType<
+      FormGroup<{
+        nameGroup: ProjectNameFormGroup;
+        informationGroup: ProjectInformationFormGroup;
+      }>['getRawValue']
+    >) =>
       this.projectApiService.updateProject({
         projectId: this.projectId,
         projectPatch: {
@@ -181,12 +130,6 @@ export class ProjectSettingsBasicInformationComponent {
       void this.registrationsTableColumnService.invalidateCache(this.projectId);
     },
   }));
-
-  readonly tooltipTargetRegistrations = $localize`The amount of people/ households your project wishes to reach.`;
-  readonly tooltipValidationProcess = $localize`Turning on the validation option enables an additional registration status: "${REGISTRATION_STATUS_LABELS[RegistrationStatusEnum.validated]}".`;
-  readonly tooltipEnableScope = $localize`Scope allows you to control which team members have access to specific registrations, based on the scope they are assigned to in the project team's page.
-
-To use this feature, make sure scope is defined in your integrated Kobo form or Excel table.`;
 
   readonly projectBasicInformationData = computed(() => {
     const projectData = this.project.data();
@@ -222,21 +165,21 @@ To use this feature, make sure scope is defined in your integrated Kobo form or 
         value: projectData?.targetNrRegistrations,
         fullWidth: true,
         type: 'number',
-        tooltip: this.tooltipTargetRegistrations,
+        tooltip: PROJECT_FORM_TOOLTIPS.targetRegistrations,
       },
       {
         label: $localize`Enable validation`,
         value: projectData?.validation ?? false,
         fullWidth: true,
         type: 'boolean',
-        tooltip: this.tooltipValidationProcess,
+        tooltip: PROJECT_FORM_TOOLTIPS.validationProcess,
       },
       {
         label: $localize`Enable scope`,
         value: projectData?.enableScope ?? false,
         fullWidth: true,
         type: 'boolean',
-        tooltip: this.tooltipEnableScope,
+        tooltip: PROJECT_FORM_TOOLTIPS.enableScope,
       },
     ];
 

--- a/interfaces/portal/src/app/pages/project-settings-information/components/project-settings-budget/project-settings-budget.component.html
+++ b/interfaces/portal/src/app/pages/project-settings-information/components/project-settings-budget/project-settings-budget.component.html
@@ -5,9 +5,9 @@
   i18n-editPencilTitle
   [canEdit]="canEdit()"
   [(isEditing)]="isEditing"
-  [formGroup]="formGroup"
+  [formGroup]="formGroup()"
   [mutation]="updateProjectMutation"
-  [mutationData]="formGroup.getRawValue()"
+  [mutationData]="formGroup()?.getRawValue()"
 >
   @if (!isEditing()) {
     <app-data-list
@@ -15,78 +15,9 @@
       data-testid="project-budget-data-list"
     />
   } @else {
-    <ng-container [formGroup]="formGroup">
-      <div class="flex w-full flex-row gap-4 [&>*]:w-1/2">
-        <app-form-field-wrapper
-          label="Funds available"
-          i18n-label
-          [errorMessage]="formFieldErrors()('budget')"
-        >
-          <input
-            pInputText
-            type="number"
-            formControlName="budget"
-            placeholder="Funds available"
-            i18n-placeholder
-          />
-        </app-form-field-wrapper>
-        <app-form-field-wrapper
-          label="Currency"
-          i18n-label
-          [errorMessage]="formFieldErrors()('currency')"
-          [labelTooltip]="tooltipCurrency"
-          [isRequired]="true"
-        >
-          <p-select
-            [options]="currencies"
-            formControlName="currency"
-            [showClear]="false"
-            class="w-full"
-            [filter]="true"
-          />
-        </app-form-field-wrapper>
-      </div>
-      <app-form-field-wrapper
-        label="Payment frequency"
-        i18n-label
-        [errorMessage]="formFieldErrors()('distributionFrequency')"
-      >
-        <input
-          pInputText
-          type="text"
-          formControlName="distributionFrequency"
-          placeholder="Payment frequency"
-          i18n-placeholder
-        />
-      </app-form-field-wrapper>
-      <app-form-field-wrapper
-        label="Default transfers per registration"
-        i18n-label
-        [errorMessage]="formFieldErrors()('distributionDuration')"
-        [labelTooltip]="tooltipDistributionDuration"
-      >
-        <input
-          pInputText
-          type="number"
-          formControlName="distributionDuration"
-          placeholder="Default transfers per registration"
-          i18n-placeholder
-        />
-      </app-form-field-wrapper>
-      <app-form-field-wrapper
-        label="Fixed transfer value"
-        i18n-label
-        [errorMessage]="formFieldErrors()('fixedTransferValue')"
-        [isRequired]="true"
-      >
-        <input
-          pInputText
-          type="number"
-          formControlName="fixedTransferValue"
-          placeholder="Fixed transfer value"
-          i18n-placeholder
-        />
-      </app-form-field-wrapper>
-    </ng-container>
+    <app-project-form-budget
+      #projectFormBudget
+      [project]="project.data()"
+    />
   }
 </app-card-editable>

--- a/interfaces/portal/src/app/pages/project-settings-team/components/add-project-team-user-dialog/add-project-team-user-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/project-settings-team/components/add-project-team-user-dialog/add-project-team-user-dialog.component.ts
@@ -33,7 +33,7 @@ import { AuthService } from '~/services/auth.service';
 import { ToastService } from '~/services/toast.service';
 import {
   generateFieldErrors,
-  genericFieldIsRequiredValidationMessage,
+  genericValidationMessage,
 } from '~/utils/form-validation';
 
 type AddUserToTeamFormGroup =
@@ -100,8 +100,8 @@ export class AddProjectTeamUserDialogComponent {
   formFieldErrors = generateFieldErrors<AddUserToTeamFormGroup>(
     this.formGroup,
     {
-      userValue: genericFieldIsRequiredValidationMessage,
-      rolesValue: genericFieldIsRequiredValidationMessage,
+      userValue: genericValidationMessage,
+      rolesValue: genericValidationMessage,
       scopeValue: (control) => {
         if (!control.invalid) {
           return;

--- a/interfaces/portal/src/app/pages/projects-overview/components/create-project-dialog/create-project-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/projects-overview/components/create-project-dialog/create-project-dialog.component.ts
@@ -24,7 +24,7 @@ import { ProjectApiService } from '~/domains/project/project.api.service';
 import { ToastService } from '~/services/toast.service';
 import {
   generateFieldErrors,
-  genericFieldIsRequiredValidationMessage,
+  genericValidationMessage,
 } from '~/utils/form-validation';
 
 type CreateProjectFormGroup =
@@ -68,8 +68,8 @@ export class CreateProjectDialogComponent {
   formFieldErrors = generateFieldErrors<CreateProjectFormGroup>(
     this.formGroup,
     {
-      token: genericFieldIsRequiredValidationMessage,
-      assetId: genericFieldIsRequiredValidationMessage,
+      token: genericValidationMessage,
+      assetId: genericValidationMessage,
     },
   );
 

--- a/interfaces/portal/src/app/pages/users/components/add-user-dialog/add-user-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/users/components/add-user-dialog/add-user-dialog.component.ts
@@ -28,7 +28,7 @@ import { User } from '~/domains/user/user.model';
 import { ToastService } from '~/services/toast.service';
 import {
   generateFieldErrors,
-  genericFieldIsRequiredValidationMessage,
+  genericValidationMessage,
 } from '~/utils/form-validation';
 
 type AddUserToTeamFormGroup =
@@ -75,13 +75,8 @@ export class AddUserDialogComponent {
   formFieldErrors = generateFieldErrors<AddUserToTeamFormGroup>(
     this.formGroup,
     {
-      displayNameValue: genericFieldIsRequiredValidationMessage,
-      usernameValue: (control) => {
-        if (!control.invalid) {
-          return;
-        }
-        return $localize`Enter a valid email address`;
-      },
+      displayNameValue: genericValidationMessage,
+      usernameValue: genericValidationMessage,
     },
   );
 

--- a/interfaces/portal/src/app/utils/form-validation.ts
+++ b/interfaces/portal/src/app/utils/form-validation.ts
@@ -1,13 +1,31 @@
 import { computed } from '@angular/core';
 import { AbstractControl, FormGroup } from '@angular/forms';
 
-export const genericFieldIsRequiredValidationMessage = (
-  control: AbstractControl,
-) => {
+import { get } from 'radashi';
+
+export const genericValidationMessage = (control: AbstractControl) => {
   if (!control.invalid) {
     return;
   }
-  return $localize`:@@generic-required-field:This field is required.`;
+
+  if (control.errors?.min) {
+    const min = get(control.errors.min, 'min') ?? 0;
+    return $localize`This field needs to be at least ${min}.`;
+  }
+
+  if (control.errors?.email) {
+    return $localize`Enter a valid email address`;
+  }
+
+  if (control.errors?.required) {
+    return $localize`:@@generic-required-field:This field is required.`;
+  }
+
+  throw new Error(
+    `No validation message found for control with errors: ${JSON.stringify(
+      control.errors,
+    )}`,
+  );
 };
 
 export const generateFieldErrors = <T extends FormGroup>(

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -1748,9 +1748,6 @@
       <trans-unit id="3845427937485595400" datatype="html">
         <source>Enable scope</source>
       </trans-unit>
-      <trans-unit id="5927673166996679723" datatype="html">
-        <source>The amount of people/ households your project wishes to reach.</source>
-      </trans-unit>
       <trans-unit id="6001336690636833920" datatype="html">
         <source>Basic information details saved successfully.</source>
       </trans-unit>
@@ -1762,9 +1759,6 @@
       </trans-unit>
       <trans-unit id="7307016430178924629" datatype="html">
         <source>Hint text...</source>
-      </trans-unit>
-      <trans-unit id="1200281517601565877" datatype="html">
-        <source>The number of times each registration will receive transfers in the project as a default.</source>
       </trans-unit>
       <trans-unit id="3033425005384068594" datatype="html">
         <source>Budget details saved successfully.</source>
@@ -1778,9 +1772,6 @@
       <trans-unit id="462133179319783861" datatype="html">
         <source>Fixed transfer value</source>
       </trans-unit>
-      <trans-unit id="6007900356631079593" datatype="html">
-        <source>This needs to be at least 0.</source>
-      </trans-unit>
       <trans-unit id="7003847942368840790" datatype="html">
         <source>Funds available</source>
       </trans-unit>
@@ -1792,9 +1783,6 @@
       </trans-unit>
       <trans-unit id="1321992891688971593" datatype="html">
         <source>Use &quot;validation&quot; in this project</source>
-      </trans-unit>
-      <trans-unit id="3772482029498071398" datatype="html">
-        <source>Turning on the validation option enables an additional registration status: &quot;<x equiv-text="REGISTRATION_STATUS_LABELS[RegistrationStatusEnum.validated]" id="PH"/>&quot;.</source>
       </trans-unit>
       <trans-unit id="773471341435150258" datatype="html">
         <source>Enable validation</source>
@@ -1840,6 +1828,18 @@
       </trans-unit>
       <trans-unit id="message-content-type-new" datatype="html">
         <source>New</source>
+      </trans-unit>
+      <trans-unit id="3271775381612841661" datatype="html">
+        <source>This enables an additional registration status: &quot;<x equiv-text="REGISTRATION_STATUS_LABELS[RegistrationStatusEnum.validated]" id="PH"/>&quot;.</source>
+      </trans-unit>
+      <trans-unit id="4941441939532394435" datatype="html">
+        <source>This field needs to be at least <x equiv-text="min" id="PH"/>.</source>
+      </trans-unit>
+      <trans-unit id="5449434756196250816" datatype="html">
+        <source>The number of times a registration will receive transfers in the project by default.</source>
+      </trans-unit>
+      <trans-unit id="6415562046042900466" datatype="html">
+        <source>The amount of people/households your project plans to reach.</source>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
[AB#38218](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38218)

I'm pulling these forms out into separate components so they can eventually be re-used in the create project wizard.

I've separated these changes from the rest of the wizard because
- they can be merged in isolation without waiting for the wizard to be completed
- I think it might make this a bit easier to review without the "noise" of the wizard
- I want approval / review on this new pattern from multiple people - if this is approved, then it's "safe" to use in the wizard without further discussion

Some things that are new / I have doubts / I would like feedback on
- naming/placement of the new `project-form` components
- clarity of the new paradigm of extracting a formGroup from a child component
- anything else as per usual

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
  - I would like 2 approvals on this one to make sure it's seen / makes sense
- [x] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7293.westeurope.3.azurestaticapps.net
