### PR TITLE
Refactor payment lock to seperate module

### DIFF
--- a/services/121-service/module-dependencies.md
+++ b/services/121-service/module-dependencies.md
@@ -2,7 +2,6 @@
 
 ```mermaid
 graph LR
-  ActionsModule-->UserModule
   ActivitiesModule-->MessageModule
   ActivitiesModule-->NoteModule
   ActivitiesModule-->RegistrationEventsModule
@@ -21,11 +20,11 @@ graph LR
   CronjobModule-->OnafriqReconciliationModule
   ExcelModule-->RegistrationsModule
   ExcelModule-->TransactionsModule
-  ExcelReconcilicationModule-->ActionsModule
   ExcelReconcilicationModule-->ExcelModule
   ExcelReconcilicationModule-->PaymentsModule
   ExcelReconcilicationModule-->ProgramFspConfigurationsModule
   ExcelReconcilicationModule-->ProgramModule
+  ExcelReconcilicationModule-->ProgramPaymentLocksModule
   ExcelReconcilicationModule-->RegistrationsModule
   ExcelReconcilicationModule-->TransactionEventsModule
   ExcelReconcilicationModule-->TransactionsModule
@@ -66,7 +65,6 @@ graph LR
   MessageQueuesModule-->RegistrationDataModule
   MessageTemplateModule-->ProgramAttributesModule
   MessageTemplateModule-->UserModule
-  MetricsModule-->ActionsModule
   MetricsModule-->IntersolveVisaModule
   MetricsModule-->IntersolveVoucherModule
   MetricsModule-->PaymentsModule
@@ -89,13 +87,13 @@ graph LR
   OnafriqReconciliationModule-->QueuesRegistryModule
   OnafriqReconciliationModule-->RedisModule
   OnafriqReconciliationModule-->TransactionsModule
-  PaymentsModule-->ActionsModule
   PaymentsModule-->ExcelModule
   PaymentsModule-->FspsModule
   PaymentsModule-->MessageTemplateModule
   PaymentsModule-->PaymentEventsModule
   PaymentsModule-->ProgramFspConfigurationsModule
   PaymentsModule-->ProgramModule
+  PaymentsModule-->ProgramPaymentLocksModule
   PaymentsModule-->RedisModule
   PaymentsModule-->RegistrationDataModule
   PaymentsModule-->RegistrationEventsModule
@@ -105,7 +103,6 @@ graph LR
   PaymentsModule-->TransactionQueuesModule
   PaymentsModule-->TransactionsModule
   PaymentsModule-->UserModule
-  ProgramModule-->ActionsModule
   ProgramModule-->FspsModule
   ProgramModule-->IntersolveVisaModule
   ProgramModule-->KoboConnectModule
@@ -114,9 +111,9 @@ graph LR
   ProgramModule-->ProgramAttributesModule
   ProgramModule-->ProgramFspConfigurationsModule
   ProgramModule-->UserModule
+  ProgramPaymentLocksModule-->RedisModule
   RegistrationEventsModule-->UserModule
   RegistrationUtilsModule-->RegistrationDataModule
-  RegistrationsModule-->ActionsModule
   RegistrationsModule-->FspsModule
   RegistrationsModule-->IntersolveVisaModule
   RegistrationsModule-->LookupModule
@@ -156,7 +153,6 @@ graph LR
   TransactionJobsModule-->TransactionsModule
   TransactionQueuesModule-->QueuesRegistryModule
   TransactionQueuesModule-->RedisModule
-  TransactionsModule-->ActionsModule
   TransactionsModule-->MessageQueuesModule
   TransactionsModule-->MessageTemplateModule
   TransactionsModule-->RegistrationUtilsModule

--- a/services/121-service/src/payments/payments.module.ts
+++ b/services/121-service/src/payments/payments.module.ts
@@ -15,7 +15,6 @@ import { PaymentsExcelFspService } from '@121-service/src/payments/services/paym
 import { PaymentsExecutionService } from '@121-service/src/payments/services/payments-execution.service';
 import { PaymentsExecutionHelperService } from '@121-service/src/payments/services/payments-execution-helper.service';
 import { PaymentsHelperService } from '@121-service/src/payments/services/payments-helper.service';
-import { PaymentsProgressHelperService } from '@121-service/src/payments/services/payments-progress.helper.service';
 import { PaymentsReportingHelperService } from '@121-service/src/payments/services/payments-reporting.helper.service';
 import { PaymentsReportingService } from '@121-service/src/payments/services/payments-reporting.service';
 import { TransactionJobsCreationService } from '@121-service/src/payments/services/transaction-jobs-creation.service';
@@ -23,6 +22,7 @@ import { TransactionEventsModule } from '@121-service/src/payments/transactions/
 import { TransactionsModule } from '@121-service/src/payments/transactions/transactions.module';
 import { ProgramFspConfigurationsModule } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.module';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
+import { ProgramPaymentLocksModule } from '@121-service/src/programs/program-payment-locks/program-payment-locks.module';
 import { ProgramModule } from '@121-service/src/programs/programs.module';
 import { RegistrationAttributeDataEntity } from '@121-service/src/registration/entities/registration-attribute-data.entity';
 import { RegistrationDataModule } from '@121-service/src/registration/modules/registration-data/registration-data.module';
@@ -54,6 +54,7 @@ import { createScopedRepositoryProvider } from '@121-service/src/utils/scope/cre
     RegistrationEventsModule,
     TransactionEventsModule,
     MessageTemplateModule,
+    ProgramPaymentLocksModule,
   ],
   providers: [
     PaymentsCreationService,
@@ -61,7 +62,6 @@ import { createScopedRepositoryProvider } from '@121-service/src/utils/scope/cre
     PaymentsExecutionHelperService,
     PaymentsReportingService,
     PaymentsReportingHelperService,
-    PaymentsProgressHelperService,
     PaymentsHelperService,
     TransactionJobsCreationService,
     PaymentsExcelFspService,
@@ -71,10 +71,6 @@ import { createScopedRepositoryProvider } from '@121-service/src/utils/scope/cre
     createScopedRepositoryProvider(RegistrationAttributeDataEntity),
   ],
   controllers: [PaymentsController],
-  exports: [
-    PaymentsExecutionService,
-    PaymentsReportingService,
-    PaymentsProgressHelperService,
-  ],
+  exports: [PaymentsExecutionService, PaymentsReportingService],
 })
 export class PaymentsModule {}

--- a/services/121-service/src/payments/reconciliation/excel/excel-reconciliation.module.ts
+++ b/services/121-service/src/payments/reconciliation/excel/excel-reconciliation.module.ts
@@ -12,6 +12,7 @@ import { TransactionEventsModule } from '@121-service/src/payments/transactions/
 import { TransactionsModule } from '@121-service/src/payments/transactions/transactions.module';
 import { ProgramFspConfigurationsModule } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.module';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
+import { ProgramPaymentLocksModule } from '@121-service/src/programs/program-payment-locks/program-payment-locks.module';
 import { ProgramModule } from '@121-service/src/programs/programs.module';
 import { RegistrationsModule } from '@121-service/src/registration/registrations.module';
 import { FileImportService } from '@121-service/src/utils/file-import/file-import.service';
@@ -24,6 +25,7 @@ import { FileImportService } from '@121-service/src/utils/file-import/file-impor
     ExcelModule,
     RegistrationsModule,
     PaymentsModule,
+    ProgramPaymentLocksModule,
     ProgramFspConfigurationsModule,
     ProgramModule,
     TransactionEventsModule,

--- a/services/121-service/src/payments/reconciliation/excel/services/excel-reconciliation.service.ts
+++ b/services/121-service/src/payments/reconciliation/excel/services/excel-reconciliation.service.ts
@@ -9,12 +9,11 @@ import { ExcelService } from '@121-service/src/payments/fsp-integration/excel/ex
 import { ExcelStatusColumn } from '@121-service/src/payments/reconciliation/excel/excel-status-column.const';
 import { ExcelReconciliationFeedbackService } from '@121-service/src/payments/reconciliation/excel/services/excel-reconciliation-feedback.service';
 import { ExcelReconciliationValidationService } from '@121-service/src/payments/reconciliation/excel/services/excel-reconciliation-validation.service';
-import { PaymentsProgressHelperService } from '@121-service/src/payments/services/payments-progress.helper.service';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { TransactionEventDescription } from '@121-service/src/payments/transactions/transaction-events/enum/transaction-event-description.enum';
-import { TransactionEventsScopedRepository } from '@121-service/src/payments/transactions/transaction-events/repositories/transaction-events.scoped.repository';
 import { TransactionsService } from '@121-service/src/payments/transactions/transactions.service';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
+import { ProgramPaymentsLocksService } from '@121-service/src/programs/program-payment-locks/program-payment-locks.service';
 import { ProgramRegistrationAttributeRepository } from '@121-service/src/programs/repositories/program-registration-attribute.repository';
 import { RegistrationViewScopedRepository } from '@121-service/src/registration/repositories/registration-view-scoped.repository';
 import {
@@ -31,11 +30,10 @@ export class ExcelReconciliationService {
     private readonly excelService: ExcelService,
     private readonly fileImportService: FileImportService,
     private readonly registrationViewScopedRepository: RegistrationViewScopedRepository,
-    private readonly paymentsProgressHelperService: PaymentsProgressHelperService,
+    private readonly programPaymentsLocksService: ProgramPaymentsLocksService,
     private readonly programRegistrationAttributeRepository: ProgramRegistrationAttributeRepository,
 
     private readonly transactionsService: TransactionsService,
-    private readonly transactionEventsScopedRepository: TransactionEventsScopedRepository,
     private readonly excelReconciliationValidationService: ExcelReconciliationValidationService,
     private readonly excelReconciliationFeedbackService: ExcelReconciliationFeedbackService,
   ) {}
@@ -102,9 +100,7 @@ export class ExcelReconciliationService {
     ////////////////////////////////////////////////////////////////////////////
     // Preparing
     ////////////////////////////////////////////////////////////////////////////
-    if (
-      await this.paymentsProgressHelperService.isPaymentInProgress(programId)
-    ) {
+    if (await this.programPaymentsLocksService.isPaymentInProgress(programId)) {
       throw new HttpException(
         'Cannot import FSP reconciliation data while payment is in progress',
         HttpStatus.BAD_REQUEST,

--- a/services/121-service/src/payments/services/payments-creation.service.spec.ts
+++ b/services/121-service/src/payments/services/payments-creation.service.spec.ts
@@ -2,14 +2,14 @@ import { PaymentEvent } from '@121-service/src/payments/payment-events/enums/pay
 import { PaymentEventsService } from '@121-service/src/payments/payment-events/payment-events.service';
 import { PaymentsCreationService } from '@121-service/src/payments/services/payments-creation.service';
 import { PaymentsHelperService } from '@121-service/src/payments/services/payments-helper.service';
-import { PaymentsProgressHelperService } from '@121-service/src/payments/services/payments-progress.helper.service';
+import { ProgramPaymentsLocksService } from '@121-service/src/payments/services/payments-progress.helper.service';
 import { TransactionsService } from '@121-service/src/payments/transactions/transactions.service';
 import { RegistrationsBulkService } from '@121-service/src/registration/services/registrations-bulk.service';
 import { RegistrationsPaginationService } from '@121-service/src/registration/services/registrations-pagination.service';
 
 describe('PaymentsCreationService', () => {
   let service: PaymentsCreationService;
-  let paymentsProgressHelperService: PaymentsProgressHelperService;
+  let programPaymentsLocksService: ProgramPaymentsLocksService;
   let paymentsHelperService: PaymentsHelperService;
   let paymentEventsService: PaymentEventsService;
   let transactionsService: TransactionsService;
@@ -26,11 +26,11 @@ describe('PaymentsCreationService', () => {
   };
 
   beforeEach(() => {
-    paymentsProgressHelperService = {
+    programPaymentsLocksService = {
       checkPaymentInProgressAndThrow: jest.fn(),
       checkAndLockPaymentProgressOrThrow: jest.fn(),
       unlockPaymentsForProgram: jest.fn(),
-    } as unknown as PaymentsProgressHelperService;
+    } as unknown as ProgramPaymentsLocksService;
 
     paymentsHelperService = {
       checkFspConfigurationsOrThrow: jest.fn(),
@@ -69,7 +69,7 @@ describe('PaymentsCreationService', () => {
       registrationsPaginationService,
       paymentsHelperService,
       paymentEventsService,
-      paymentsProgressHelperService,
+      programPaymentsLocksService,
       transactionsService,
     );
     (service as any).paymentRepository = {
@@ -82,10 +82,10 @@ describe('PaymentsCreationService', () => {
     const result = await service.createPayment(params);
 
     expect(
-      paymentsProgressHelperService.checkAndLockPaymentProgressOrThrow,
+      programPaymentsLocksService.checkAndLockPaymentProgressOrThrow,
     ).not.toHaveBeenCalled();
     expect(
-      paymentsProgressHelperService.unlockPaymentsForProgram,
+      programPaymentsLocksService.unlockPaymentsForProgram,
     ).not.toHaveBeenCalled();
     expect(paymentEventsService.createEvent).not.toHaveBeenCalled();
     expect(
@@ -131,7 +131,7 @@ describe('PaymentsCreationService', () => {
 
     // Assert
     expect(
-      paymentsProgressHelperService.unlockPaymentsForProgram,
+      programPaymentsLocksService.unlockPaymentsForProgram,
     ).toHaveBeenCalledWith(basePaymentParams.programId);
     expect(paymentEventsService.createEvent).toHaveBeenCalledWith({
       userId: 1,
@@ -174,7 +174,7 @@ describe('PaymentsCreationService', () => {
       'Simulated error',
     );
     expect(
-      paymentsProgressHelperService.unlockPaymentsForProgram,
+      programPaymentsLocksService.unlockPaymentsForProgram,
     ).toHaveBeenCalledWith(basePaymentParams.programId);
   });
 
@@ -200,7 +200,7 @@ describe('PaymentsCreationService', () => {
       programFspConfigurationNames: [],
     });
     expect(
-      paymentsProgressHelperService.unlockPaymentsForProgram,
+      programPaymentsLocksService.unlockPaymentsForProgram,
     ).toHaveBeenCalledWith(basePaymentParams.programId);
   });
 });

--- a/services/121-service/src/payments/services/payments-creation.service.ts
+++ b/services/121-service/src/payments/services/payments-creation.service.ts
@@ -8,8 +8,8 @@ import { TransactionCreationDetails } from '@121-service/src/payments/interfaces
 import { PaymentEvent } from '@121-service/src/payments/payment-events/enums/payment-event.enum';
 import { PaymentEventsService } from '@121-service/src/payments/payment-events/payment-events.service';
 import { PaymentsHelperService } from '@121-service/src/payments/services/payments-helper.service';
-import { PaymentsProgressHelperService } from '@121-service/src/payments/services/payments-progress.helper.service';
 import { TransactionsService } from '@121-service/src/payments/transactions/transactions.service';
+import { ProgramPaymentsLocksService } from '@121-service/src/programs/program-payment-locks/program-payment-locks.service';
 import { BulkActionResultPaymentDto } from '@121-service/src/registration/dto/bulk-action-result.dto';
 import { MappedPaginatedRegistrationDto } from '@121-service/src/registration/dto/mapped-paginated-registration.dto';
 import { RegistrationViewEntity } from '@121-service/src/registration/entities/registration-view.entity';
@@ -29,7 +29,7 @@ export class PaymentsCreationService {
     private readonly registrationsPaginationService: RegistrationsPaginationService,
     private readonly paymentsHelperService: PaymentsHelperService,
     private readonly paymentEventsService: PaymentEventsService,
-    private readonly paymentsProgressHelperService: PaymentsProgressHelperService,
+    private readonly programPaymentsLocksService: ProgramPaymentsLocksService,
     private readonly transactionsService: TransactionsService,
   ) {}
 
@@ -49,12 +49,12 @@ export class PaymentsCreationService {
     note?: string;
   }): Promise<BulkActionResultPaymentDto> {
     if (dryRun) {
-      await this.paymentsProgressHelperService.checkPaymentInProgressAndThrow(
+      await this.programPaymentsLocksService.checkPaymentInProgressAndThrow(
         programId,
       );
     } else {
       // Only lock payments when not a dry run
-      await this.paymentsProgressHelperService.checkAndLockPaymentProgressOrThrow(
+      await this.programPaymentsLocksService.checkAndLockPaymentProgressOrThrow(
         { programId },
       );
     }
@@ -109,7 +109,7 @@ export class PaymentsCreationService {
     } finally {
       if (!dryRun) {
         // make sure to unblock payments also in case of failure
-        await this.paymentsProgressHelperService.unlockPaymentsForProgram(
+        await this.programPaymentsLocksService.unlockPaymentsForProgram(
           programId,
         );
       }

--- a/services/121-service/src/payments/services/payments-excel-fsp.service.ts
+++ b/services/121-service/src/payments/services/payments-excel-fsp.service.ts
@@ -4,12 +4,12 @@ import { Equal, In } from 'typeorm';
 import { Fsps } from '@121-service/src/fsps/enums/fsp-name.enum';
 import { FspInstructions } from '@121-service/src/payments/dto/fsp-instructions.dto';
 import { ExcelService } from '@121-service/src/payments/fsp-integration/excel/excel.service';
-import { PaymentsProgressHelperService } from '@121-service/src/payments/services/payments-progress.helper.service';
 import { PaymentsReportingService } from '@121-service/src/payments/services/payments-reporting.service';
 import { TransactionEntity } from '@121-service/src/payments/transactions/entities/transaction.entity';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { TransactionViewScopedRepository } from '@121-service/src/payments/transactions/repositories/transaction.view.scoped.repository';
 import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';
+import { ProgramPaymentsLocksService } from '@121-service/src/programs/program-payment-locks/program-payment-locks.service';
 
 // The functionality in this service was meant a generic implementation of FSPs that work by importing and exporting files like vodacash
 // but in the end we converged to using it only for a generically configurable excel based FSP integration
@@ -20,7 +20,7 @@ export class PaymentsExcelFspService {
   public constructor(
     private readonly excelService: ExcelService,
     private readonly programFspConfigurationRepository: ProgramFspConfigurationRepository,
-    private readonly paymentsProgressHelperService: PaymentsProgressHelperService,
+    private readonly programPaymentsLocksService: ProgramPaymentsLocksService,
     private readonly paymentsReportingService: PaymentsReportingService,
     private readonly transactionViewScopedRepository: TransactionViewScopedRepository,
   ) {}
@@ -33,9 +33,7 @@ export class PaymentsExcelFspService {
     // Validation & preparation
     /////////////////////////////////////
 
-    if (
-      await this.paymentsProgressHelperService.isPaymentInProgress(programId)
-    ) {
+    if (await this.programPaymentsLocksService.isPaymentInProgress(programId)) {
       throw new HttpException(
         'Cannot export FSP instructions while payment is in progress',
         HttpStatus.BAD_REQUEST,

--- a/services/121-service/src/payments/services/payments-reporting.service.ts
+++ b/services/121-service/src/payments/services/payments-reporting.service.ts
@@ -9,10 +9,10 @@ import { ProgramPaymentsStatusDto } from '@121-service/src/payments/dto/program-
 import { PaymentEntity } from '@121-service/src/payments/entities/payment.entity';
 import { PaymentEventsReturnDto } from '@121-service/src/payments/payment-events/dtos/payment-events-return.dto';
 import { PaymentEventsService } from '@121-service/src/payments/payment-events/payment-events.service';
-import { PaymentsProgressHelperService } from '@121-service/src/payments/services/payments-progress.helper.service';
 import { PaymentsReportingHelperService } from '@121-service/src/payments/services/payments-reporting.helper.service';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { TransactionViewScopedRepository } from '@121-service/src/payments/transactions/repositories/transaction.view.scoped.repository';
+import { ProgramPaymentsLocksService } from '@121-service/src/programs/program-payment-locks/program-payment-locks.service';
 import { ProgramRegistrationAttributeRepository } from '@121-service/src/programs/repositories/program-registration-attribute.repository';
 import { MappedPaginatedRegistrationDto } from '@121-service/src/registration/dto/mapped-paginated-registration.dto';
 import {
@@ -29,7 +29,7 @@ export class PaymentsReportingService {
 
   public constructor(
     private readonly paymentsReportingHelperService: PaymentsReportingHelperService,
-    private readonly paymentsProgressHelperService: PaymentsProgressHelperService,
+    private readonly programPaymentsLocksService: ProgramPaymentsLocksService,
     private readonly programRegistrationAttributeRepository: ProgramRegistrationAttributeRepository,
     private readonly registrationPaginationService: RegistrationsPaginationService,
     private readonly transactionViewScopedRepository: TransactionViewScopedRepository,
@@ -124,7 +124,7 @@ export class PaymentsReportingService {
   ): Promise<ProgramPaymentsStatusDto> {
     return {
       inProgress:
-        await this.paymentsProgressHelperService.isPaymentInProgress(programId),
+        await this.programPaymentsLocksService.isPaymentInProgress(programId),
     };
   }
 

--- a/services/121-service/src/programs/program-payment-locks/program-payment-lock.entity.ts
+++ b/services/121-service/src/programs/program-payment-locks/program-payment-lock.entity.ts
@@ -1,0 +1,21 @@
+import {
+  BaseEntity,
+  Column,
+  Index,
+  JoinColumn,
+  OneToOne,
+  Relation,
+} from 'typeorm';
+
+import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
+
+export class ProgramPaymentLockEntity extends BaseEntity {
+  @Index({ unique: true })
+  @OneToOne(() => ProgramEntity, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'programId' })
+  public program: Relation<ProgramEntity>;
+  @Column({ type: 'int', nullable: false })
+  public programId: number;
+}

--- a/services/121-service/src/programs/program-payment-locks/program-payment-locks.module.ts
+++ b/services/121-service/src/programs/program-payment-locks/program-payment-locks.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { RedisModule } from '@121-service/src/payments/redis/redis.module';
+import { ProgramPaymentLockEntity } from '@121-service/src/programs/program-payment-locks/program-payment-lock.entity';
+import { ProgramPaymentsLocksService } from '@121-service/src/programs/program-payment-locks/program-payment-locks.service';
+
+@Module({
+  imports: [RedisModule, TypeOrmModule.forFeature([ProgramPaymentLockEntity])],
+  controllers: [],
+  providers: [ProgramPaymentsLocksService],
+  exports: [ProgramPaymentsLocksService],
+})
+export class ProgramPaymentLocksModule {}


### PR DESCRIPTION
AB#XXXX <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

I got to work not allowing editing FSP config during a payment for this [item](https://dev.azure.com/redcrossnl/121%20Platform/_sprints/taskboard/121%20Development%20Team/121%20Platform/Sprint%20167?workitem=38745). Due to circular depencies it was not possible to use the payment in progress helper in the fspconfigmodule. So I refactored the whole thing in a separate module. 

Buuut..., later I realized that, this subtask was mostly about not allowing fsp config changes between creation and start and not during payment in progress. Not editing fsp config between create and start I think we already cover because we check the fspcConfig also when starting the payment.. 

So this PR is a bit of waste. What do you think @jannisvisser, worth it to continue this effort or discard it. I am inclined to discard it

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines
- [ ] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
