### PR TITLE
chore: prevent quirky undefined behaviour in FormControls

### DIFF
--- a/interfaces/portal/eslint-rules/no-form-control-undefined-value.js
+++ b/interfaces/portal/eslint-rules/no-form-control-undefined-value.js
@@ -1,0 +1,63 @@
+/**
+ * ESLint rule: no-form-control-undefined-value
+ *
+ * This rule prevents passing `undefined` as the first argument to Angular FormControl constructors.
+ *
+ * Problem:
+ * When you pass `undefined` as the first argument to FormControl, it can cause issues with Angular's
+ * reactive forms, where the value in `getRawValue()` or `controls[controlName].value` will be treated as
+ * `null` instead of `undefined` after initialization or reset.
+ *
+ * Sadly, the only way to avoid this is to use the object format for the first argument, like so:
+ *
+ * Instead of:
+ *   new FormControl(undefined, { nonNullable: true })
+ *
+ * Use:
+ *   new FormControl({ value: undefined, disabled: false }, { nonNullable: true })
+ *
+ * Reference: https://github.com/angular/angular/issues/40608
+ */
+
+module.exports = {
+  create(context) {
+    return {
+      NewExpression(node) {
+        // Check if this is a FormControl constructor call
+        if (
+          node.callee &&
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'FormControl' &&
+          node.arguments.length >= 1
+        ) {
+          const firstArg = node.arguments[0];
+
+          // Check if the first argument is undefined (identifier or literal)
+          if (
+            (firstArg.type === 'Identifier' && firstArg.name === 'undefined') ||
+            (firstArg.type === 'Literal' && firstArg.value === undefined)
+          ) {
+            context.report({
+              messageId: 'noUndefinedValue',
+              node: firstArg,
+            });
+          }
+        }
+      },
+    };
+  },
+  meta: {
+    docs: {
+      category: 'Possible Errors',
+      description:
+        'Disallow undefined as the first argument to FormControl constructor',
+    },
+    fixable: null,
+    messages: {
+      noUndefinedValue:
+        'Do not pass undefined as the first argument to FormControl. Use the second argument format instead: new FormControl({ value: undefined, disabled: false }, options)',
+    },
+    schema: [],
+    type: 'problem',
+  },
+};

--- a/interfaces/portal/eslint.config.mjs
+++ b/interfaces/portal/eslint.config.mjs
@@ -12,6 +12,16 @@ import eslintSortClassMembers from 'eslint-plugin-sort-class-members';
 import globals from 'globals';
 import tsEslint from 'typescript-eslint';
 
