### PR TITLE
fix: Prevent broken-up sentences and incorrect/partial translations

### DIFF
--- a/interfaces/portal/src/app/pages/project-registrations/components/export-registrations/export-registrations.component.html
+++ b/interfaces/portal/src/app/pages/project-registrations/components/export-registrations/export-registrations.component.html
@@ -25,22 +25,24 @@
       >{{ exportSelectedActionData()?.count }} selected registration(s)</strong
     >.
   </p>
-  <p class="mt-2">
-    <ng-container i18n>
-      Only the columns that are currently visible in the table will be included.
-      You can learn how to show or hide columns in the
-    </ng-container>
+  <ng-template #manualLink>
     <a
       href="https://manual.121.global/"
       target="_blank"
       title="Opens in a new window"
       i18n-title="@@generic-opens-in-new-window"
-      class="p-button p-button-link"
-    >
-      <ng-container i18n>manual</ng-container>
-      <span class="p-button-icon pi pi-external-link text-sm"></span>
-    </a>
-    .
+      class="p-button p-button-link gap-1"
+      ><span i18n="@@generic-121-manual-title">121 Manual</span>
+      <span class="p-button-icon pi pi-external-link text-sm"></span
+    ></a>
+  </ng-template>
+  <p
+    class="mt-2"
+    i18n
+  >
+    Only the columns that are currently visible in the table will be included.
+    You can learn how to show or hide columns in the
+    <ng-container [ngTemplateOutlet]="manualLink"></ng-container>.
   </p>
 
   <strong

--- a/interfaces/portal/src/app/pages/project-registrations/components/export-registrations/export-registrations.component.ts
+++ b/interfaces/portal/src/app/pages/project-registrations/components/export-registrations/export-registrations.component.ts
@@ -1,3 +1,4 @@
+import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -47,6 +48,7 @@ import {
     ReactiveFormsModule,
     FormFieldWrapperComponent,
     RadioButtonModule,
+    NgTemplateOutlet,
   ],
   templateUrl: './export-registrations.component.html',
   styles: ``,

--- a/interfaces/portal/src/app/pages/project-registrations/project-registrations.page.html
+++ b/interfaces/portal/src/app/pages/project-registrations/project-registrations.page.html
@@ -123,23 +123,24 @@
           </span>
         </div>
 
-        <p
-          i18n
-          class="mt-4"
-        >
-          There are no registrations in this project yet.<br />
-          For information about importing registrations to your project check
-          out the
+        <ng-template #manualLink>
           <a
             href="https://manual.121.global/"
             target="_blank"
             title="Opens in a new window"
             i18n-title="@@generic-opens-in-new-window"
             class="p-button p-button-link gap-1"
-          >
-            121 Manual
-            <span class="p-button-icon pi pi-external-link text-sm"></span> </a
-          >.
+            ><span i18n="@@generic-121-manual-title">121 Manual</span>
+            <span class="p-button-icon pi pi-external-link text-sm"></span
+          ></a>
+        </ng-template>
+        <p
+          i18n
+          class="mt-4"
+        >
+          There are no registrations in this project yet.<br />
+          For information about importing registrations to your project check
+          out the <ng-container [ngTemplateOutlet]="manualLink"></ng-container>.
         </p></ng-template
       >
     </app-registrations-table>

--- a/interfaces/portal/src/app/pages/project-registrations/project-registrations.page.ts
+++ b/interfaces/portal/src/app/pages/project-registrations/project-registrations.page.ts
@@ -1,3 +1,4 @@
+import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -55,6 +56,7 @@ import { getOriginUrl } from '~/utils/url-helper';
     RegistrationsTableComponent,
     TranslatableStringPipe,
     ImportRegistrationsMenuComponent,
+    NgTemplateOutlet,
   ],
   providers: [ToastService],
   templateUrl: './project-registrations.page.html',

--- a/interfaces/portal/src/app/pages/project-settings-team/components/add-project-team-user-dialog/add-project-team-user-dialog.component.html
+++ b/interfaces/portal/src/app/pages/project-settings-team/components/add-project-team-user-dialog/add-project-team-user-dialog.component.html
@@ -19,18 +19,21 @@
         your project team.</ng-container
       >
     }
