### PR TITLE
chore: update Jest Snapshot version headers

### DIFF
--- a/services/121-service/test/commercial-bank-ethiopia/__snapshots__/export-validation-report.test.ts.snap
+++ b/services/121-service/test/commercial-bank-ethiopia/__snapshots__/export-validation-report.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Export CBE validation report should successfully generate a report of CBE validation data 1`] = `
 {

--- a/services/121-service/test/metrics/__snapshots__/export-list.test.ts.snap
+++ b/services/121-service/test/metrics/__snapshots__/export-list.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Metric export list should export all registration attributes when no "select" is provided 1`] = `
 {

--- a/services/121-service/test/payment/__snapshots__/do-payment-fsp-airtel.test.ts.snap
+++ b/services/121-service/test/payment/__snapshots__/do-payment-fsp-airtel.test.ts.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Do payment with FSP: Airtel should create a transaction with status error when we do a payment with an invalid phonenumber 1`] = `"Airtel Error: Mobile number entered is incorrect. (DP00900001012)"`;

--- a/services/121-service/test/payment/__snapshots__/do-payment-fsp-commercial-bank-ethiopia.test.ts.snap
+++ b/services/121-service/test/payment/__snapshots__/do-payment-fsp-commercial-bank-ethiopia.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Do payment with FSP: Commercial Bank of Ethiopia when credit transfer API call gives an error response should successfully do a payment with transactions that have status error 1`] = `"Other failure"`;
 

--- a/services/121-service/test/payment/__snapshots__/do-payment-fsp-excel.test.ts.snap
+++ b/services/121-service/test/payment/__snapshots__/do-payment-fsp-excel.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Do payment with Excel FSP Export FSP instructions Should return all program-registration-attributes on Get FSP instruction with Excel-FSP when "columnsToExport" is not set 1`] = `
 [

--- a/services/121-service/test/payment/__snapshots__/do-payment-fsp-nedbank.test.ts.snap
+++ b/services/121-service/test/payment/__snapshots__/do-payment-fsp-nedbank.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Do payment with FSP: Nedbank when create order API call gives a valid response should create a transaction with status error when phone number is missing 1`] = `"Errors: Request Validation Error - TPP account configuration mismatch (Message: BUSINESS ERROR, Code: NB.APIM.Field.Invalid, Id: 1d3e3076-9e1c-4933-aa7f-69290941ec70)"`;
 

--- a/services/121-service/test/payment/__snapshots__/do-payment-fsp-voucher.test.ts.snap
+++ b/services/121-service/test/payment/__snapshots__/do-payment-fsp-voucher.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Do payment to 1 PA with FSP: Intersolve Voucher WhatsApp should fail pay-out due to invalid phone number 1`] = `"Magic fail (ErrorCode: 1)"`;
 

--- a/services/121-service/test/payment/__snapshots__/do-payment-retry.test.ts.snap
+++ b/services/121-service/test/payment/__snapshots__/do-payment-retry.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Do payment retry should thrown an error if payment does not exist yet 1`] = `
 {

--- a/services/121-service/test/program/__snapshots__/manage-program-fsp-configuration.test.ts.snap
+++ b/services/121-service/test/program/__snapshots__/manage-program-fsp-configuration.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Manage Fsp configurations should not delete existing program Fsp configuration because of active registrations with that config 1`] = `
 {

--- a/services/121-service/test/programs/users/__snapshots__/roles.test.ts.snap
+++ b/services/121-service/test/programs/users/__snapshots__/roles.test.ts.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Programs / Users / Roles should return an error when a user tries to assign roles to themselves 1`] = `"You cannot update your own program assignment"`;

--- a/services/121-service/test/registrations/__snapshots__/calculate-payment-amount-multiplier.test.ts.snap
+++ b/services/121-service/test/registrations/__snapshots__/calculate-payment-amount-multiplier.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Set/calculate payment amount multiplier should error if paymentAmountMultiplier is set while program has a formula 1`] = `
 {

--- a/services/121-service/test/registrations/__snapshots__/import-registration.test.ts.snap
+++ b/services/121-service/test/registrations/__snapshots__/import-registration.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Import a registration should give me a CSV template when I request it 1`] = `
 [

--- a/services/121-service/test/registrations/__snapshots__/update-registration-program-fsp-configuration.test.ts.snap
+++ b/services/121-service/test/registrations/__snapshots__/update-registration-program-fsp-configuration.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Update program fsp configuration of PA should fail when updating program fsp configuration when a required property of new FSP is not yet present 1`] = `
 {

--- a/services/121-service/test/registrations/__snapshots__/update-registration.test.ts.snap
+++ b/services/121-service/test/registrations/__snapshots__/update-registration.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Update attribute of PA should fail when removing a required program registration attribute 1`] = `
 {

--- a/services/121-service/test/registrations/duplicates/__snapshots__/create-registration-uniques-errors.test.ts.snap
+++ b/services/121-service/test/registrations/duplicates/__snapshots__/create-registration-uniques-errors.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Unsuccessfully mark registrations as unique from each other should fail to create an ignored duplicate registration pair for more that 10 registrations 1`] = `
 [

--- a/services/121-service/test/registrations/pagination/__snapshots__/filter-registration.test.ts.snap
+++ b/services/121-service/test/registrations/pagination/__snapshots__/filter-registration.test.ts.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Filter registrations not operator filters should throw bad request for $not:$null filter on registration attribute data 1`] = `"Using $not:$null is not supported for registration attribute data filters."`;

--- a/services/121-service/test/transactions/__snapshots__/export-transactions.test.ts.snap
+++ b/services/121-service/test/transactions/__snapshots__/export-transactions.test.ts.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Export transactions should export transaction with the correct fields 1`] = `"Male"`;

--- a/services/121-service/test/users/__snapshots__/user-roles.test.ts.snap
+++ b/services/121-service/test/users/__snapshots__/user-roles.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`/ Users / Roles should not create a role when the role already exists 1`] = `"{"statusCode":409,"message":"Role already exists: test-manager"}"`;
 

--- a/services/121-service/test/visa-card/__snapshots__/export-report.test.ts.snap
+++ b/services/121-service/test/visa-card/__snapshots__/export-report.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Export Visa debit card report should successfully generate a report of all Visa Debit cards 1`] = `
 [


### PR DESCRIPTION
[AB#38634](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38634) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Each `.snap` file contains a "version header" comment indicating which snapshot version the file adheres to.

The corresponding URL in that comment is updated when running the integration tests locally. This creates changes in those files. Let's not have that.

Solution:

1. run integration tests locally
2. commit the changed version header comments

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
- [x] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