+// Import custom rule
+import noFormControlUndefinedValue from './eslint-rules/no-form-control-undefined-value.js';
+
+// Custom rules plugin
+const customRulesPlugin = {
+  rules: {
+    'no-form-control-undefined-value': noFormControlUndefinedValue,
+  },
+};
+
 export default tsEslint.config(
   {
     languageOptions: {
@@ -35,6 +45,7 @@ export default tsEslint.config(
     ],
     files: ['**/*.ts'],
     plugins: {
+      'custom-rules': customRulesPlugin,
       'eslint-comments': eslintPluginComments,
       'no-relative-import-paths': eslintPluginNoRelativePaths,
       perfectionist: eslintPluginPerfectionist,
@@ -80,6 +91,7 @@ export default tsEslint.config(
         },
       ],
       'arrow-body-style': 'error',
+      'custom-rules/no-form-control-undefined-value': 'error',
       'eslint-comments/require-description': 'error',
       'func-style': 'error',
       'max-params': ['error', 2],

--- a/interfaces/portal/src/app/components/project-form-budget/project-form-budget.component.ts
+++ b/interfaces/portal/src/app/components/project-form-budget/project-form-budget.component.ts
@@ -50,23 +50,35 @@ export class ProjectFormBudgetComponent {
     .sort((a, b) => a.label.localeCompare(b.label));
 
   formGroup = new FormGroup({
-    budget: new FormControl<number | undefined>(undefined, {
-      nonNullable: true,
-      validators: [Validators.min(0)],
-    }),
-    currency: new FormControl<CurrencyCode | undefined>(undefined, {
-      nonNullable: true,
-      // eslint-disable-next-line @typescript-eslint/unbound-method -- https://github.com/typescript-eslint/typescript-eslint/issues/1929#issuecomment-618695608
-      validators: [Validators.required],
-    }),
-    distributionFrequency: new FormControl<string | undefined>(undefined, {
-      nonNullable: true,
-      validators: [],
-    }),
-    distributionDuration: new FormControl<number | undefined>(undefined, {
-      nonNullable: true,
-      validators: [Validators.min(0)],
-    }),
+    budget: new FormControl<number | undefined>(
+      { value: undefined, disabled: false },
+      {
+        nonNullable: true,
+        validators: [Validators.min(0)],
+      },
+    ),
+    currency: new FormControl<CurrencyCode | undefined>(
+      { value: undefined, disabled: false },
+      {
+        nonNullable: true,
+        // eslint-disable-next-line @typescript-eslint/unbound-method -- https://github.com/typescript-eslint/typescript-eslint/issues/1929#issuecomment-618695608
+        validators: [Validators.required],
+      },
+    ),
+    distributionFrequency: new FormControl<string | undefined>(
+      { value: undefined, disabled: false },
+      {
+        nonNullable: true,
+        validators: [],
+      },
+    ),
+    distributionDuration: new FormControl<number | undefined>(
+      { value: undefined, disabled: false },
+      {
+        nonNullable: true,
+        validators: [Validators.min(0)],
+      },
+    ),
     fixedTransferValue: new FormControl(0, {
       nonNullable: true,
       // eslint-disable-next-line @typescript-eslint/unbound-method -- https://github.com/typescript-eslint/typescript-eslint/issues/1929#issuecomment-618695608

--- a/interfaces/portal/src/app/components/project-form-information/project-form-information.component.ts
+++ b/interfaces/portal/src/app/components/project-form-information/project-form-information.component.ts
@@ -45,15 +45,24 @@ export class ProjectFormInformationComponent {
   readonly project = input<Project>();
 
   formGroup = new FormGroup({
-    startDate: new FormControl<Date | undefined>(undefined, {
-      nonNullable: true,
-    }),
-    endDate: new FormControl<Date | undefined>(undefined, {
-      nonNullable: true,
-    }),
-    location: new FormControl<string | undefined>(undefined, {
-      nonNullable: true,
-    }),
+    startDate: new FormControl<Date | undefined>(
+      { value: undefined, disabled: false },
+      {
+        nonNullable: true,
+      },
+    ),
+    endDate: new FormControl<Date | undefined>(
+      { value: undefined, disabled: false },
+      {
+        nonNullable: true,
+      },
+    ),
+    location: new FormControl<string | undefined>(
+      { value: undefined, disabled: false },
+      {
+        nonNullable: true,
+      },
+    ),
     targetNrRegistrations: new FormControl(0, {
       nonNullable: true,
       // eslint-disable-next-line @typescript-eslint/unbound-method -- https://github.com/typescript-eslint/typescript-eslint/issues/1929#issuecomment-618695608

--- a/interfaces/portal/src/app/components/project-form-name/project-form-name.component.ts
+++ b/interfaces/portal/src/app/components/project-form-name/project-form-name.component.ts
@@ -45,9 +45,12 @@ export class ProjectFormNameComponent {
       // eslint-disable-next-line @typescript-eslint/unbound-method -- https://github.com/typescript-eslint/typescript-eslint/issues/1929#issuecomment-618695608
       validators: [Validators.required],
     }),
-    description: new FormControl<string | undefined>(undefined, {
-      nonNullable: true,
-    }),
+    description: new FormControl<string | undefined>(
+      { value: undefined, disabled: false },
+      {
+        nonNullable: true,
+      },
+    ),
   });
 
   formFieldErrors = generateFieldErrors<ProjectNameFormGroup>(this.formGroup, {

--- a/interfaces/portal/src/app/pages/project-payments/components/export-payments/export-payments.component.ts
+++ b/interfaces/portal/src/app/pages/project-payments/components/export-payments/export-payments.component.ts
@@ -76,8 +76,14 @@ export class ExportPaymentsComponent {
   ExportType = ExportType;
 
   paymentRangeFormGroup = new FormGroup({
-    fromDate: new FormControl<Date | undefined>(undefined, {}),
-    toDate: new FormControl<Date | undefined>(undefined, {}),
+    fromDate: new FormControl<Date | undefined>(
+      { value: undefined, disabled: false },
+      {},
+    ),
+    toDate: new FormControl<Date | undefined>(
+      { value: undefined, disabled: false },
+      {},
+    ),
   });
 
   exportByTypeMutation = injectMutation(() =>

--- a/interfaces/portal/src/app/pages/project-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.ts
+++ b/interfaces/portal/src/app/pages/project-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.ts
@@ -44,14 +44,17 @@ export class ChangeStatusContentsWithCustomMessageComponent implements OnInit {
   readonly customMessageUpdated = output<string>();
 
   formGroup = new FormGroup({
-    customMessage: new FormControl<string | undefined>(undefined, {
-      nonNullable: true,
-      validators: [
-        // eslint-disable-next-line @typescript-eslint/unbound-method -- https://github.com/typescript-eslint/typescript-eslint/issues/1929#issuecomment-618695608
-        Validators.required,
-        Validators.minLength(20),
-      ],
-    }),
+    customMessage: new FormControl<string | undefined>(
+      { value: undefined, disabled: false },
+      {
+        nonNullable: true,
+        validators: [
+          // eslint-disable-next-line @typescript-eslint/unbound-method -- https://github.com/typescript-eslint/typescript-eslint/issues/1929#issuecomment-618695608
+          Validators.required,
+          Validators.minLength(20),
+        ],
+      },
+    ),
   });
   readonly previewData = signal<Partial<MessageInputData> | undefined>(
     undefined,

--- a/interfaces/portal/src/app/pages/project-registrations/components/export-registrations/export-registrations.component.ts
+++ b/interfaces/portal/src/app/pages/project-registrations/components/export-registrations/export-registrations.component.ts
@@ -90,8 +90,14 @@ export class ExportRegistrationsComponent {
   });
 
   dataChangesFormGroup = new FormGroup({
-    fromDate: new FormControl<Date | undefined>(undefined, {}),
-    toDate: new FormControl<Date | undefined>(undefined, {}),
+    fromDate: new FormControl<Date | undefined>(
+      { value: undefined, disabled: false },
+      {},
+    ),
+    toDate: new FormControl<Date | undefined>(
+      { value: undefined, disabled: false },
+      {},
+    ),
   });
 
   exportByTypeMutation = injectMutation(() =>

--- a/interfaces/portal/src/app/pages/project-registrations/components/send-message-dialog/send-message-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/project-registrations/components/send-message-dialog/send-message-dialog.component.ts
@@ -96,12 +96,21 @@ export class SendMessageDialogComponent
       // eslint-disable-next-line @typescript-eslint/unbound-method -- https://github.com/typescript-eslint/typescript-eslint/issues/1929#issuecomment-618695608
       validators: [Validators.required],
     }),
-    messageTemplateKey: new FormControl<string | undefined>(undefined, {
-      nonNullable: true,
-    }),
-    customMessage: new FormControl<string | undefined>(undefined, {
-      nonNullable: true,
-    }),
+    messageTemplateKey: new FormControl<string | undefined>(
+      { value: undefined, disabled: false },
+      {
+        nonNullable: true,
+      },
+    ),
+    customMessage: new FormControl<string | undefined>(
+      {
+        value: undefined,
+        disabled: false,
+      },
+      {
+        nonNullable: true,
+      },
+    ),
   });
 
   formFieldErrors = generateFieldErrors<SendMessageFormGroup>(this.formGroup, {


### PR DESCRIPTION
[AB#38421](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38421)

## Describe your changes

- Add custom ESLint rule 'no-form-control-undefined-value' to prevent passing undefined as the first argument to FormControl constructors
- Move rule to separate file with documentation explaining the Angular issue (https://github.com/angular/angular/issues/40608)
- Update FormControl usage in 8 component files to follow the recommended pattern

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
- [x] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7364.westeurope.3.azurestaticapps.net
