### PR TITLE
fix: Catch several connection errors for CBE in 1 log-line

### DIFF
--- a/services/121-service/src/payments/fsp-integration/commercial-bank-ethiopia/services/commercial-bank-ethiopia.api.service.ts
+++ b/services/121-service/src/payments/fsp-integration/commercial-bank-ethiopia/services/commercial-bank-ethiopia.api.service.ts
@@ -272,7 +272,7 @@ export class CommercialBankEthiopiaApiService {
         resultDescription: 'Unknown error occurred.',
       };
 
-      if (error.code === 'ENOTFOUND') {
+      if (['ENOTFOUND', 'ECONNREFUSED', 'ETIMEDOUT'].includes(error.code)) {
         console.error(
           'Failed because of CBE connection error. Please try again later',
         );


### PR DESCRIPTION
[AB#39215](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39215)

## Describe your changes

Currently, when there is a CBE-VPN/API-related connection-issue, the daily cronjob of "account enquiries" will produce a lot of noise in the Docker-logs.

In this case, the failure of 1800+ requests resulted in 12 (!) separate log-files, all with a lot of verbose "the whole request+response object"-data.
<img width="957" height="263" alt="image" src="https://github.com/user-attachments/assets/ee38b284-be19-4d51-ab00-c93c7b3dcbbf" />

The changed code would catch more of these issue under 1 generic "something is wrong with the connection"-logline.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have NOT added tests for my changes
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
