### PR TITLE
Order of question in registrations pages stays the same

### DIFF
--- a/services/121-service/src/program-attributes/program-attributes.service.ts
+++ b/services/121-service/src/program-attributes/program-attributes.service.ts
@@ -22,7 +22,7 @@ export class ProgramAttributesService {
   @InjectRepository(ProgramEntity)
   private readonly programRepository: Repository<ProgramEntity>;
   @InjectRepository(ProgramRegistrationAttributeEntity)
-  private readonly programRegistrationAttributeEntity: Repository<ProgramRegistrationAttributeEntity>;
+  private readonly programRegistrationAttributeRepository: Repository<ProgramRegistrationAttributeEntity>;
 
   public getFilterableAttributes(program: ProgramEntity) {
     const genericPaAttributeFilters = [
@@ -163,7 +163,7 @@ export class ProgramAttributesService {
     programId: number,
   ): Promise<Attribute[]> {
     const programRegistrationAttributes = (
-      await this.programRegistrationAttributeEntity.find({
+      await this.programRegistrationAttributeRepository.find({
         where: { program: { id: Equal(programId) } },
       })
     ).map((c) => {
@@ -181,7 +181,7 @@ export class ProgramAttributesService {
     programId: number,
     filterShowInRegistrationsTable?: boolean,
   ): Promise<Attribute[]> {
-    let queryRegistrationAttr = this.programRegistrationAttributeEntity
+    let queryRegistrationAttr = this.programRegistrationAttributeRepository
       .createQueryBuilder('programRegistrationAttribute')
       .orderBy('programRegistrationAttribute.created', 'ASC')
       .where({ program: { id: programId } });

--- a/services/121-service/src/utils/test-helpers/createQueryBuilderMock.helper.ts
+++ b/services/121-service/src/utils/test-helpers/createQueryBuilderMock.helper.ts
@@ -7,6 +7,7 @@ interface QueryBuilderMock {
   getMany?: () => any;
   getRawMany?: () => any;
   distinct?: () => QueryBuilderMock;
+  orderBy?: () => QueryBuilderMock;
 }
 
 export function generateMockCreateQueryBuilder(
@@ -20,6 +21,7 @@ export function generateMockCreateQueryBuilder(
     andWhere: () => mock,
     leftJoin: () => mock,
     distinct: () => mock,
+    orderBy: () => mock,
   };
 
   if (options.useGetMany) {


### PR DESCRIPTION
[AB#39319](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39319) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

PR ensures that order of the questions on the registration page stays the same. 

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from our PR guidelines

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
