### PR TITLE
Fix query size eror on very large payments and enable related k6 test

### DIFF
--- a/k6/run-all-tests.sh
+++ b/k6/run-all-tests.sh
@@ -22,14 +22,6 @@ done
 echo ""
 
 for file in "${test_files[@]}"; do
-  # TODO: AB#38219 - fix failing test
-  # skip payment100kRegistrationIntersolveVisa.js for now as it is failing
-  if [[ $(basename "${file}") == "payment100kRegistrationIntersolveVisa.js" ]]; then
-    echo "Skipping failing test: ${file}"
-    continue
-  fi
-
-
   echo ::group::Running test: "${file}"
 
   echo "Creating log directory"

--- a/services/121-service/src/payments/services/payments-execution.service.ts
+++ b/services/121-service/src/payments/services/payments-execution.service.ts
@@ -158,7 +158,6 @@ export class PaymentsExecutionService {
           );
         });
     }
-
     return bulkActionResultPaymentDto;
   }
 

--- a/services/121-service/src/registration/services/registrations-bulk.service.ts
+++ b/services/121-service/src/registration/services/registrations-bulk.service.ts
@@ -335,23 +335,6 @@ export class RegistrationsBulkService {
     return query;
   }
 
-  public getRegistrationsForPaymentQuery(
-    referenceIds: string[],
-    dataFieldNames: string[],
-  ) {
-    return this.setQueryPropertiesBulkAction({
-      query: {
-        path: '',
-        filter: { referenceId: `$in:${referenceIds.join(',')}` },
-      },
-      includePaymentAttributes: true,
-      includeSendMessageProperties: false,
-      includeStatusChangeProperties: false,
-      usedPlaceholders: [],
-      selectColumns: dataFieldNames,
-    });
-  }
-
   private getStatusUpdateBaseQuery(
     allowedCurrentStatuses: RegistrationStatusEnum[],
     registrationStatus?: RegistrationStatusEnum,


### PR DESCRIPTION
[AB#38219](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38219) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

- Fixed an issue related to query size when doing a payment with 60k + registrations
  - Solution: filtering on referenceId in a querybuilder instead of using the pagination filter functionality
- Enable related k6 test


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
- [x] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
