### PR TITLE
chore: revert failing typecheck on e2e lint-staged

### DIFF
--- a/e2e/.lintstagedrc.js
+++ b/e2e/.lintstagedrc.js
@@ -3,6 +3,5 @@ const baseConfig = require('../.lintstagedrc.js');
 // See: https://github.com/lint-staged/lint-staged#using-js-configuration-files
 module.exports = {
   ...baseConfig,
-  '*.ts': () => 'npm run typecheck', // Needs to run the whole project, not just the staged/changed files
   '*.{ts,js}': 'eslint --fix',
 };


### PR DESCRIPTION
[AB#39195](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39195)

## Describe your changes

This check was failing whenever there were staged e2e files, so reverting it. 

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
