### PR TITLE
Prototype: Transfer Value Calculation (Kobo-style) — Spike

### DIFF
--- a/services/121-service/package-lock.json
+++ b/services/121-service/package-lock.json
@@ -32,6 +32,7 @@
         "cookie-parser": "^1.4.7",
         "csv-parser": "^3.2.0",
         "easy-soap-request": "^5.7.0",
+        "expr-eval": "2.0.2",
         "form-data": "^4.0.4",
         "he": "^1.2.0",
         "ioredis": "^5.4.1",
@@ -11302,6 +11303,12 @@
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
+    },
+    "node_modules/expr-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expr-eval/-/expr-eval-2.0.2.tgz",
+      "integrity": "sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==",
+      "license": "MIT"
     },
     "node_modules/express": {
       "version": "5.1.0",

--- a/services/121-service/package.json
+++ b/services/121-service/package.json
@@ -81,6 +81,7 @@
     "cookie-parser": "^1.4.7",
     "csv-parser": "^3.2.0",
     "easy-soap-request": "^5.7.0",
+    "expr-eval": "2.0.2",
     "form-data": "^4.0.4",
     "he": "^1.2.0",
     "ioredis": "^5.4.1",

--- a/services/121-service/src/registration/services/registrations-import.service.ts
+++ b/services/121-service/src/registration/services/registrations-import.service.ts
@@ -287,10 +287,12 @@ export class RegistrationsImportService {
         );
       }
       if (program.paymentAmountMultiplierFormula) {
-        await this.inclusionScoreService.calculatePaymentAmountMultiplier(
-          program,
-          registration.referenceId,
-        );
+        await this.inclusionScoreService.calculatePaymentAmountMultiplier({
+          paymentAmountMultiplierFormula:
+            program.paymentAmountMultiplierFormula,
+          referenceId: registration.referenceId,
+          programId: registration.programId,
+        });
       }
     }
     await this.actionService.saveAction(

--- a/services/121-service/src/registration/services/registrations.service.ts
+++ b/services/121-service/src/registration/services/registrations.service.ts
@@ -567,10 +567,11 @@ export class RegistrationsService {
     const savedRegistration =
       await this.registrationUtilsService.save(registration);
     const calculatedRegistration =
-      await this.inclusionScoreService.calculatePaymentAmountMultiplier(
-        program,
-        registration.referenceId,
-      );
+      await this.inclusionScoreService.calculatePaymentAmountMultiplier({
+        paymentAmountMultiplierFormula: program.paymentAmountMultiplierFormula,
+        referenceId: registration.referenceId,
+        programId: registration.programId,
+      });
     if (calculatedRegistration) {
       return this.getRegistrationOrThrow({
         referenceId: calculatedRegistration.referenceId,

--- a/services/121-service/test/helpers/program.helper.ts
+++ b/services/121-service/test/helpers/program.helper.ts
@@ -66,11 +66,15 @@ export async function getProgram(
     .set('Cookie', [accessToken]);
 }
 
-export async function postProgramRegistrationAttribute(
-  programRegistrationAttribute: ProgramRegistrationAttributeDto,
-  programId: number,
-  accessToken: string,
-): Promise<request.Response> {
+export async function postProgramRegistrationAttribute({
+  programRegistrationAttribute,
+  programId,
+  accessToken,
+}: {
+  programRegistrationAttribute: ProgramRegistrationAttributeDto;
+  programId: number;
+  accessToken: string;
+}): Promise<request.Response> {
   return await getServer()
     .post(`/programs/${programId}/registration-attributes`)
     .set('Cookie', [accessToken])

--- a/services/121-service/test/program/create-program-registration-attribute.test.ts
+++ b/services/121-service/test/program/create-program-registration-attribute.test.ts
@@ -41,28 +41,28 @@ describe('Create program', () => {
 
   it('should post a program registration attribute', async () => {
     // Act
-    const createReponse = await postProgramRegistrationAttribute(
+    const createReponse = await postProgramRegistrationAttribute({
       programRegistrationAttribute,
-      programIdPV,
+      programId: programIdPV,
       accessToken,
-    );
+    });
     // Assert
     expect(createReponse.statusCode).toBe(HttpStatus.CREATED);
   });
 
   it('should not be able to post a registration attributes with a name that already exists', async () => {
     // Arrange
-    await postProgramRegistrationAttribute(
+    await postProgramRegistrationAttribute({
       programRegistrationAttribute,
-      programIdPV,
+      programId: programIdPV,
       accessToken,
-    );
+    });
     // Act
-    const createReponse2 = await postProgramRegistrationAttribute(
-      programRegistrationAttribute as any,
-      programIdPV,
+    const createReponse2 = await postProgramRegistrationAttribute({
+      programRegistrationAttribute: programRegistrationAttribute as any,
+      programId: programIdPV,
       accessToken,
-    );
+    });
     // Assert
     expect(createReponse2.statusCode).toBe(HttpStatus.BAD_REQUEST);
   });
@@ -76,11 +76,11 @@ describe('Create program', () => {
       };
       delete programRegistrationAttributeCopy[attribute];
 
-      const createResponse = await postProgramRegistrationAttribute(
-        programRegistrationAttributeCopy as any,
-        programIdPV,
+      const createResponse = await postProgramRegistrationAttribute({
+        programRegistrationAttribute: programRegistrationAttributeCopy as any,
+        programId: programIdPV,
         accessToken,
-      );
+      });
       // Assert
       expect(createResponse.statusCode).toBe(HttpStatus.BAD_REQUEST);
     }
@@ -99,11 +99,11 @@ describe('Create program', () => {
       programRegistrationAttributeCopy.name = name;
 
       // Act
-      const createReponse = await postProgramRegistrationAttribute(
-        programRegistrationAttributeCopy,
-        programIdPV,
+      const createReponse = await postProgramRegistrationAttribute({
+        programRegistrationAttribute: programRegistrationAttributeCopy,
+        programId: programIdPV,
         accessToken,
-      );
+      });
       // Assert
       expect(createReponse.statusCode).toBe(HttpStatus.BAD_REQUEST);
     }

--- a/services/121-service/test/registrations/calculate-payment-amount-multiplier.test.ts
+++ b/services/121-service/test/registrations/calculate-payment-amount-multiplier.test.ts
@@ -1,13 +1,17 @@
 import { HttpStatus } from '@nestjs/common';
 
-import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
+import { RegistrationAttributeTypes } from '@121-service/src/registration/enum/registration-attribute.enum';
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
-import { getTransactions } from '@121-service/test/helpers/program.helper';
 import {
-  doPaymentAndWaitForCompletion,
+  getTransactions,
+  patchProgram,
+  postProgramRegistrationAttribute,
+} from '@121-service/test/helpers/program.helper';
+import {
   importRegistrations,
   searchRegistrationByReferenceId,
-  seedIncludedRegistrations,
+  seedPaidRegistrations,
+  seedRegistrations,
 } from '@121-service/test/helpers/registration.helper';
 import {
   getAccessToken,
@@ -23,129 +27,285 @@ import {
 describe('Set/calculate payment amount multiplier', () => {
   let accessToken: string;
 
+  let registrationWesterosCopy: any;
+
   beforeEach(async () => {
     accessToken = await getAccessToken();
   });
 
-  it('should automatically calculate payment amount based on formula', async () => {
-    // Arrange
-    await resetDB(SeedScript.testMultiple, __filename);
-    const nrOfDragons = 2.5; // We are using half a dragon here to ensure decimal calculations also work
-    const transferValue = 10;
-    const registrationWesterosCopy = { ...registrationWesteros1 };
-    registrationWesterosCopy.dragon = nrOfDragons;
+  describe('Payment amount multiplier formula is set', () => {
+    beforeEach(async () => {
+      await resetDB(SeedScript.testMultiple, __filename);
 
-    // Act
-    await seedIncludedRegistrations(
-      [registrationWesterosCopy],
-      programIdWesteros,
-      accessToken,
-    );
-    const searchRegistrationResponse = await searchRegistrationByReferenceId(
-      registrationWesterosCopy.referenceId,
-      programIdWesteros,
-      accessToken,
-    );
-    const importedRegistration = searchRegistrationResponse.body.data[0];
+      registrationWesterosCopy = { ...registrationWesteros1 };
+      registrationWesterosCopy.dothraki = 0; // default value
 
-    const paymentId = await doPaymentAndWaitForCompletion({
-      programId: programIdWesteros,
-      referenceIds: [importedRegistration.referenceId],
-      transferValue,
-      accessToken,
-      completeStatusses: Object.values(TransactionStatusEnum),
+      await postProgramRegistrationAttribute({
+        programId: programIdWesteros,
+        programRegistrationAttribute: {
+          name: 'dothraki',
+          label: { en: 'Dothraki' },
+          isRequired: true,
+          type: RegistrationAttributeTypes.numeric,
+        },
+        accessToken,
+      });
     });
 
-    const transactionsResponse = await getTransactions({
-      programId: programIdWesteros,
-      paymentId,
-      registrationReferenceId: importedRegistration.referenceId,
+    it('should automatically calculate payment amount based on formula (addition)', async () => {
+      // Arrange
 
-      accessToken,
+      const nrOfDragons = 3; // We are using half a dragon here to ensure decimal calculations also work
+      const transferValue = 10;
+      const nrOfDothraki = 2;
+
+      registrationWesterosCopy.dragon = nrOfDragons;
+      registrationWesterosCopy.dothraki = nrOfDothraki;
+
+      await patchProgram(
+        programIdWesteros,
+        {
+          paymentAmountMultiplierFormula: '${dragon} + ${dothraki}',
+        },
+        accessToken,
+      );
+
+      // Act
+      const paymentId = await seedPaidRegistrations(
+        [registrationWesterosCopy],
+        programIdWesteros,
+        transferValue,
+      );
+      const searchRegistrationResponse = await searchRegistrationByReferenceId(
+        registrationWesterosCopy.referenceId,
+        programIdWesteros,
+        accessToken,
+      );
+      const importedRegistration = searchRegistrationResponse.body.data[0];
+
+      const transactionsResponse = await getTransactions({
+        programId: programIdWesteros,
+        paymentId,
+        registrationReferenceId: importedRegistration.referenceId,
+
+        accessToken,
+      });
+      const transaction = transactionsResponse.body[0];
+
+      // Assert
+      expect(importedRegistration.paymentAmountMultiplier).toBe(
+        nrOfDragons + nrOfDothraki,
+      );
+      expect(transaction.amount).toBe(
+        transferValue * (nrOfDragons + nrOfDothraki),
+      );
     });
-    const transaction = transactionsResponse.body[0];
-    // Assert
 
-    expect(importedRegistration.paymentAmountMultiplier).toBe(nrOfDragons + 1);
-    expect(transaction.amount).toBe(transferValue * (nrOfDragons + 1));
+    it('should succesfully payment amount multiplier based on different formula', async () => {
+      // Arrange
+
+      const nrOfDragons = 2;
+      const nrOfDothraki = 4;
+
+      registrationWesterosCopy.dragon = nrOfDragons;
+      registrationWesterosCopy.dothraki = nrOfDothraki;
+
+      const formulateAndResults: { formula: string; expectedResult: number }[] =
+        [
+          {
+            formula: '${dragon} - ${dothraki}',
+            expectedResult: nrOfDragons - nrOfDothraki,
+          },
+          {
+            formula: '${dragon} * ${dothraki}',
+            expectedResult: nrOfDragons * nrOfDothraki,
+          },
+          {
+            formula: '${dothraki} / ${dragon}',
+            expectedResult: nrOfDothraki / nrOfDragons,
+          },
+          {
+            formula: 'if(${dragon} < 3, 100, 200)',
+            expectedResult: 100, // since nrOfDragons is 2
+          },
+          {
+            formula: 'round(2.5)', // ROUND DOES NOT WORK WITH PLACES only to whole numbers
+            expectedResult: 3, // since 2.5 rounded is 3
+          },
+          {
+            formula: "if(${house} != 'stark', 55, 66)",
+            expectedResult: 66,
+          },
+
+          {
+            formula: "if(${house} = 'stark', 77, 88)",
+            expectedResult: 77,
+          },
+          {
+            formula: 'if(${dragon} = 2, 9, 10)',
+            expectedResult: 9,
+          },
+          {
+            formula: 'if(${dothraki} != 4, 19, 20)',
+            expectedResult: 20,
+          },
+          {
+            formula: 'if(${dothraki} < 5, 11, 22)',
+            expectedResult: 11,
+          },
+          {
+            formula: 'if(${dragon} <= 2, 33, 44)',
+            expectedResult: 33,
+          },
+          {
+            formula: 'if(${dothraki} > 3, 77, 88)',
+            expectedResult: 77,
+          },
+          {
+            formula: 'if(${dragon} >= 2, 99, 111)',
+            expectedResult: 99,
+          },
+          {
+            formula: 'if(${dragon} > 1 and ${dothraki} > 100, 123, 456)',
+            expectedResult: 456,
+          },
+          {
+            formula: 'if(${dragon} > 1 and ${dothraki} > 1, 123, 456)',
+            expectedResult: 123,
+          },
+          {
+            formula: 'if(${dragon} > 100 or ${dothraki} > 100, 321, 654)',
+            expectedResult: 654,
+          },
+          {
+            formula: 'if(${dragon} > 1 or ${dothraki} > 1, 321, 654)',
+            expectedResult: 321,
+          },
+          {
+            formula:
+              'if(${dragon} > 1 or ${dothraki} > 1, ${dragon} + ${dothraki}, 654)',
+            expectedResult: nrOfDothraki + nrOfDragons,
+          },
+          {
+            formula: 'if( 2 > 1 , if(3 > 2, 111, 222), 333)',
+            expectedResult: 111,
+          },
+        ];
+
+      let i = 0;
+      for (const formulateAndResult of formulateAndResults) {
+        await patchProgram(
+          programIdWesteros,
+          {
+            paymentAmountMultiplierFormula: formulateAndResult.formula,
+          },
+          accessToken,
+        );
+
+        // Act
+
+        // esnure we can easily identify the registration based on referenceId which is now the same as the formula
+        const registrationUniqueRefId = {
+          ...registrationWesterosCopy,
+          referenceId: `reference-${i}`,
+        };
+
+        await seedRegistrations([registrationUniqueRefId], programIdWesteros);
+        const searchRegistrationResponse =
+          await searchRegistrationByReferenceId(
+            registrationUniqueRefId.referenceId,
+            programIdWesteros,
+            accessToken,
+          );
+
+        // Assert
+        const importedRegistration = searchRegistrationResponse.body.data[0];
+        expect(importedRegistration.paymentAmountMultiplier).toBe(
+          formulateAndResult.expectedResult,
+        );
+        i++;
+      }
+    });
+
+    it('should error if paymentAmountMultiplier is set while program has a formula', async () => {
+      await resetDB(SeedScript.testMultiple, __filename);
+      // Arrange
+      const registrationWesterosCopy = {
+        ...registrationWesteros1,
+        ...{ paymentAmountMultiplier: 3 },
+      };
+
+      // Act
+      const responseImport = await importRegistrations(
+        programIdWesteros,
+        [registrationWesterosCopy],
+        accessToken,
+      );
+
+      const searchRegistrationResponse = await searchRegistrationByReferenceId(
+        registrationWesterosCopy.referenceId,
+        programIdWesteros,
+        accessToken,
+      );
+      // Assert
+      expect(responseImport.statusCode).toBe(HttpStatus.BAD_REQUEST);
+      expect(searchRegistrationResponse.body).toMatchSnapshot();
+    });
   });
 
-  it('should error if paymentAmountMultiplier is set while program has a formula', async () => {
-    await resetDB(SeedScript.testMultiple, __filename);
-    // Arrange
-    const registrationWesterosCopy = {
-      ...registrationWesteros1,
-      ...{ paymentAmountMultiplier: 3 },
-    };
+  describe('Payment amount multiplier formula is not set', () => {
+    it('should set paymentAmountMultiplier to 1 and paymentAmountMultiplier in import is not set', async () => {
+      // Arrange
+      await resetDB(SeedScript.nlrcMultiple, __filename);
+      const registrationPvCopy = {
+        ...registrationPV5,
+      };
 
-    // Act
-    const responseImport = await importRegistrations(
-      programIdWesteros,
-      [registrationWesterosCopy],
-      accessToken,
-    );
+      // Act
+      const responseImport = await importRegistrations(
+        programIdPV,
+        [registrationPvCopy],
+        accessToken,
+      );
 
-    const searchRegistrationResponse = await searchRegistrationByReferenceId(
-      registrationWesterosCopy.referenceId,
-      programIdWesteros,
-      accessToken,
-    );
-    // Assert
-    expect(responseImport.statusCode).toBe(HttpStatus.BAD_REQUEST);
-    expect(searchRegistrationResponse.body).toMatchSnapshot();
-  });
+      const searchRegistrationResponse = await searchRegistrationByReferenceId(
+        registrationPvCopy.referenceId,
+        programIdPV,
+        accessToken,
+      );
+      const importedRegistration = searchRegistrationResponse.body.data[0];
+      // Assert
+      expect(responseImport.statusCode).toBe(HttpStatus.CREATED);
+      expect(searchRegistrationResponse.body.data.length).toBe(1);
+      expect(importedRegistration.paymentAmountMultiplier).toBe(1);
+    });
 
-  it('should set paymentAmountMultiplier to 1 if program has no formula and paymentAmountMultiplier in import is not set', async () => {
-    // Arrange
-    await resetDB(SeedScript.nlrcMultiple, __filename);
-    const registrationPvCopy = {
-      ...registrationPV5,
-    };
+    it('should set paymentAmountMultiplier based paymentAmountMultiplier', async () => {
+      // Arrange
+      await resetDB(SeedScript.nlrcMultiple, __filename);
+      const paymentAmountMultiplier = 3;
+      const registrationPvCopy = {
+        ...registrationPV5,
+        ...{ paymentAmountMultiplier },
+      };
+      // Act
+      const responseImport = await importRegistrations(
+        programIdPV,
+        [registrationPvCopy],
+        accessToken,
+      );
 
-    // Act
-    const responseImport = await importRegistrations(
-      programIdPV,
-      [registrationPvCopy],
-      accessToken,
-    );
-
-    const searchRegistrationResponse = await searchRegistrationByReferenceId(
-      registrationPvCopy.referenceId,
-      programIdPV,
-      accessToken,
-    );
-    const importedRegistration = searchRegistrationResponse.body.data[0];
-    // Assert
-    expect(responseImport.statusCode).toBe(HttpStatus.CREATED);
-    expect(searchRegistrationResponse.body.data.length).toBe(1);
-    expect(importedRegistration.paymentAmountMultiplier).toBe(1);
-  });
-
-  it('should set paymentAmountMultiplier based paymentAmountMultiplier if program has no formula', async () => {
-    // Arrange
-    await resetDB(SeedScript.nlrcMultiple, __filename);
-    const paymentAmountMultiplier = 3;
-    const registrationPvCopy = {
-      ...registrationPV5,
-      ...{ paymentAmountMultiplier },
-    };
-    // Act
-    const responseImport = await importRegistrations(
-      programIdPV,
-      [registrationPvCopy],
-      accessToken,
-    );
-
-    const searchRegistrationResponse = await searchRegistrationByReferenceId(
-      registrationPvCopy.referenceId,
-      programIdPV,
-      accessToken,
-    );
-    const importedRegistration = searchRegistrationResponse.body.data[0];
-    // Assert
-    expect(responseImport.statusCode).toBe(HttpStatus.CREATED);
-    expect(importedRegistration.paymentAmountMultiplier).toBe(
-      paymentAmountMultiplier,
-    );
+      const searchRegistrationResponse = await searchRegistrationByReferenceId(
+        registrationPvCopy.referenceId,
+        programIdPV,
+        accessToken,
+      );
+      const importedRegistration = searchRegistrationResponse.body.data[0];
+      // Assert
+      expect(responseImport.statusCode).toBe(HttpStatus.CREATED);
+      expect(importedRegistration.paymentAmountMultiplier).toBe(
+        paymentAmountMultiplier,
+      );
+    });
   });
 });


### PR DESCRIPTION
[AB#38785](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38785) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

This PR introduces a prototype for supporting dynamic transfer value calculation in the 121 platform, inspired by how KoboToolbox handles calculation logic in XLSForms.

**Key changes:**

Added logic to parse and evaluate calculation formulas (e.g., ${dragon} * 2, if(${age} < 65, 100, 200)) using the [expr-eval](vscode-file://vscode-app/Users/rubenvandervalk/Documents/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) npm package.
Preprocesses formulas to convert Kobo/XLSForm-style ${variable} references to plain variable names for compatibility with expr-eval.

**Why expr-eval?**


KoBo uses [Enketo](https://github.com/enketo/enketo) for calculations, but no official Node.js library exists for Enketo’s calculation engine.

I also considered running the Enketo Docker image locally (see [GitHub](https://github.com/enketo/enketo)), but Enketo Express is designed to render forms and process submissions for web clients — not to expose a general-purpose calculation API.

Another option was to use [`openrosa-xpath-evaluator`](https://github.com/enketo/openrosa-xpath-evaluator), the XPath engine used by Enketo/KoBo. However, that package assumes a browser DOM environment, which makes it difficult to use directly in a Node.js backend (though workarounds exist).

In the end, I chose to use [`expr-eval`](https://www.npmjs.com/package/expr-eval), one of the most widely used and lightweight expression evaluators. I tested all [scenarios](https://teams.microsoft.com/l/message/19:d5a2a22ac7a14a7395c24c3a2a458a9a@thread.skype/1761571913778?tenantId=d3ab9790-6ae2-4bd8-aa5e-02864483e7c7&groupId=55f2fa49-7d9b-4c63-b616-b986f3136c3a&parentMessageId=1761571913778&teamName=510%20-%20CVA&channelName=General&createdTime=1761571913778) described by Tijs, and it works for all of them except `round(number, places)`, as it only supports rounding to whole numbers (the `places` argument isn’t supported).

I recommend using `expr-eval` because it behaves closely enough to KoBo’s calculation logic without requiring complex workarounds. We can always switch to a different calculation engine later if user needs evolve.

**Why not dynamically calculate transfer value with for example a database view?**

Writing custom queries for all possible logic is too complex


## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines
- [ ] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
