### PR TITLE
Add E2E test for validating second payment

### DIFF
--- a/e2e/portal/pages/PaymentsPage.ts
+++ b/e2e/portal/pages/PaymentsPage.ts
@@ -128,6 +128,8 @@ class PaymentsPage extends BasePage {
     successfulTransfers,
     failedTransfers,
     currency = '€',
+    projectId,
+    paymentId = 1,
   }: {
     date: string;
     registrationsNumber: number;
@@ -135,20 +137,38 @@ class PaymentsPage extends BasePage {
     successfulTransfers: number;
     failedTransfers: number;
     currency?: string;
+    projectId: number;
+    paymentId?: number;
   }) {
-    const paymentTitle = await this.paymentTitle.textContent();
-    const includedRegistrationsElement = await this.paymentSummaryMetrics
+    // Locate the specific payment card using the payment link and then navigate to its ancestor card element
+    const card = this.page
+      .locator(`a[href="/en-GB/project/${projectId}/payments/${paymentId}"]`)
+      .locator('xpath=ancestor::*[@data-pc-name="card"]')
+      .getByTestId('payment-summary-metrics')
+      .locator('app-metric-container');
+
+    const paymentTitle = await this.page
+      .locator(`a[href="/en-GB/project/${projectId}/payments/${paymentId}"]`)
+      .getByTitle(date)
+      .textContent();
+
+    const includedRegistrationsElement = await card
       .filter({ hasText: 'Included reg.' })
       .textContent();
-    const totalAmountElement = await this.paymentSummaryMetrics
+
+    // Get the total amount element within the card
+    const totalAmountElement = await card
       .filter({ hasText: 'Expected total amount' })
       .textContent();
-    const successfulTransfersElement = await this.paymentSummaryMetrics
+
+    const successfulTransfersElement = await card
       .filter({ hasText: 'Amount successfully sent' })
       .textContent();
-    const failedTransfersElement = await this.paymentSummaryMetrics
+
+    const failedTransfersElement = await card
       .filter({ hasText: 'Failed transfers' })
       .textContent();
+
     // Validate payment title
     expect(paymentTitle).toContain(date);
     // Validate included registrations

--- a/e2e/portal/tests/DoPayment/DoFailedPaymentWithCbe.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoFailedPaymentWithCbe.spec.ts
@@ -69,6 +69,7 @@ test('[36101] Do failed payment for Cbe fsp', async ({ page }) => {
       successfulTransfers: 0,
       failedTransfers: numberOfPas,
       currency: CbeProgram.currency,
+      projectId: programIdCbe,
     });
   });
 });

--- a/e2e/portal/tests/DoPayment/DoFailedPaymentWithSafaricom.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoFailedPaymentWithSafaricom.spec.ts
@@ -79,6 +79,7 @@ test('[36096] Do failed payment for Safaricom fsp', async ({ page }) => {
       successfulTransfers: 0,
       failedTransfers: numberOfPas,
       currency: KRCSProgram.currency,
+      projectId: programIdSafaricom,
     });
   });
 });

--- a/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithCbe.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithCbe.spec.ts
@@ -79,6 +79,7 @@ test('[36081] Do successful payment for Cbe fsp', async ({ page }) => {
       successfulTransfers: defaultMaxTransferValue,
       failedTransfers: 0,
       currency: CbeProgram.currency,
+      projectId: programIdCbe,
     });
   });
 });

--- a/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithNedbank.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithNedbank.spec.ts
@@ -78,6 +78,7 @@ test('[36080] Do successful payment for Nedbank fsp', async ({ page }) => {
       successfulTransfers: defaultMaxTransferValue,
       failedTransfers: 0,
       currency: NedbankProgram.currencySymbol,
+      projectId: programIdNedbank,
     });
   });
 });

--- a/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithSafaricom.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithSafaricom.spec.ts
@@ -76,6 +76,7 @@ test('[36009] Do successful payment for Safaricom fsp', async ({ page }) => {
       successfulTransfers: defaultMaxTransferValue,
       failedTransfers: 0,
       currency: KRCSProgram.currency,
+      projectId: programIdSafaricom,
     });
   });
 });

--- a/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithVoucher.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithVoucher.spec.ts
@@ -70,6 +70,7 @@ test('[36008] Do successful payment for Voucher fsp', async ({ page }) => {
       registrationsNumber: numberOfPas,
       successfulTransfers: defaultMaxTransferValue,
       failedTransfers: 0,
+      projectId: programIdPV,
     });
   });
 });

