### PR TITLE
chore: better error handling in portal

### DIFF
--- a/e2e/portal/tests/ChangePassword/CurrentPasswordIncorrect.spec.ts
+++ b/e2e/portal/tests/ChangePassword/CurrentPasswordIncorrect.spec.ts
@@ -38,7 +38,7 @@ test('[29310] Change password unsuccessfully (Non-matching passwords)', async ({
     });
     await changePasswordPage.submitChangePassword();
     await changePasswordPage.validateFormError({
-      errorText: 'Something went wrong: Your password was incorrect.',
+      errorText: 'Something went wrong: "Your password was incorrect."',
     });
   });
 });

--- a/e2e/portal/tests/CreateNewProject/FillInInvalidToken.spec.ts
+++ b/e2e/portal/tests/CreateNewProject/FillInInvalidToken.spec.ts
@@ -39,7 +39,7 @@ test('[29636] Fill in with invalid Token', async ({ page }) => {
     });
     await createProject.submitForm();
     await createProject.validateFormError({
-      errorText: 'Something went wrong: Invalid token.',
+      errorText: 'Something went wrong: "Invalid token."',
     });
   });
 });

--- a/e2e/portal/tests/ProjectLevelAttachments/AddAttachmentsOnProjectLevel.spec.ts
+++ b/e2e/portal/tests/ProjectLevelAttachments/AddAttachmentsOnProjectLevel.spec.ts
@@ -105,7 +105,8 @@ test.describe('Attachments on Project Level', () => {
 
     await test.step('Validate wrong file format error message', async () => {
       await projectMonitoring.validateFormError({
-        errorText: 'Something went wrong: Validation failed',
+        errorText:
+          'Something went wrong: "Validation failed (invalid file type)"',
       });
     });
   });
@@ -123,7 +124,7 @@ test.describe('Attachments on Project Level', () => {
     await test.step('Validate file size error message', async () => {
       await projectMonitoring.validateFormError({
         errorText:
-          'Something went wrong: Validation failed (current file size is 110100480, expected size is less than 100000000)',
+          'Something went wrong: "Validation failed (current file size is 110100480, expected size is less than 100000000)"',
       });
     });
   });

--- a/e2e/portal/tests/UpdateRegistrations/UpdateRegistrationsUnsuccessfully.spec.ts
+++ b/e2e/portal/tests/UpdateRegistrations/UpdateRegistrationsUnsuccessfully.spec.ts
@@ -60,7 +60,7 @@ test('[36351] Wrong CSV should trigger error (wrong data, column name etc.)', as
 
   await test.step('Validate import error message', async () => {
     await registrationsPage.validateErrorMessage(
-      `Something went wrong: The following referenceIds were not found in the database: ${fakeReferenceId}`,
+      `Something went wrong: "The following referenceIds were not found in the database: ${fakeReferenceId}"`,
     );
   });
 });

--- a/e2e/portal/tests/ViewPayment/ErrorOnMissinCollumnMatchConfiguration.spec.ts
+++ b/e2e/portal/tests/ViewPayment/ErrorOnMissinCollumnMatchConfiguration.spec.ts
@@ -77,7 +77,7 @@ test('[32302] [Excel fsp]: Error message should be shown in case no matching col
     });
     await paymentsPage.startPayment();
     await paymentsPage.validateToastMessage(
-      'Something went wrong: Missing required configuration columnToMatch for FSP Excel',
+      'Something went wrong: "Missing required configuration columnToMatch for FSP Excel"',
     );
   });
 });

--- a/interfaces/portal/src/app/services/http-wrapper.service.ts
+++ b/interfaces/portal/src/app/services/http-wrapper.service.ts
@@ -120,7 +120,7 @@ export class HttpWrapperService {
     if (errorMessage) {
       return of(
         new Error(
-          $localize`:@@generic-error-with-message:Something went wrong: ${errorMessage}:errorMessage:`,
+          $localize`:@@generic-error-with-message:Something went wrong: ${JSON.stringify(errorMessage)}:errorMessage:`,
         ),
       );
     }

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -731,7 +731,7 @@
         <source>Token expired</source>
       </trans-unit>
       <trans-unit id="generic-error-with-message" datatype="html">
-        <source>Something went wrong: <x equiv-text="errorMessage" id="errorMessage"/></source>
+        <source>Something went wrong: <x equiv-text="JSON.stringify(errorMessage)" id="errorMessage"/></source>
       </trans-unit>
       <trans-unit id="1070128073768279969" datatype="html">
         <source>Select a message from the template messages or write a custom message.</source>

--- a/services/121-service/src/programs/program-attachments/program-attachments.controller.ts
+++ b/services/121-service/src/programs/program-attachments/program-attachments.controller.ts
@@ -85,7 +85,7 @@ export class ProgramAttachmentsController {
       'application/pdf',
     ];
     if (!allowedMimeTypes.includes(file.mimetype)) {
-      throw new BadRequestException('Something went wrong: Validation failed');
+      throw new BadRequestException('Validation failed (invalid file type)');
     }
 
     const userId = RequestHelper.getUserId(req);


### PR DESCRIPTION
[AB#38599](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38599)

Spin-off from #7383

Whilst working on #7383, I realised some errors from the BE were being swallowed in the frontend. An easy fix was to introduce this `JSON.stringify` in the error handler.

When the errorMessage we've extracted is a string, it just adds double quotes around it, but then when it is an object it will output the contents of the object, rather than
`[Object object]` which is what I was seeing before.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
- [x] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7401.westeurope.3.azurestaticapps.net
