### PR TITLE
feat: Add tracking-events to "Retry transfer"-button(s)

### DIFF
--- a/interfaces/portal/src/app/pages/project-payment-transfer-list/components/retry-transfers-dialog/retry-transfers-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/project-payment-transfer-list/components/retry-transfers-dialog/retry-transfers-dialog.component.ts
@@ -77,7 +77,7 @@ export class RetryTransfersDialogComponent {
         ? 'retry-transaction:single'
         : 'retry-transaction:multiple';
     this.trackingService.trackEvent({
-      category: TrackingCategory.manageTransactions,
+      category: TrackingCategory.manageRetryTransactions,
       action: TrackingAction.clickRetryTransactionButton,
       name: eventName,
       value: referenceIds.length,
@@ -94,7 +94,7 @@ export class RetryTransfersDialogComponent {
     this.referenceIdsForRetryTransfers.set(referenceIds);
     this.retryTransfersConfirmationDialog().show({
       trackingEvent: {
-        category: TrackingCategory.manageTransactions,
+        category: TrackingCategory.manageRetryTransactions,
         action: TrackingAction.clickProceedButton,
         name: eventName,
         value: referenceIds.length,

--- a/interfaces/portal/src/app/services/tracking.service.ts
+++ b/interfaces/portal/src/app/services/tracking.service.ts
@@ -27,8 +27,8 @@ export enum TrackingCategory {
   export = 'Export',
   hiddenFeatures = 'Hidden Features',
   manageRegistrations = 'Manage Registrations',
+  manageRetryTransactions = 'Manage Retry Transactions',
   manageTableSettings = 'Manage Table-settings',
-  manageTransactions = 'Manage Transactions',
 }
 
 /**


### PR DESCRIPTION
See [AB#38843](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38843)

[AB#38815](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38815) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Matomo tracking of retry payment flow.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines
- [x] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7502.westeurope.3.azurestaticapps.net
