### PR TITLE
fix: refresh table after bulk status change with non applicable registrations

### DIFF
--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
@@ -235,8 +235,6 @@ export class ChangeStatusDialogComponent
         this.invalidateCache();
 
         return;
-      } else {
-        this.invalidateCache();
       }
 
       if (data.applicableCount === 0) {
@@ -251,6 +249,9 @@ export class ChangeStatusDialogComponent
       this.dryRunWarningDialog().show({
         resetMutation: false,
       });
+      if (!variables.dryRun) {
+        this.invalidateCache();
+      }
     },
   }));
 


### PR DESCRIPTION
[AB#39458](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39458) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7608.westeurope.3.azurestaticapps.net
