### PR TITLE
fix: Prevent clipping of PrimeIcons (in Firefox)

### DIFF
--- a/interfaces/portal/src/styles.css
+++ b/interfaces/portal/src/styles.css
@@ -407,11 +407,13 @@ svg-icon svg {
     @apply txt-body-s;
   }
 
-   /*
+  /**
    * Prevents PrimeIcons (.pi) from overflowing their containers during layout changes.
    * See AB#38977 for details.
+   * Using only  `contain: paint;` will cause clipping-issues in Firefox, these 2 values below fix it cross-platform.
    */
   .pi {
-    contain: paint;
+    transform: translateZ(0);
+    will-change: transform;
   }
 }


### PR DESCRIPTION
[AB#39396](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39396)

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] Adding tests is unnecessary/irrelevant
- [x] I have NOT asked the design team to review these changes
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7564.westeurope.3.azurestaticapps.net
