### PR TITLE
fix: Make sure all languages are shown consistently capitalized in language-switcher

### DIFF
--- a/interfaces/portal/src/app/components/locale-switcher/locale-switcher.component.html
+++ b/interfaces/portal/src/app/components/locale-switcher/locale-switcher.component.html
@@ -2,7 +2,7 @@
   [options]="locales"
   [(ngModel)]="selectedLocale"
   [showClear]="false"
-  styleClass="w-full"
+  class="w-full"
   data-testid="locale-dropdown"
 >
   <ng-template pTemplate="selectedItem">

--- a/interfaces/portal/src/app/components/locale-switcher/locale-switcher.component.ts
+++ b/interfaces/portal/src/app/components/locale-switcher/locale-switcher.component.ts
@@ -1,3 +1,4 @@
+import { TitleCasePipe } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -21,15 +22,21 @@ import {
 @Component({
   selector: 'app-locale-switcher',
   imports: [FormsModule, SelectModule],
+  providers: [TitleCasePipe],
   templateUrl: './locale-switcher.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LocaleSwitcherComponent {
   private locale = inject<Locale>(LOCALE_ID);
-  public locales = getAvailableLocales();
+  private titleCasePipe = inject(TitleCasePipe);
+
+  public locales = getAvailableLocales().map((locale) => ({
+    label: this.titleCasePipe.transform(locale.label),
+    value: locale.value,
+  }));
   public readonly selectedLocale = model(this.locale);
   public readonly selectedLocaleLabel = computed(() =>
-    getLocaleLabel(this.selectedLocale()),
+    this.titleCasePipe.transform(getLocaleLabel(this.selectedLocale())),
   );
 
   constructor() {


### PR DESCRIPTION
[AB#39460](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39460)

## Describe your changes

In the language-switcher, not all languages where shown with a capital first character...
As they are capitalized according to each language's rules... But we're not using the word "in a sentence", we're using it as a standalone label. So each entry should be 'equal(ly capitalized)'.

**Note:**  
I tried it first with an "only CSS"-option, but that didn't work for both use-cases (the list AND the selected-option); Therefore: both in JS (only)

**Note 2:**  
The other uses of a "languages dropdown" show the whole list "in the language of the UI" according to the rules of _that_ language. (So each language is equal in the list)
Therefor: I left those 'as-is' (so "all languages lowercase" in French/Dutch).

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] Adding tests is unnecessary/irrelevant
- [x] The changes fix the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7610.westeurope.3.azurestaticapps.net