--- a/e2e/portal/tests/ViewPayments/ValidateSecondPayment.spec.ts
+++ b/e2e/portal/tests/ViewPayments/ValidateSecondPayment.spec.ts
@@ -3,6 +3,10 @@ import { format } from 'date-fns';
 
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import NLRCProgram from '@121-service/src/seed-data/program/program-nlrc-ocw.json';
+import {
+  doPayment,
+  waitForPaymentTransactionsToComplete,
+} from '@121-service/test/helpers/program.helper';
 import { seedIncludedRegistrations } from '@121-service/test/helpers/registration.helper';
 import {
   getAccessToken,
@@ -14,13 +18,41 @@ import {
 } from '@121-service/test/registrations/pagination/pagination-data';
 
 import LoginPage from '@121-e2e/portal/pages/LoginPage';
-import PaymentPage from '@121-e2e/portal/pages/PaymentPage';
 import PaymentsPage from '@121-e2e/portal/pages/PaymentsPage';
+
+const transferValueForSecondPayment = 10;
 
 test.beforeEach(async ({ page }) => {
   await resetDB(SeedScript.nlrcMultiple, __filename);
   const accessToken = await getAccessToken();
   await seedIncludedRegistrations(registrationsVisa, programIdOCW, accessToken);
+  // do 1st payment
+  await doPayment({
+    programId: programIdOCW,
+    amount: 25,
+    referenceIds: registrationsVisa.map((reg) => reg.referenceId),
+    accessToken,
+  });
+  await waitForPaymentTransactionsToComplete({
+    programId: programIdOCW,
+    paymentReferenceIds: registrationsVisa.map((reg) => reg.referenceId),
+    accessToken,
+    maxWaitTimeMs: 2_000,
+  }); // wait for 1st payment to be processed
+  // do 2nd payment
+  await doPayment({
+    programId: programIdOCW,
+    amount: transferValueForSecondPayment,
+    referenceIds: registrationsVisa.map((reg) => reg.referenceId),
+    accessToken,
+  });
+  await waitForPaymentTransactionsToComplete({
+    programId: programIdOCW,
+    paymentReferenceIds: registrationsVisa.map((reg) => reg.referenceId),
+    accessToken,
+    maxWaitTimeMs: 2_000,
+    paymentId: 2,
+  }); // wait for 2nd payment to be processed
 
   // Login
   const loginPage = new LoginPage(page);
@@ -28,45 +60,31 @@ test.beforeEach(async ({ page }) => {
   await loginPage.login();
 });
 
-test('[31970] Do successful payment for Visa fsp', async ({ page }) => {
-  const paymentPage = new PaymentPage(page);
+test('[38338] Validate second payment is correctly displayed on payment card', async ({
+  page,
+}) => {
   const paymentsPage = new PaymentsPage(page);
   const projectTitle = NLRCProgram.titlePortal.en;
   const numberOfPas = registrationsVisa.length;
-  const defaultTransferValue = NLRCProgram.fixedTransferValue;
   const defaultMaxTransferValue = registrationsVisa.reduce((output, pa) => {
-    return output + pa.paymentAmountMultiplier * defaultTransferValue;
+    return output + pa.paymentAmountMultiplier * transferValueForSecondPayment;
   }, 0);
   const lastPaymentDate = `${format(new Date(), 'dd/MM/yyyy')}`;
 
-  await test.step('Navigate to Program payments', async () => {
+  await test.step('Navigate to payments', async () => {
     await paymentsPage.selectProgram(projectTitle);
-
     await paymentsPage.navigateToProgramPage('Payments');
   });
 
-  await test.step('Do payment', async () => {
-    await paymentsPage.createPayment();
-    await paymentsPage.startPayment();
-    // Assert redirection to payment overview page
-    await page.waitForURL((url) =>
-      url.pathname.startsWith(`/en-GB/project/${programIdOCW}/payments/1`),
-    );
-    // Assert payment overview page by payment date/ title
-    await paymentPage.validatePaymentsDetailsPageByDate(lastPaymentDate);
-  });
-
-  await test.step('Validate payment card', async () => {
-    await paymentPage.validateToastMessageAndClose('Payment created.');
-    await paymentPage.waitForPaymentToComplete();
-    await paymentPage.navigateToProgramPage('Payments');
+  await test.step('Validate 2nd payment card', async () => {
     await paymentsPage.validatePaymentCard({
       date: lastPaymentDate,
       paymentAmount: defaultMaxTransferValue,
       registrationsNumber: numberOfPas,
       successfulTransfers: defaultMaxTransferValue,
       failedTransfers: 0,
-      projectId: programIdOCW,
+      projectId: 3,
+      paymentId: 2,
     });
   });
 });


### PR DESCRIPTION
AB#38313 <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

- Updates test setup so now we can validate multiple payment  cards based on ```projectId``` and ```paymentId```
- Updates tests dependent on the assertion

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines
- [ ] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