-    <br /><ng-container i18n="@@info-in-manual">
-      For more information see the
+    <br />
+    <ng-template #manualLink>
       <a
         href="https://manual.121.global/"
         target="_blank"
         title="Opens in a new window"
         i18n-title="@@generic-opens-in-new-window"
         class="p-button p-button-link gap-1"
-      >
-        121 Manual
-        <span class="p-button-icon pi pi-external-link text-sm"></span> </a
-      >.
+        ><span i18n="@@generic-121-manual-title">121 Manual</span>
+        <span class="p-button-icon pi pi-external-link text-sm"></span
+      ></a>
+    </ng-template>
+    <ng-container i18n="@@generic-more-info-in-manual">
+      For more information see the
+      <ng-container [ngTemplateOutlet]="manualLink"></ng-container>.
     </ng-container>
   </p>
   <app-form-field-wrapper

--- a/interfaces/portal/src/app/pages/project-settings-team/components/add-project-team-user-dialog/add-project-team-user-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/project-settings-team/components/add-project-team-user-dialog/add-project-team-user-dialog.component.ts
@@ -1,3 +1,4 @@
+import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -46,6 +47,7 @@ import { generateFieldErrors } from '~/utils/form-validation';
     MultiSelectModule,
     InputTextModule,
     ReactiveFormsModule,
