### PR TITLE
fix: i18n error

### DIFF
--- a/interfaces/portal/src/app/app.routes.ts
+++ b/interfaces/portal/src/app/app.routes.ts
@@ -191,7 +191,7 @@ export const routes: Routes = [
             title:
               $localize`:@@page-title-project-settings-fsps:FSPs` +
               ' | ' +
-              $localize`:@@page-title-project-settings:Project settings`,
+              $localize`:@@page-title-project-project-settings:Project settings`,
             loadComponent: () =>
               import(
                 '~/pages/project-settings-fsps/project-settings-fsps.page'

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -2003,6 +2003,9 @@
       <trans-unit id="9102963095355753902" datatype="html">
         <source>Slovak</source>
       </trans-unit>
+      <trans-unit id="page-title-project-project-settings" datatype="html">
+        <source>Project settings</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
[AB#39056](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39056)

## Describe your changes

Fixes this error on running 'npm run extract-i18n'. Unclear why this suddenly popped up while the cause for it seems to have been in the codebase for some time. 
```
WARNINGS:
- Duplicate messages with id "page-title-project-settings":
   - "Settings" : src/app/components/page-layout/components/project-menu/project-menu.component.ts:48
   - "Settings" : src/app/app.routes.ts:167
   - "Settings" : src/app/app.routes.ts:174
   - "Project settings" : src/app/app.routes.ts:194
   - "Settings" : src/app/app.routes.ts:208
 ```

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines
- [ ] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7498.westeurope.3.azurestaticapps.net
