### PR TITLE
fix: Settings page permission is too strict

### DIFF
--- a/interfaces/portal/src/app/app.routes.ts
+++ b/interfaces/portal/src/app/app.routes.ts
@@ -149,7 +149,9 @@ export const routes: Routes = [
                 '~/pages/project-monitoring-files/project-monitoring-files.page'
               ).then((x) => x.ProjectMonitoringFilesPageComponent),
             canActivate: [
-              projectPermissionsGuard(PermissionEnum.ProgramAttachmentsREAD),
+              projectPermissionsGuard({
+                permission: PermissionEnum.ProgramAttachmentsREAD,
+              }),
             ],
           },
           {
@@ -174,7 +176,13 @@ export const routes: Routes = [
                 '~/pages/project-settings-information/project-settings-information.page'
               ).then((x) => x.ProjectSettingsInformationPageComponent),
             canActivate: [
-              projectPermissionsGuard(PermissionEnum.ProgramUPDATE),
+              projectPermissionsGuard({
+                permission: PermissionEnum.ProgramUPDATE,
+                fallbackRoute: [
+                  AppRoutes.projectSettings,
+                  AppRoutes.projectSettingsTeam,
+                ],
+              }),
             ],
           },
           {
@@ -188,7 +196,9 @@ export const routes: Routes = [
                 '~/pages/project-settings-team/project-settings-team.page'
               ).then((x) => x.ProjectSettingsTeamPageComponent),
             canActivate: [
-              projectPermissionsGuard(PermissionEnum.AidWorkerProgramREAD),
+              projectPermissionsGuard({
+                permission: PermissionEnum.AidWorkerProgramREAD,
+              }),
             ],
           },
           {

--- a/interfaces/portal/src/app/components/page-layout-project-settings/page-layout-project-settings.component.ts
+++ b/interfaces/portal/src/app/components/page-layout-project-settings/page-layout-project-settings.component.ts
@@ -55,7 +55,7 @@ export class PageLayoutProjectSettingsComponent {
       ],
       visible: this.authService.hasPermission({
         projectId: this.projectId(),
-        requiredPermission: PermissionEnum.AidWorkerProgramUPDATE,
+        requiredPermission: PermissionEnum.AidWorkerProgramREAD,
       }),
     },
   ]);

--- a/interfaces/portal/src/app/components/page-layout/components/project-menu/project-menu.component.ts
+++ b/interfaces/portal/src/app/components/page-layout/components/project-menu/project-menu.component.ts
@@ -46,6 +46,9 @@ export class ProjectMenuComponent {
     },
     {
       label: $localize`:@@page-title-project-settings:Settings`,
+      // We link to the root of the project settings page, which is currently
+      // not a page itself. We decide in app.routes.ts where to redirect to
+      // based on permissions.
       routerLink: `/${AppRoutes.project}/${this.projectId()}/${AppRoutes.projectSettings}`,
       styleClass: 'ms-auto',
       icon: 'pi pi-cog',

--- a/interfaces/portal/src/app/guards/project-permissions-guard.ts
+++ b/interfaces/portal/src/app/guards/project-permissions-guard.ts
@@ -8,9 +8,18 @@ import { AuthService } from '~/services/auth.service';
 
 export const PERMISSION_DENIED_QUERY_KEY = 'permissionDenied';
 
-export const projectPermissionsGuard: (
-  permission: PermissionEnum,
-) => CanActivateFn = (permission: PermissionEnum) =>
+interface projectPermissionsGuardType {
+  permission: PermissionEnum;
+  fallbackRoute?: string[];
+}
+
+export const projectPermissionsGuard: ({
+  permission,
+  fallbackRoute,
+}: projectPermissionsGuardType) => CanActivateFn = ({
+  permission,
+  fallbackRoute,
+}: projectPermissionsGuardType) =>
   function projectPermissionsCanActivateFn(route: ActivatedRouteSnapshot) {
     const authService = inject(AuthService);
 
@@ -20,6 +29,15 @@ export const projectPermissionsGuard: (
       authService.hasPermission({ projectId, requiredPermission: permission })
     ) {
       return true;
+    }
+
+    if (fallbackRoute) {
+      return inject(Router).createUrlTree([
+        '/',
+        AppRoutes.project,
+        projectId,
+        ...fallbackRoute,
+      ]);
     }
 
     return inject(Router).createUrlTree(['/', AppRoutes.project, projectId], {


### PR DESCRIPTION
AB#38382 <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Users with permission to see team page could not reach team page

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
- [x] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