+    NgTemplateOutlet,
   ],
 })
 export class AddProjectTeamUserDialogComponent {

--- a/interfaces/portal/src/app/pages/users/components/add-user-dialog/add-user-dialog.component.html
+++ b/interfaces/portal/src/app/pages/users/components/add-user-dialog/add-user-dialog.component.html
@@ -14,18 +14,20 @@
       >Add a user to the 121 platform. Fill in the fields below to create a new
       user account.</ng-container
     ><br />
-    <ng-container i18n="@@info-in-manual">
-      For more information see the
+    <ng-template #manualLink>
       <a
         href="https://manual.121.global/"
         target="_blank"
         title="Opens in a new window"
         i18n-title="@@generic-opens-in-new-window"
         class="p-button p-button-link gap-1"
-      >
-        121 Manual
-        <span class="p-button-icon pi pi-external-link text-sm"></span> </a
-      >.
+        ><span i18n="@@generic-121-manual-title">121 Manual</span>
+        <span class="p-button-icon pi pi-external-link text-sm"></span
+      ></a>
+    </ng-template>
+    <ng-container i18n="@@generic-more-info-in-manual">
+      For more information see the
+      <ng-container [ngTemplateOutlet]="manualLink"></ng-container>.
     </ng-container>
   </p>
   <app-form-field-wrapper

--- a/interfaces/portal/src/app/pages/users/components/add-user-dialog/add-user-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/users/components/add-user-dialog/add-user-dialog.component.ts
@@ -1,3 +1,4 @@
+import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -39,6 +40,7 @@ import { generateFieldErrors } from '~/utils/form-validation';
     FormFieldWrapperComponent,
     InputTextModule,
     ReactiveFormsModule,
+    NgTemplateOutlet,
   ],
 })
 export class AddUserDialogComponent {

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -1138,9 +1138,6 @@
       <trans-unit id="5452570589103987928" datatype="html">
         <source>Payment status chart.</source>
       </trans-unit>
-      <trans-unit id="2982203751444563776" datatype="html">
-        <source>There are no registrations in this project yet.<x ctype="lb" equiv-text="&lt;br /&gt;" id="LINE_BREAK"/> For information about importing registrations to your project check out the <x ctype="x-a" equiv-text="&lt;a href=&quot;https://manual.121.global/&quot; target=&quot;_blank&quot; title=&quot;Opens in a new window&quot; i18n-title=&quot;@@generic-opens-in-new-window&quot; class=&quot;p-button p-button-link gap-1&quot; &gt;" id="START_LINK"/> 121 Manual <x ctype="x-span" equiv-text="&lt;span class=&quot;p-button-icon pi pi-external-link text-sm&quot;&gt;" id="START_TAG_SPAN"/><x ctype="x-span" equiv-text="&lt;/span&gt;" id="CLOSE_TAG_SPAN"/><x ctype="x-a" equiv-text="&lt;/a &gt;" id="CLOSE_LINK"/>.</source>
-      </trans-unit>
       <trans-unit id="37959892232763790" datatype="html">
         <source>Welcome to <x equiv-text="{{ project.data()?.titlePortal | translatableString }}" id="INTERPOLATION"/></source>
       </trans-unit>
@@ -1574,9 +1571,6 @@
       <trans-unit id="7088714514100361567" datatype="html">
         <source>Equal to</source>
       </trans-unit>
-      <trans-unit id="4874025357079324070" datatype="html">
-        <source>Only the columns that are currently visible in the table will be included. You can learn how to show or hide columns in the</source>
-      </trans-unit>
       <trans-unit id="1053772170616919441" datatype="html">
         <source>You&apos;re about to download an Excel file with all of the registrations included in payments.</source>
       </trans-unit>
@@ -1684,9 +1678,6 @@
       </trans-unit>
       <trans-unit id="9048541856160254605" datatype="html">
         <source>Add user to 121</source>
-      </trans-unit>
-      <trans-unit id="info-in-manual" datatype="html">
-        <source>For more information see the <x ctype="x-a" equiv-text="&lt;a href=&quot;https://manual.121.global/&quot; target=&quot;_blank&quot; title=&quot;Opens in a new window&quot; i18n-title=&quot;@@generic-opens-in-new-window&quot; class=&quot;p-button p-button-link gap-1&quot; &gt;" id="START_LINK"/> 121 Manual <x ctype="x-span" equiv-text="&lt;span class=&quot;p-button-icon pi pi-external-link text-sm&quot;&gt;" id="START_TAG_SPAN"/><x ctype="x-span" equiv-text="&lt;/span&gt;" id="CLOSE_TAG_SPAN"/><x ctype="x-a" equiv-text="&lt;/a &gt;" id="CLOSE_LINK"/>.</source>
       </trans-unit>
       <trans-unit id="3063750609223607355" datatype="html">
         <source>Add to team</source>
@@ -1846,6 +1837,18 @@
       </trans-unit>
       <trans-unit id="1581201431976430187" datatype="html">
         <source>This field cannot be more than <x equiv-text="max" id="PH"/>.</source>
+      </trans-unit>
+      <trans-unit id="generic-121-manual-title" datatype="html">
+        <source>121 Manual</source>
+      </trans-unit>
+      <trans-unit id="3671758184194478074" datatype="html">
+        <source>Only the columns that are currently visible in the table will be included. You can learn how to show or hide columns in the <x ctype="x-ng_container" equiv-text="&lt;ng-container [ngTemplateOutlet]=&quot;manualLink&quot;&gt;" id="START_TAG_NG_CONTAINER"/><x ctype="x-ng_container" equiv-text="&lt;/ng-container&gt;" id="CLOSE_TAG_NG_CONTAINER"/>.</source>
+      </trans-unit>
+      <trans-unit id="6912528976135991062" datatype="html">
+        <source>There are no registrations in this project yet.<x ctype="lb" equiv-text="&lt;br /&gt;" id="LINE_BREAK"/> For information about importing registrations to your project check out the <x ctype="x-ng_container" equiv-text="&lt;ng-container [ngTemplateOutlet]=&quot;manualLink&quot;&gt;" id="START_TAG_NG_CONTAINER"/><x ctype="x-ng_container" equiv-text="&lt;/ng-container&gt;" id="CLOSE_TAG_NG_CONTAINER"/>.</source>
+      </trans-unit>
+      <trans-unit id="generic-more-info-in-manual" datatype="html">
+        <source>For more information see the <x ctype="x-ng_container" equiv-text="&lt;ng-container [ngTemplateOutlet]=&quot;manualLink&quot;&gt;" id="START_TAG_NG_CONTAINER"/><x ctype="x-ng_container" equiv-text="&lt;/ng-container&gt;" id="CLOSE_TAG_NG_CONTAINER"/>.</source>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
[AB#38448](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38448)

## Describe your changes

Using the existing syntax of the "outer" sentence, it wasn't possible to properly (auto-)translate.

Not the "translated-bits-inside-translated-bits-inside-a-sentence" is handles as a special piece of the template(s)


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] Adding tests is unnecessary/irrelevant
  - Although... some magical lint-rule would be nice. ;)
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7376.westeurope.3.azurestaticapps.net
