### PR TITLE
chore: Tell CoPilot how not to use TypeORM querybuilder

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -561,6 +561,8 @@ npm run test:all           # Run all tests
 - ❌ Missing error handling in async operations
 - ❌ Circular dependencies between modules
 - ❌ Unsafe TypeORM where conditions
+- ❌ Using TypeORM's `queryBuilder` without using table aliases
+- ❌ Using TypeORM's `queryBuilder` when `.find`, `.findOne` or `.save` would suffice
 
 ## Additional Resources
 


### PR DESCRIPTION
[AB#38946](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38946) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Tell CoPilot how not to use TypeORM querybuilder.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
- [x] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
