### PR TITLE
feat: Add "Cloud Role name" to all telemetry of the Portal

### DIFF
--- a/interfaces/portal/src/app/services/log.service.ts
+++ b/interfaces/portal/src/app/services/log.service.ts
@@ -39,6 +39,11 @@ export class LogService {
       },
     });
 
+    this.appInsights.addTelemetryInitializer((envelope) => {
+      if (!envelope.tags) return;
+      envelope.tags['ai.cloud.role'] = 'portal';
+      envelope.tags['ai.cloud.roleInstance'] = window.location.hostname;
+    });
     this.appInsights.loadAppInsights();
     this.appInsightsInitialized = true;
   }


### PR DESCRIPTION
So we can correlate it with requests to the API

[AB#37849](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37849)

## Describe your changes

See: https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-map?tabs=javascript#set-cloud-role-name

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] Adding tests is unnecessary/irrelevant
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7311.westeurope.3.azurestaticapps.net
