### PR TITLE
feat: project settings -> registration data page

### DIFF
--- a/interfaces/portal/src/app/app.routes.ts
+++ b/interfaces/portal/src/app/app.routes.ts
@@ -29,6 +29,7 @@ export enum AppRoutes {
   projectSettings = 'settings',
   projectSettingsFsps = 'fsps',
   projectSettingsInformation = 'information',
+  projectSettingsRegistrationData = 'registration-data',
   projectSettingsTeam = 'team',
   registrationByReferenceId = 'registration-by-reference-id',
   registrationLookup = 'registration-lookup',
@@ -196,6 +197,20 @@ export const routes: Routes = [
               import(
                 '~/pages/project-settings-fsps/project-settings-fsps.page'
               ).then((x) => x.ProjectSettingsFspsPageComponent),
+            canActivate: [
+              authCapabilitiesGuard((authService) => authService.isAdmin),
+            ],
+          },
+          {
+            path: AppRoutes.projectSettingsRegistrationData,
+            title:
+              $localize`:@@page-title-project-settings-registration-data:Registration data` +
+              ' | ' +
+              $localize`:@@page-title-project-settings:Project settings`,
+            loadComponent: () =>
+              import(
+                '~/pages/project-settings-registration-data/project-settings-registration-data.page'
+              ).then((x) => x.ProjectSettingsRegistrationDataPageComponent),
             canActivate: [
               authCapabilitiesGuard((authService) => authService.isAdmin),
             ],

--- a/interfaces/portal/src/app/app.theme.ts
+++ b/interfaces/portal/src/app/app.theme.ts
@@ -195,6 +195,9 @@ const AppTheme = definePreset(Aura, {
         hoverColor: colors.grey[700],
         hoverBorderColor: colors.grey[700],
       },
+      tabpanel: {
+        padding: '1rem 0 0',
+      },
     },
     toast: {
       colorScheme: {

--- a/interfaces/portal/src/app/components/page-layout-project-settings/page-layout-project-settings.component.ts
+++ b/interfaces/portal/src/app/components/page-layout-project-settings/page-layout-project-settings.component.ts
@@ -56,6 +56,18 @@ export class PageLayoutProjectSettingsComponent {
       visible: this.authService.isAdmin,
     },
     {
+      label: $localize`Registration data`,
+      icon: 'pi pi-file-edit',
+      routerLink: [
+        '/',
+        AppRoutes.project,
+        this.projectId(),
+        AppRoutes.projectSettings,
+        AppRoutes.projectSettingsRegistrationData,
+      ],
+      visible: this.authService.isAdmin,
+    },
+    {
       label: $localize`:@@page-title-project-settings-team:Project team`,
       icon: 'pi pi-users',
       routerLink: [

--- a/interfaces/portal/src/app/components/project-language-tabs/project-language-tabs.component.html
+++ b/interfaces/portal/src/app/components/project-language-tabs/project-language-tabs.component.html
@@ -1,0 +1,23 @@
+@let languages = projectLanguages();
+
+@if (languages.length > 1) {
+  <p-tabs [(value)]="currentLanguage">
+    <p-tablist>
+      @for (language of languages; track language) {
+        <p-tab [value]="language">
+          <i class="pi pi-globe"></i>
+          {{ LANGUAGE_ENUM_LABEL[language] }}</p-tab
+        >
+      }
+    </p-tablist>
+    <p-tabpanels>
+      @for (language of languages; track language) {
+        <p-tabpanel [value]="language">
+          <ng-container *ngTemplateOutlet="languageTemplate()"></ng-container>
+        </p-tabpanel>
+      }
+    </p-tabpanels>
+  </p-tabs>
+} @else {
+  <ng-container *ngTemplateOutlet="languageTemplate()"></ng-container>
+}

--- a/interfaces/portal/src/app/components/project-language-tabs/project-language-tabs.component.ts
+++ b/interfaces/portal/src/app/components/project-language-tabs/project-language-tabs.component.ts
@@ -1,0 +1,53 @@
+import { NgTemplateOutlet } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  contentChild,
+  effect,
+  inject,
+  input,
+  model,
+  TemplateRef,
+} from '@angular/core';
+
+import { injectQuery } from '@tanstack/angular-query-experimental';
+import { TabsModule } from 'primeng/tabs';
+
+import { LanguageEnum } from '@121-service/src/shared/enum/language.enums';
+
+import { ProjectApiService } from '~/domains/project/project.api.service';
+import { LANGUAGE_ENUM_LABEL } from '~/domains/registration/registration.helper';
+
+@Component({
+  selector: 'app-project-language-tabs',
+  imports: [TabsModule, NgTemplateOutlet],
+  templateUrl: './project-language-tabs.component.html',
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProjectLanguageTabsComponent {
+  readonly projectId = input.required<number | string>();
+  readonly currentLanguage = model.required<LanguageEnum>();
+
+  readonly languageTemplate =
+    contentChild<TemplateRef<unknown>>('languageTemplate');
+
+  readonly projectApiService = inject(ProjectApiService);
+
+  readonly project = injectQuery(
+    this.projectApiService.getProject(this.projectId),
+  );
+
+  LANGUAGE_ENUM_LABEL = LANGUAGE_ENUM_LABEL;
+
+  readonly projectLanguages = computed(
+    () => this.project.data()?.languages ?? [],
+  );
+
+  updateCurrentLanguage = effect(() => {
+    if (this.projectLanguages().length === 1) {
+      this.currentLanguage.set(this.projectLanguages()[0]);
+    }
+  });
+}

--- a/interfaces/portal/src/app/components/project-language-tabs/project-language-tabs.helper.ts
+++ b/interfaces/portal/src/app/components/project-language-tabs/project-language-tabs.helper.ts
@@ -1,0 +1,26 @@
+import { FormControl, FormGroup } from '@angular/forms';
+
+import { LanguageEnum } from '@121-service/src/shared/enum/language.enums';
+
+import { Project } from '~/domains/project/project.model';
+
+export const getTranslatableFormGroup = ({
+  project,
+  getInitialValue,
+}: {
+  project: Project;
+  getInitialValue: (language: LanguageEnum) => string;
+}) => {
+  const languages = project.languages;
+
+  return new FormGroup(
+    Object.fromEntries(
+      languages.map((language) => [
+        language,
+        new FormControl(getInitialValue(language), {
+          nonNullable: true,
+        }),
+      ]),
+    ),
+  );
+};

--- a/interfaces/portal/src/app/domains/project/project.model.ts
+++ b/interfaces/portal/src/app/domains/project/project.model.ts
@@ -27,7 +27,6 @@ export type ProjectUserWithRolesLabel = {
 
 export type Attribute = Dto<AttributeFrom121Service>;
 
-export type AttributeWithTranslatedLabel = { label: string } & Omit<
-  Attribute,
-  'label'
->;
+export type AttributeWithTranslatedLabel = {
+  translatedLabel: string;
+} & Attribute;

--- a/interfaces/portal/src/app/pages/project-registrations/components/custom-message-control/custom-message-control.component.ts
+++ b/interfaces/portal/src/app/pages/project-registrations/components/custom-message-control/custom-message-control.component.ts
@@ -57,7 +57,7 @@ export class CustomMessageControlComponent implements ControlValueAccessor {
   placeholders = injectQuery(
     this.messagingService.getMessagePlaceholders(this.projectId),
   );
-  readonly messagePlaceholders = computed<{ label: string }[]>(() => {
+  readonly messagePlaceholders = computed<{ translatedLabel: string }[]>(() => {
     if (this.placeholders.isSuccess()) {
       return this.placeholders.data();
     }
@@ -65,14 +65,14 @@ export class CustomMessageControlComponent implements ControlValueAccessor {
     if (this.placeholders.isError()) {
       return [
         {
-          label: $localize`Failed to load options`,
+          translatedLabel: $localize`Failed to load options`,
         },
       ];
     }
 
     return [
       {
-        label: $localize`:@@generic-loading:Loading...`,
+        translatedLabel: $localize`:@@generic-loading:Loading...`,
       },
     ];
   });
@@ -80,7 +80,7 @@ export class CustomMessageControlComponent implements ControlValueAccessor {
   readonly mentionConfig = computed(() => ({
     items: this.messagePlaceholders(),
     triggerChar: '@',
-    labelKey: 'label',
+    labelKey: 'translatedLabel',
     mentionSelect: (item: AttributeWithTranslatedLabel) => `{{${item.name}}} `,
   }));
 

--- a/interfaces/portal/src/app/pages/project-settings-fsps/components/fsp-configuration-card/fsp-configuration-card.component.html
+++ b/interfaces/portal/src/app/pages/project-settings-fsps/components/fsp-configuration-card/fsp-configuration-card.component.html
@@ -47,7 +47,7 @@
           let-attribute
         >
           <tr>
-            <td>{{ attribute.label }}</td>
+            <td>{{ attribute.translatedLabel }}</td>
             <td>
               {{ attribute.name }}
               <p-button

--- a/interfaces/portal/src/app/pages/project-settings-registration-data/components/deduplication-attributes-table/deduplication-attributes-table.component.html
+++ b/interfaces/portal/src/app/pages/project-settings-registration-data/components/deduplication-attributes-table/deduplication-attributes-table.component.html
@@ -1,0 +1,53 @@
+<app-card-editable
+  header="De-duplication"
+  i18n-header
+  editPencilTitle="Edit de-duplication attributes"
+  i18n-editPencilTitle
+  [canEdit]="true"
+  [(isEditing)]="isEditing"
+  [formGroup]="formGroup"
+  [mutation]="updateAttributesMutation"
+  [mutationData]="formGroup.getRawValue()"
+>
+  <p
+    i18n
+    class="mb-4"
+  >
+    Select the fields you would like to use as duplication indicators - if these
+    fields are found to match the registrations will be flagged as duplicates.
+    Note that some FSPs may require specific fields to be unique, check for
+    notes in the FSP page.
+  </p>
+
+  @if (!isEditing()) {
+    <p-table [value]="duplicateCheckAttributes()">
+      <ng-template #header>
+        <tr>
+          <th i18n>Duplication fields</th>
+        </tr>
+      </ng-template>
+      <ng-template
+        #body
+        let-attribute
+      >
+        <tr>
+          <td>{{ attribute.translatedLabel }}</td>
+        </tr>
+      </ng-template>
+      <ng-template #emptymessage>
+        <tr>
+          <td i18n>No attributes selected.</td>
+        </tr>
+      </ng-template>
+    </p-table>
+  } @else {
+    <p-multiselect
+      [options]="project.data()?.programRegistrationAttributes"
+      formControlName="deduplicationAttributes"
+      [optionLabel]="'translatedLabel'"
+      placeholder="Select Attributes"
+      i18n-placeholder
+      styleClass="mt-4 w-full"
+    />
+  }
+</app-card-editable>

--- a/interfaces/portal/src/app/pages/project-settings-registration-data/components/deduplication-attributes-table/deduplication-attributes-table.component.ts
+++ b/interfaces/portal/src/app/pages/project-settings-registration-data/components/deduplication-attributes-table/deduplication-attributes-table.component.ts
@@ -1,0 +1,105 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  model,
+} from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+
+import {
+  injectMutation,
+  injectQuery,
+} from '@tanstack/angular-query-experimental';
+import { MultiSelectModule } from 'primeng/multiselect';
+import { TableModule } from 'primeng/table';
+
+import { CardEditableComponent } from '~/components/card-editable/card-editable.component';
+import { ProjectApiService } from '~/domains/project/project.api.service';
+import { Project } from '~/domains/project/project.model';
+import { ToastService } from '~/services/toast.service';
+
+type DeduplicationAttributesFormGroup =
+  typeof DeduplicationAttributesTableComponent.prototype.formGroup;
+
+@Component({
+  selector: 'app-deduplication-attributes-table',
+  imports: [
+    TableModule,
+    ReactiveFormsModule,
+    MultiSelectModule,
+    CardEditableComponent,
+  ],
+  templateUrl: './deduplication-attributes-table.component.html',
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [ToastService],
+})
+export class DeduplicationAttributesTableComponent {
+  readonly projectId = input.required<string>();
+
+  readonly projectApiService = inject(ProjectApiService);
+  readonly toastService = inject(ToastService);
+
+  project = injectQuery(this.projectApiService.getProject(this.projectId));
+
+  formGroup = new FormGroup({
+    deduplicationAttributes: new FormControl<
+      Project['programRegistrationAttributes']
+    >([], { nonNullable: true }),
+  });
+
+  readonly isEditing = model(false);
+
+  readonly duplicateCheckAttributes = computed(() =>
+    (this.project.data()?.programRegistrationAttributes ?? []).filter(
+      (attribute) => attribute.duplicateCheck,
+    ),
+  );
+
+  updateFormGroup = effect(() => {
+    if (!this.project.isSuccess()) {
+      return;
+    }
+
+    this.formGroup.setValue({
+      deduplicationAttributes: this.duplicateCheckAttributes(),
+    });
+  });
+
+  updateAttributesMutation = injectMutation(() => ({
+    mutationFn: (
+      formData: ReturnType<DeduplicationAttributesFormGroup['getRawValue']>,
+    ) =>
+      // XXX: should be a single API call
+      Promise.all(
+        (this.project.data()?.programRegistrationAttributes ?? []).map(
+          (attribute) =>
+            this.projectApiService.updateProjectRegistrationAttribute({
+              projectId: this.projectId,
+              programRegistrationAttributeName: attribute.name,
+              attribute: {
+                duplicateCheck: formData.deduplicationAttributes.some(
+                  (item) => item.name === attribute.name,
+                ),
+              },
+            }),
+        ),
+      ),
+    onSuccess: () => {
+      void this.projectApiService.invalidateCache(this.projectId);
+      this.isEditing.set(false);
+      this.toastService.showToast({
+        detail: $localize`Update successful.`,
+      });
+    },
+    onError: () => {
+      this.toastService.showToast({
+        severity: 'error',
+        detail: $localize`An error occurred during the update.`,
+      });
+    },
+  }));
+}

--- a/interfaces/portal/src/app/pages/project-settings-registration-data/components/registration-questions-table/registration-questions-table.component.html
+++ b/interfaces/portal/src/app/pages/project-settings-registration-data/components/registration-questions-table/registration-questions-table.component.html
@@ -1,0 +1,67 @@
+<app-card-editable
+  header="Personal information"
+  i18n-header
+  editPencilTitle="Edit personal information"
+  i18n-editPencilTitle
+  [canEdit]="true"
+  [(isEditing)]="isEditing"
+  [formGroup]="formGroup"
+  [mutation]="updateAttributesMutation"
+  [mutationData]="formGroup.getRawValue()"
+>
+  <p
+    i18n
+    class="mb-4"
+  >
+    Below are the {{ projectAttributes.data()?.length }} questions from the
+    integrated Kobo form. Please edit each column name to a shorter version that
+    will be displayed in the data table and on the profile page.
+  </p>
+
+  <app-project-language-tabs
+    [projectId]="projectId()"
+    [(currentLanguage)]="currentLanguage"
+  >
+    <ng-template #languageTemplate>
+      @let attributes = sortedAttributes();
+
+      <p-table [value]="attributes">
+        <ng-template #header>
+          <tr>
+            <th
+              i18n
+              class="w-1/2"
+            >
+              Data column name
+            </th>
+            <th
+              i18n
+              class="w-1/2"
+            >
+              Question label
+            </th>
+          </tr>
+        </ng-template>
+        <ng-template
+          #body
+          let-attribute
+        >
+          <tr [formGroupName]="attribute.name">
+            <td>{{ attribute.name }}</td>
+            @if (isEditing()) {
+              <td>
+                <input
+                  type="text"
+                  pInputText
+                  [formControlName]="currentLanguage()"
+                />
+              </td>
+            } @else {
+              <td>{{ attribute.label[currentLanguage()] }}</td>
+            }
+          </tr>
+        </ng-template>
+      </p-table>
+    </ng-template>
+  </app-project-language-tabs>
+</app-card-editable>

--- a/interfaces/portal/src/app/pages/project-settings-registration-data/components/registration-questions-table/registration-questions-table.component.ts
+++ b/interfaces/portal/src/app/pages/project-settings-registration-data/components/registration-questions-table/registration-questions-table.component.ts
@@ -1,0 +1,127 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  model,
+} from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+
+import {
+  injectMutation,
+  injectQuery,
+} from '@tanstack/angular-query-experimental';
+import { InputTextModule } from 'primeng/inputtext';
+import { TableModule } from 'primeng/table';
+
+import { LanguageEnum } from '@121-service/src/shared/enum/language.enums';
+
+import { CardEditableComponent } from '~/components/card-editable/card-editable.component';
+import { ProjectLanguageTabsComponent } from '~/components/project-language-tabs/project-language-tabs.component';
+import { getTranslatableFormGroup } from '~/components/project-language-tabs/project-language-tabs.helper';
+import { ProjectApiService } from '~/domains/project/project.api.service';
+import { LANGUAGE_ENUM_LABEL } from '~/domains/registration/registration.helper';
+import { ToastService } from '~/services/toast.service';
+
+@Component({
+  selector: 'app-registration-questions-table',
+  imports: [
+    TableModule,
+    ReactiveFormsModule,
+    InputTextModule,
+    CardEditableComponent,
+    ProjectLanguageTabsComponent,
+  ],
+  templateUrl: './registration-questions-table.component.html',
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [ToastService],
+})
+export class RegistrationQuestionsTableComponent {
+  readonly projectId = input.required<string>();
+
+  readonly projectApiService = inject(ProjectApiService);
+  readonly toastService = inject(ToastService);
+
+  project = injectQuery(this.projectApiService.getProject(this.projectId));
+  projectAttributes = injectQuery(
+    this.projectApiService.getProjectAttributes({
+      projectId: this.projectId,
+      includeProgramRegistrationAttributes: true,
+    }),
+  );
+
+  LANGUAGE_ENUM_LABEL = LANGUAGE_ENUM_LABEL;
+
+  formGroup = new FormGroup<
+    Record<
+      string,
+      FormGroup<Partial<Record<LanguageEnum, FormControl<string>>>>
+    >
+  >({});
+
+  readonly isEditing = model(false);
+  readonly currentLanguage = model<LanguageEnum>(LanguageEnum.en);
+
+  defineFormGroup = effect(() => {
+    if (!this.project.isSuccess() || !this.projectAttributes.isSuccess()) {
+      return;
+    }
+
+    const project = this.project.data();
+    const projectAttributes = this.projectAttributes.data();
+
+    this.formGroup = new FormGroup(
+      Object.fromEntries(
+        projectAttributes.map((attribute) => [
+          attribute.name,
+          getTranslatableFormGroup({
+            project,
+            getInitialValue: (language) => attribute.label?.[language] ?? '',
+          }),
+        ]),
+      ),
+    );
+  });
+
+  updateAttributesMutation = injectMutation(() => ({
+    mutationFn: (formData: ReturnType<typeof this.formGroup.getRawValue>) =>
+      // XXX: should be a single API call
+      Promise.all(
+        Object.entries(formData).map(([attributeName, attributeFormData]) =>
+          this.projectApiService.updateProjectRegistrationAttribute({
+            projectId: this.projectId,
+            programRegistrationAttributeName: attributeName,
+            attribute: {
+              label: attributeFormData,
+            },
+          }),
+        ),
+      ),
+    onSuccess: () => {
+      void this.projectApiService.invalidateCache(this.projectId);
+      this.isEditing.set(false);
+      this.toastService.showToast({
+        detail: $localize`Update successful.`,
+      });
+    },
+    onError: () => {
+      this.toastService.showToast({
+        severity: 'error',
+        detail: $localize`An error occurred while updating the labels.`,
+      });
+    },
+  }));
+
+  readonly sortedAttributes = computed(() => {
+    if (!this.projectAttributes.isSuccess()) {
+      return [];
+    }
+
+    return this.projectAttributes
+      .data()
+      .sort((a, b) => a.name.localeCompare(b.name));
+  });
+}

--- a/interfaces/portal/src/app/pages/project-settings-registration-data/project-settings-registration-data.page.html
+++ b/interfaces/portal/src/app/pages/project-settings-registration-data/project-settings-registration-data.page.html
@@ -1,0 +1,7 @@
+<app-page-layout-project-settings [projectId]="projectId()">
+  <app-registration-questions-table [projectId]="projectId()" />
+  <app-deduplication-attributes-table
+    [projectId]="projectId()"
+    class="mt-5 block"
+  />
+</app-page-layout-project-settings>

--- a/interfaces/portal/src/app/pages/project-settings-registration-data/project-settings-registration-data.page.ts
+++ b/interfaces/portal/src/app/pages/project-settings-registration-data/project-settings-registration-data.page.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+import { CardModule } from 'primeng/card';
+
+import { PageLayoutProjectSettingsComponent } from '~/components/page-layout-project-settings/page-layout-project-settings.component';
+import { DeduplicationAttributesTableComponent } from '~/pages/project-settings-registration-data/components/deduplication-attributes-table/deduplication-attributes-table.component';
+import { RegistrationQuestionsTableComponent } from '~/pages/project-settings-registration-data/components/registration-questions-table/registration-questions-table.component';
+
+@Component({
+  selector: 'app-project-settings-registration-data',
+  imports: [
+    CardModule,
+    RegistrationQuestionsTableComponent,
+    DeduplicationAttributesTableComponent,
+    PageLayoutProjectSettingsComponent,
+  ],
+  templateUrl: './project-settings-registration-data.page.html',
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProjectSettingsRegistrationDataPageComponent {
+  readonly projectId = input.required<string>();
+}

--- a/interfaces/portal/src/app/services/fsp-configuration.service.spec.ts
+++ b/interfaces/portal/src/app/services/fsp-configuration.service.spec.ts
@@ -40,7 +40,10 @@ const createProjectAttribute = (
   name: string,
 ): AttributeWithTranslatedLabel => ({
   name,
-  label: 'label',
+  label: {
+    en: 'label',
+  },
+  translatedLabel: 'label',
   type: RegistrationAttributeTypes.text,
 });
 

--- a/interfaces/portal/src/app/services/registration-attribute.service.ts
+++ b/interfaces/portal/src/app/services/registration-attribute.service.ts
@@ -222,7 +222,7 @@ export class RegistrationAttributeService {
     );
 
     return projectAttributes.map((attribute) => {
-      const { isRequired, name, label, pattern, type } = attribute;
+      const { isRequired, name, translatedLabel, pattern, type } = attribute;
       const options = project.programRegistrationAttributes
         .find((a) => a.name === name)
         ?.options?.map((option) => ({
@@ -234,7 +234,7 @@ export class RegistrationAttributeService {
       return {
         isRequired: isRequired ?? false,
         name,
-        label,
+        label: translatedLabel,
         pattern,
         options,
         value,

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -2000,6 +2000,51 @@
       <trans-unit id="922512355272678698" datatype="html">
         <source>Learn more about updating selected registrations in the <x ctype="x-app_manual_link" equiv-text="&lt;app-manual-link /&gt;" id="START_TAG_APP_MANUAL_LINK"/><x ctype="x-app_manual_link" equiv-text="&lt;app-manual-link /&gt;" id="CLOSE_TAG_APP_MANUAL_LINK"/>.</source>
       </trans-unit>
+      <trans-unit id="1419676661357831374" datatype="html">
+        <source>Registration data</source>
+      </trans-unit>
+      <trans-unit id="3560595744015834305" datatype="html">
+        <source>Update successful.</source>
+      </trans-unit>
+      <trans-unit id="4870684362400415992" datatype="html">
+        <source>Duplication fields</source>
+      </trans-unit>
+      <trans-unit id="4958457044114658950" datatype="html">
+        <source>No attributes selected.</source>
+      </trans-unit>
+      <trans-unit id="6062854020526523813" datatype="html">
+        <source>Below are the <x equiv-text="{{ projectAttributes.data()?.length }}" id="INTERPOLATION"/> questions from the integrated Kobo form. Please edit each column name to a shorter version that will be displayed in the data table and on the profile page.</source>
+      </trans-unit>
+      <trans-unit id="6124886965308904831" datatype="html">
+        <source>An error occurred during the update.</source>
+      </trans-unit>
+      <trans-unit id="6711033592081422255" datatype="html">
+        <source>Question label</source>
+      </trans-unit>
+      <trans-unit id="8094115796114921772" datatype="html">
+        <source>An error occurred while updating the labels.</source>
+      </trans-unit>
+      <trans-unit id="809774108055144125" datatype="html">
+        <source>Select the fields you would like to use as duplication indicators - if these fields are found to match the registrations will be flagged as duplicates. Note that some FSPs may require specific fields to be unique, check for notes in the FSP page.</source>
+      </trans-unit>
+      <trans-unit id="964040539261320237" datatype="html">
+        <source>Select Attributes</source>
+      </trans-unit>
+      <trans-unit id="page-title-project-settings-registration-data" datatype="html">
+        <source>Registration data</source>
+      </trans-unit>
+      <trans-unit id="4705747697674144692" datatype="html">
+        <source>Personal information</source>
+      </trans-unit>
+      <trans-unit id="5648292710765442159" datatype="html">
+        <source>Edit de-duplication attributes</source>
+      </trans-unit>
+      <trans-unit id="6267577653105675049" datatype="html">
+        <source>Edit personal information</source>
+      </trans-unit>
+      <trans-unit id="652894116103613049" datatype="html">
+        <source>De-duplication</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Adds a new "Registration Data" page in project settings.
- Registration question translation is working
- Duplication attributes configuration is working

This does not include the kobo integration, which has been separated into #7413. This separation means that the registration data page is working and can be merged without the kobo integration.

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines
- [ ] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7405.westeurope.3.azurestaticapps.net
