### PR TITLE
Fix: Redline flaky test "View search-results"

### DIFF
--- a/e2e/portal/tests/Redline/ViewRegistrationPageInRedline.spec.ts
+++ b/e2e/portal/tests/Redline/ViewRegistrationPageInRedline.spec.ts
@@ -94,14 +94,21 @@ test('[35449] View search-results with multiple matched registrations', async ({
   await expect(page.locator('app-registration-lookup-menu')).toContainText(
     `${testRegistrations.length} registration(s) found with this number.`,
   );
-
+  // Check that the number of tabs equals the number of test registrations
   await expect(
     page.locator('app-registration-lookup-menu').getByRole('tab'),
   ).toHaveCount(testRegistrations.length);
-  await expect(page.getByRole('tab').nth(0)).toHaveText(
-    `${testRegistrations[0].fullName} - ${projectTitle}`,
+
+  // Check that both expected tab texts are present
+  const expectedTabTexts = testRegistrations.map(
+    (registration) => `${registration.fullName} - ${projectTitle}`,
   );
-  await expect(
-    page.locator('app-registration-lookup-menu').getByRole('tab').nth(1),
-  ).toHaveText(`${testRegistrations[1].fullName} - ${projectTitle}`);
+
+  for (const expectedText of expectedTabTexts) {
+    await expect(
+      page
+        .locator('app-registration-lookup-menu')
+        .getByRole('tab', { name: expectedText }),
+    ).toBeVisible();
+  }
 });


### PR DESCRIPTION
[AB#38809](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38809) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Adds fix for flaky Redline test "View search-results with multiple matched registrations"

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
