### PR TITLE
feat: make sure readonlyuser in db can read future db objects

### DIFF
--- a/services/121-service/src/migration/1762340084238-add-default-privileges-for-readonly-user.ts
+++ b/services/121-service/src/migration/1762340084238-add-default-privileges-for-readonly-user.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDefaultPrivilegesForReadonlyUser1762340084238
+  implements MigrationInterface
+{
+  name = 'AddDefaultPrivilegesForReadonlyUser1762340084238';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const doesReadonlyuserExist = await queryRunner.query(
+      `SELECT * FROM pg_roles WHERE rolname='readonlyuser'`,
+    );
+    if (doesReadonlyuserExist.length === 0) {
+      // We're not sure all instances have a readonly user.
+      return;
+    }
+    await queryRunner.query(
+      `GRANT USAGE ON SCHEMA "121-service" TO "readonlyuser";`,
+    );
+    await queryRunner.query(
+      `GRANT SELECT ON ALL TABLES IN SCHEMA "121-service" TO "readonlyuser";`,
+    );
+    await queryRunner.query(
+      `ALTER DEFAULT PRIVILEGES IN SCHEMA "121-service" GRANT SELECT ON TABLES TO "readonlyuser";`,
+    );
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // only up
+  }
+}


### PR DESCRIPTION
[AB#38935](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38935) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

feat: make sure readonlyuser in db can read future db objects

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
- [x] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
