### PR TITLE
fix: Remove "deployments"-noise from PRs timelines

### DIFF
--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -48,7 +48,6 @@ jobs:
     needs: path-filter
     runs-on: ubuntu-latest
     if: ${{ needs.path-filter.outputs.should_skip != 'true' }}
-    environment: test
     steps:
       - name: Check out repository code
         uses: actions/checkout@v5
@@ -75,8 +74,6 @@ jobs:
       - path-filter
       - lint-code
     if: ${{ needs.path-filter.outputs.should_skip != 'true' }}
-    environment: test
-
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Access to the environments' Vars / Secrets is not used, so no need.

See [AB#39402](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39402)

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] Adding tests is unnecessary/irrelevant
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
