### PR TITLE
feat: Add TelemetryProcessor to correlate Portal-requests to back-end

### DIFF
--- a/interfaces/portal/src/app/services/http-wrapper.service.ts
+++ b/interfaces/portal/src/app/services/http-wrapper.service.ts
@@ -12,7 +12,10 @@ import { get } from 'radashi';
 import { lastValueFrom, of } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 
-import { InterfaceNames } from '@121-service/src/shared/enum/interface-names.enum';
+import {
+  INTERFACE_NAME_HEADER,
+  InterfaceNames,
+} from '@121-service/src/shared/enum/interface-names.enum';
 
 import { getUserFromLocalStorage } from '~/utils/local-storage';
 import { environment } from '~environment';
@@ -42,7 +45,7 @@ export class HttpWrapperService {
     let headers = new HttpHeaders({
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      'X-121-Interface': InterfaceNames.portal,
+      [INTERFACE_NAME_HEADER]: InterfaceNames.portal,
     });
 
     if (isUpload) {

--- a/interfaces/portal/src/logout/logout.js
+++ b/interfaces/portal/src/logout/logout.js
@@ -18,7 +18,7 @@ window.setTimeout(async () => {
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
-        'X-121-Interface': 'portal', // See: services/121-service/src/shared/enum/interface-names.enum.ts
+        'x-121-interface': 'portal', // See: services/121-service/src/shared/enum/interface-names.enum.ts
       },
       method: 'POST',
       mode: 'cors',

--- a/services/121-service/src/shared/enum/interface-names.enum.ts
+++ b/services/121-service/src/shared/enum/interface-names.enum.ts
@@ -1,3 +1,5 @@
+export const INTERFACE_NAME_HEADER = 'x-121-interface';
+
 export enum InterfaceNames {
   portal = 'portal', // Hard-coded, used in: interfaces/portal/src/logout/logout.js (make sure to keep in sync)
 }

--- a/services/121-service/src/strategies/cookie-jwt.strategy.ts
+++ b/services/121-service/src/strategies/cookie-jwt.strategy.ts
@@ -11,7 +11,10 @@ import { Strategy } from 'passport-jwt';
 import { env } from '@121-service/src/env';
 import { AuthenticatedUserParameters } from '@121-service/src/guards/authenticated-user.decorator';
 import { CookieNames } from '@121-service/src/shared/enum/cookie.enums';
-import { InterfaceNames } from '@121-service/src/shared/enum/interface-names.enum';
+import {
+  INTERFACE_NAME_HEADER,
+  InterfaceNames,
+} from '@121-service/src/shared/enum/interface-names.enum';
 import { UserRequestData } from '@121-service/src/user/user.interface';
 import { UserService } from '@121-service/src/user/user.service';
 
@@ -26,8 +29,8 @@ export class CookieJwtStrategy
     super({
       jwtFromRequest: (req: any) => {
         let token = null;
-        const headerKey = 'x-121-interface';
-        const originInterface: InterfaceNames = req.headers[headerKey];
+        const originInterface: InterfaceNames =
+          req.headers[INTERFACE_NAME_HEADER];
 
         if (req && req.cookies) {
           switch (originInterface) {

--- a/services/121-service/src/user/user.service.ts
+++ b/services/121-service/src/user/user.service.ts
@@ -13,7 +13,10 @@ import { env } from '@121-service/src/env';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { ProgramAidworkerAssignmentEntity } from '@121-service/src/programs/entities/program-aidworker.entity';
 import { CookieNames } from '@121-service/src/shared/enum/cookie.enums';
-import { InterfaceNames } from '@121-service/src/shared/enum/interface-names.enum';
+import {
+  INTERFACE_NAME_HEADER,
+  InterfaceNames,
+} from '@121-service/src/shared/enum/interface-names.enum';
 import { PostgresStatusCodes } from '@121-service/src/shared/enum/postgres-status-codes.enum';
 import {
   CreateProgramAssignmentDto,
@@ -600,8 +603,7 @@ export class UserService {
   }
 
   public getInterfaceKeyByHeader(): string {
-    const headerKey = 'x-121-interface';
-    const originInterface = this.request.headers[headerKey];
+    const originInterface = this.request.headers[INTERFACE_NAME_HEADER];
     switch (originInterface) {
       case InterfaceNames.portal:
         return CookieNames.portal;


### PR DESCRIPTION
[AB#39575](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39575)

Also, see: [AB#37849](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/37849)

## Describe your changes

Add a customProperty to all "incoming Requests"-logs in Azure;
So we can correlate the use of our Portal v.s. "other uses"

See also: #7311

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have NOT added tests for my changes
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7547.westeurope.3.azurestaticapps.net
