### PR TITLE
chore: point-wiki-module-diagram-to-121-repo

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -11,7 +11,6 @@ AB#XXXX <!--- Replace this with a reference to a DevOps/backlog-issue -->
 - [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
 - [ ] I have made sure that all automated checks pass before requesting a review
 - [ ] I do not need any deviation from our PR guidelines
-- [ ] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.
 
 ## Portal preview-deployment
 

--- a/services/121-service/src/main.ts
+++ b/services/121-service/src/main.ts
@@ -35,7 +35,6 @@ function generateModuleDependencyGraph(app: INestApplication): void {
   const edges = SpelunkerModule.findGraphEdges(root);
   const genericModules = [
     // Sorted alphabetically
-    'ActionModule',
     'ApplicationModule',
     'AuthModule',
     'BullModule',


### PR DESCRIPTION
[AB#39170](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39170)

## Describe your changes

- the most notable change for this is in the [wiki](https://github.com/global-121/121-platform/wiki/121-Service) of course
- in here: remove bullet from the PR template + remove actions-module from modules to ignore (already, as this is soon removed in the start-payment feature branch).

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I do not need any deviation from our PR guidelines
- [ ] I have updated the [121 Service Module Dependency Diagram in the wiki](https://github.com/global-121/121-platform/wiki/121-Service-Module-Diagram) when the 121 module dependencies have changed.

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
