### PR TITLE
Prevent duplicate message on fast consecutive yes replies

### DIFF
--- a/e2e/portal/tests/DebitCards/ManageDebitCards.spec.ts
+++ b/e2e/portal/tests/DebitCards/ManageDebitCards.spec.ts
@@ -51,7 +51,7 @@ test('[34619] User can view debit cards of a registration with a single active d
 
   await test.step('User can view current debit card data', async () => {
     const currentDate = new Date();
-    const currentDateString = format(currentDate, 'dd MMMM yyyy');
+    const currentDateString = format(currentDate, 'd MMMM yyyy');
     const expectedDebitCardData = {
       'Card number': expect.any(String),
       'Card status': 'Active',

--- a/e2e/portal/tests/ProjectSettings/ProjectInformation/EditProjectInformation.spec.ts
+++ b/e2e/portal/tests/ProjectSettings/ProjectInformation/EditProjectInformation.spec.ts
@@ -91,8 +91,8 @@ test('[38155] Edit Project Information', async ({ page }) => {
       expect(basicInformationData).toEqual({
         '*Project name': projectInfo.name,
         'Project description': projectInfo.description,
-        'Start date': format(projectInfo.dateRange.start, 'dd MMMM yyyy'),
-        'End date': format(projectInfo.dateRange.end, 'dd MMMM yyyy'),
+        'Start date': format(projectInfo.dateRange.start, 'd MMMM yyyy'),
+        'End date': format(projectInfo.dateRange.end, 'd MMMM yyyy'),
         Location: projectInfo.location,
         '*Target registrations': projectInfo.targetRegistrations,
         'Enable validation': 'No',

--- a/services/121-service/test/registrations/pagination/send-message.test.ts
+++ b/services/121-service/test/registrations/pagination/send-message.test.ts
@@ -228,4 +228,61 @@ describe('send arbitrary messages to set of registrations', () => {
       TwilioErrorCodes.toNumberDoesNotExist,
     );
   });
+
+  it('should not send message twice to the same registrations on fast consecutive requests', async () => {
+    // Arrange
+    const message = 'Send this message multiple times';
+    const finalMessage =
+      'Send this message at the end to check if all are complete, so we know we need to stop waiting';
+
+    // The choice for 5 is arbitrary, we just want to send it multiple times
+    // Without the fix the bug was not always triggered with 2 sends to we picked a higher number for now
+    const amountOfSends = 5;
+
+    // Act: Send the same message in fast consecutive requests
+
+    for (let i = 0; i < amountOfSends; i++) {
+      await sendMessage(
+        accessToken,
+        programIdOCW,
+        [registrationOCW1.referenceId],
+        message,
+      );
+    }
+
+    // Send a final message to know when to stop waiting
+    await sendMessage(
+      accessToken,
+      programIdOCW,
+      [registrationOCW1.referenceId],
+      finalMessage,
+    );
+
+    // Wait for all messages to complete
+    await waitForMessagesToComplete({
+      programId: programIdOCW,
+      referenceIds: [registrationOCW1.referenceId],
+      accessToken,
+      expectedMessageAttribute: {
+        key: 'body',
+        values: [finalMessage],
+      },
+    });
+
+    // Assert
+    const messageHistory = (
+      await getMessageHistory(
+        programIdOCW,
+        registrationOCW1.referenceId,
+        accessToken,
+      )
+    ).body;
+
+    // Filter message history to only include messages with body equal to message
+    const filteredMessageHistory = messageHistory.filter(
+      (msg) => msg.attributes.body === message,
+    );
+
+    expect(filteredMessageHistory.length).toBe(amountOfSends);
+  });
 });


### PR DESCRIPTION
[AB#38259](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38259) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your change

Prevent duplicate message on fast consecutive yes replies

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
- [x] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
