### PR TITLE
improve VS Code shared settings - language-specific formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,11 +21,7 @@
       "severity": "info"
     }
   ],
-  "eslint.workingDirectories": [
-    {
-      "mode": "auto"
-    }
-  ],
+  "eslint.workingDirectories": [{ "mode": "auto" }],
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit",
     "source.removeUnusedImports": "explicit"

--- a/e2e/.vscode/settings.json
+++ b/e2e/.vscode/settings.json
@@ -1,5 +1,17 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit",
     "source.removeUnusedImports": "explicit"

--- a/interfaces/portal/.vscode/settings.json
+++ b/interfaces/portal/.vscode/settings.json
@@ -1,5 +1,17 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit",
     "source.removeUnusedImports": "explicit"

--- a/services/121-service/.vscode/settings.json
+++ b/services/121-service/.vscode/settings.json
@@ -1,5 +1,17 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "eslint.enable": true,
   "eslint.format.enable": true,
   "eslint.rules.customizations": [

--- a/services/mock-service/.vscode/settings.json
+++ b/services/mock-service/.vscode/settings.json
@@ -1,5 +1,17 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "eslint.enable": true,
   "eslint.format.enable": true,
   "eslint.rules.customizations": [


### PR DESCRIPTION
[AB#38285](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38285) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

1. Saving `.vscode/settings.json` formatted it so separate commit.
2. Actual work: user-level language-specific settings take precedence over workspace level language-**a**-specific settings. So add workspace language-specific settings to win that race.


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
- [x] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7394.westeurope.3.azurestaticapps.net
