### PR TITLE
chore: minor TS improvement in Pipe

### DIFF
--- a/services/121-service/src/pipes/assert-iso8601.pipe.ts
+++ b/services/121-service/src/pipes/assert-iso8601.pipe.ts
@@ -28,15 +28,13 @@ export class AssertIso8601Pipe implements PipeTransform<string> {
   }
 
   public transform(value?: string): string | undefined {
-    if (isNil(value) && this.options.optional) {
-      return value;
-    }
+    if (isNil(value)) {
+      if (this.options.optional) {
+        return value;
+      }
 
-    if (!this.options.optional && isNil(value)) {
       throw this.exceptionFactory('Validation failed (date string expected)');
     }
-
-    value = value as string;
 
     if (!isISO8601(value)) {
       throw this.exceptionFactory(


### PR DESCRIPTION
[AB#38532](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38532)

## Describe your changes

This change prevents the need for casting `value` to `string` through the use of the `as` keyword.

This is possible because the return type of `isNil` is a [type predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates)

<img width="342" height="52" alt="image" src="https://github.com/user-attachments/assets/d653d6d7-e7e9-4a5e-8f85-ce530720f724" />


So, typescript can infer that anything beyond `isNil(value)` is definitely not `null` and not `undefined`. **However, this only works if `isNil(value)` is checked alone, otherwise Typescript cannot guarantee this.**

### Before

When hovering on `value`:

<img width="442" height="290" alt="image" src="https://github.com/user-attachments/assets/887adb26-a6f4-4f10-b4d7-fb275214c0e4" />

### After

When hovering on `value`:

<img width="404" height="293" alt="image" src="https://github.com/user-attachments/assets/653df737-8af0-4186-99e1-e4f98ee03826" />

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
- [x] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
