### PR TITLE
fix: Prevent "⌘+Enter" for sensitive operations (workaround)

### DIFF
--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
@@ -19,8 +19,8 @@
   <form
     class="block w-full"
     (ngSubmit)="onFormSubmit()"
-    (keydown.control.enter)="onFormSubmit()"
-    (keydown.meta.enter)="onFormSubmit()"
+    (keydown.control.enter)="onKeyboardSubmit()"
+    (keydown.meta.enter)="onKeyboardSubmit()"
   >
     <div class="space-y-4">
       <p>

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
@@ -279,8 +279,26 @@ export class ChangeStatusDialogComponent
     this.changeStatusMutation.mutate({ dryRun: true });
   }
 
+  onKeyboardSubmit(): void {
+    // Prevent "Enter"-key from submitting for 'sensitive' status changes like "Delete";
+    // Only as a quick workaround, before we have properly refactored several dialogs and their form-validation-logic. See AB#39194
+    if (this.status() === RegistrationStatusEnum.deleted) {
+      return;
+    }
+
+    this.onFormSubmit();
+  }
+
   onChangeStatusCancel() {
     this.dialogVisible.set(false);
     this.changeStatusMutation.reset();
+
+    // Manual reset the input that might already be given;
+    // These steps are only necessary while they're not properly part of a FormGroup that can reset on close of the dialog
+    // See AB#39194
+    this.reason.set(undefined);
+    this.reasonValidationErrorMessage.set(undefined);
+    this.enableSendMessage.set(false);
+    this.customMessage.set(undefined);
   }
 }


### PR DESCRIPTION
[AB#38959](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38959)

## Describe your changes

⚠️ Not the prettiest fix.
Some manual checks should still be done to see if we're not blocking/breaking other confirm-promtps...

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have NOT added tests for my changes
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7526.westeurope.3.azurestaticapps.net
