### PR TITLE
delete jumbo

### DIFF
--- a/services/121-service/src/fsps/enums/fsp-name.enum.ts
+++ b/services/121-service/src/fsps/enums/fsp-name.enum.ts
@@ -6,8 +6,6 @@ export enum Fsps {
   airtel = 'Airtel',
   commercialBankEthiopia = 'Commercial-bank-ethiopia',
   excel = 'Excel',
-  // TODO AB#38595 remove this deprecated FSP
-  deprecatedJumbo = 'Intersolve-jumbo-physical',
   nedbank = 'Nedbank',
   onafriq = 'Onafriq',
 }

--- a/services/121-service/src/fsps/fsp-settings.const.ts
+++ b/services/121-service/src/fsps/fsp-settings.const.ts
@@ -232,13 +232,4 @@ export const FSP_SETTINGS: Record<Fsps, FspDto> = {
       },
     ],
   },
-  [Fsps.deprecatedJumbo]: {
-    name: Fsps.deprecatedJumbo,
-    integrationType: FspIntegrationType.api,
-    defaultLabel: {
-      en: 'Jumbo (DO NOT USE - deprecated)',
-    },
-    attributes: [],
-    configurationProperties: [],
-  },
 };

--- a/services/121-service/src/fsps/fsp.service.ts
+++ b/services/121-service/src/fsps/fsp.service.ts
@@ -19,8 +19,6 @@ export class FspsService {
   }
 
   public async getAllFsps(): Promise<FspDto[]> {
-    return Object.values(FSP_SETTINGS).filter(
-      (fsp) => fsp.name !== Fsps.deprecatedJumbo,
-    );
+    return Object.values(FSP_SETTINGS);
   }
 }


### PR DESCRIPTION
[AB#38595](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38595)

## Describe your changes

- delete deprecated jumbo reference in code
- there is already no jumbo fspconfig or references to it in database any more (deleted in 1734524945346-MakeProgramFspConfigNullableForeignKey migration)

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
- [x] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
