### PR TITLE
refactor: Make all (sorted) translated lists, locale-aware

### DIFF
--- a/interfaces/portal/src/app/components/data-list/data-list.component.ts
+++ b/interfaces/portal/src/app/components/data-list/data-list.component.ts
@@ -111,6 +111,8 @@ export class DataListComponent {
       return this.translatableStringService.translate(option?.label) ?? v;
     });
 
-    return this.translatableStringService.commaSeparatedList(valueList);
+    return this.translatableStringService.commaSeparatedList({
+      values: valueList,
+    });
   }
 }

--- a/interfaces/portal/src/app/components/page-layout-payment/components/program-payment-chart/program-payment-chart.component.ts
+++ b/interfaces/portal/src/app/components/page-layout-payment/components/program-payment-chart/program-payment-chart.component.ts
@@ -128,11 +128,12 @@ export class ProgramPaymentChartComponent {
 
     return (
       $localize`Payment status chart. ` +
-      this.translatableStringService.commaSeparatedList(
-        chartData.labels.map(
+      this.translatableStringService.commaSeparatedList({
+        values: chartData.labels.map(
           (label, index) => `${label}: ${String(metrics[index])}`,
         ),
-      )
+        sortedAlphabetically: false,
+      })
     );
   });
 }

--- a/interfaces/portal/src/app/components/page-layout-payment/page-layout-payment.component.ts
+++ b/interfaces/portal/src/app/components/page-layout-payment/page-layout-payment.component.ts
@@ -36,6 +36,7 @@ import { AuthService } from '~/services/auth.service';
 import { PaginateQuery } from '~/services/paginate-query.service';
 import { RtlHelperService } from '~/services/rtl-helper.service';
 import { TranslatableStringService } from '~/services/translatable-string.service';
+import { Locale } from '~/utils/locale';
 @Component({
   selector: 'app-page-layout-payment',
   imports: [
@@ -62,7 +63,7 @@ export class PageLayoutPaymentComponent {
 
   readonly rtlHelper = inject(RtlHelperService);
   readonly currencyPipe = inject(CurrencyPipe);
-  readonly locale = inject(LOCALE_ID);
+  readonly locale = inject<Locale>(LOCALE_ID);
   readonly paymentApiService = inject(PaymentApiService);
   readonly programApiService = inject(ProgramApiService);
   readonly translatableStringService = inject(TranslatableStringService);
@@ -221,7 +222,9 @@ export class PageLayoutPaymentComponent {
           '',
       );
 
-    return fspLabels.join(', ');
+    return this.translatableStringService.commaSeparatedList({
+      values: fspLabels,
+    });
   });
 
   readonly startPaymentTransactionCount = computed<string>(() => {

--- a/interfaces/portal/src/app/components/page-layout-registration/components/registration-duplicates-banner/registration-duplicates-banner.component.html
+++ b/interfaces/portal/src/app/components/page-layout-registration/components/registration-duplicates-banner/registration-duplicates-banner.component.html
@@ -39,17 +39,16 @@
               }
               <span class="pi pi-external-link ms-1"></span>
             </a>
+            @let matchingFieldNames =
+              translatableStringService.commaSeparatedList({
+                values: duplicate.attributeNames,
+              });
             <span
               i18n
               class="ms-1"
             >
-              (matching fields:
-              {{
-                translatableStringService.commaSeparatedList(
-                  duplicate.attributeNames
-                )
-              }})</span
-            >
+              (matching fields: {{ matchingFieldNames }})
+            </span>
           </li>
         }
       </ul>

--- a/interfaces/portal/src/app/components/program-form-budget/program-form-budget.component.ts
+++ b/interfaces/portal/src/app/components/program-form-budget/program-form-budget.component.ts
@@ -2,7 +2,9 @@ import {
   ChangeDetectionStrategy,
   Component,
   effect,
+  inject,
   input,
+  LOCALE_ID,
 } from '@angular/core';
 import {
   FormControl,
@@ -20,6 +22,7 @@ import { FormFieldWrapperComponent } from '~/components/form-field-wrapper/form-
 import { PROGRAM_FORM_TOOLTIPS } from '~/domains/program/program.helper';
 import { Program } from '~/domains/program/program.model';
 import { generateFieldErrors } from '~/utils/form-validation';
+import { Locale } from '~/utils/locale';
 
 export type ProgramBudgetFormGroup =
   (typeof ProgramFormBudgetComponent)['prototype']['formGroup'];
@@ -37,6 +40,7 @@ export type ProgramBudgetFormGroup =
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProgramFormBudgetComponent {
+  private readonly locale = inject<Locale>(LOCALE_ID);
   readonly program = input<Program>();
 
   readonly currencies = Object.values(CurrencyCode)
@@ -44,7 +48,7 @@ export class ProgramFormBudgetComponent {
       label: code,
       value: code,
     }))
-    .sort((a, b) => a.label.localeCompare(b.label));
+    .sort((a, b) => a.label.localeCompare(b.label, this.locale));
 
   formGroup = new FormGroup({
     budget: new FormControl<number | undefined>(

--- a/interfaces/portal/src/app/domains/notification/notification.api.service.ts
+++ b/interfaces/portal/src/app/domains/notification/notification.api.service.ts
@@ -45,7 +45,7 @@ export class NotificationApiService extends DomainApiService {
               this.translatableStringService.translate(template.label) ??
               $localize`<UNNAMED TEMPLATE>`,
           }))
-          .sort((a, b) => a.label.localeCompare(b.label)),
+          .sort((a, b) => a.label.localeCompare(b.label, this.locale)),
       enabled: () => !!programId(),
     });
   }

--- a/interfaces/portal/src/app/pages/program-monitoring-dashboard/components/payments-aggregate-chart/payments-aggregate-chart.component.ts
+++ b/interfaces/portal/src/app/pages/program-monitoring-dashboard/components/payments-aggregate-chart/payments-aggregate-chart.component.ts
@@ -18,6 +18,7 @@ import { TransactionStatusEnum } from '@121-service/src/payments/transactions/en
 import { MetricApiService } from '~/domains/metric/metric.api.service';
 import { TRANSACTION_STATUS_LABELS } from '~/domains/transaction/transaction.helper';
 import { ChartTextAlternativeOptions } from '~/pages/program-monitoring-dashboard/program-monitoring-dashboard.page';
+import { Locale } from '~/utils/locale';
 
 @Component({
   selector: 'app-payments-aggregate-chart',
@@ -30,7 +31,7 @@ import { ChartTextAlternativeOptions } from '~/pages/program-monitoring-dashboar
 export class PaymentsAggregateChartComponent {
   // This component can show a chart for either the amount or count of payments.
   private metricApiService = inject(MetricApiService);
-  readonly locale = inject(LOCALE_ID);
+  readonly locale = inject<Locale>(LOCALE_ID);
   readonly programId = input.required<string>();
   readonly aggregateType = input.required<'count' | 'transferValue'>();
 

--- a/interfaces/portal/src/app/pages/program-monitoring-dashboard/program-monitoring-dashboard.page.ts
+++ b/interfaces/portal/src/app/pages/program-monitoring-dashboard/program-monitoring-dashboard.page.ts
@@ -62,12 +62,13 @@ export class ProgramMonitoringDashboardPageComponent {
       .map(
         (axisUnit, labelIndex) =>
           `${axisUnit}: ` +
-          this.translatableStringService.commaSeparatedList(
-            datasets.map(
+          this.translatableStringService.commaSeparatedList({
+            values: datasets.map(
               (set: ChartDataSet) =>
                 `${set.label ? `${set.label}: ` : ''}${String(set.data[labelIndex])}`,
             ),
-          ),
+            sortedAlphabetically: false,
+          }),
       )
       .join('\n')}`;
 

--- a/interfaces/portal/src/app/pages/program-registration-activity-log/components/activity-log-expanded-row/activity-log-expanded-row.component.ts
+++ b/interfaces/portal/src/app/pages/program-registration-activity-log/components/activity-log-expanded-row/activity-log-expanded-row.component.ts
@@ -32,6 +32,7 @@ import { ActivityLogVoucherDialogComponent } from '~/pages/program-registration-
 import { ActivityLogTableCellContext } from '~/pages/program-registration-activity-log/program-registration-activity-log.page';
 import { AuthService } from '~/services/auth.service';
 import { RegistrationAttributeService } from '~/services/registration-attribute.service';
+import { Locale } from '~/utils/locale';
 
 @Component({
   selector: 'app-activity-log-expanded-row',
@@ -43,7 +44,7 @@ import { RegistrationAttributeService } from '~/services/registration-attribute.
 export class ActivityLogExpandedRowComponent
   implements TableCellComponent<Activity, ActivityLogTableCellContext>
 {
-  private locale = inject(LOCALE_ID);
+  private locale = inject<Locale>(LOCALE_ID);
   private readonly programApiService = inject(ProgramApiService);
   private readonly registrationAttributeService = inject(
     RegistrationAttributeService,

--- a/interfaces/portal/src/app/services/translatable-string.service.spec.ts
+++ b/interfaces/portal/src/app/services/translatable-string.service.spec.ts
@@ -1,0 +1,128 @@
+import { LOCALE_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { UILanguage } from '@121-service/src/shared/enum/ui-language.enum';
+import { UILanguageTranslation } from '@121-service/src/shared/types/ui-language-translation.type';
+
+import { TranslatableStringService } from '~/services/translatable-string.service';
+
+describe('TranslatableStringService', () => {
+  let service: TranslatableStringService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        TranslatableStringService,
+        { provide: LOCALE_ID, useValue: 'nl' },
+      ],
+    });
+    service = TestBed.inject(TranslatableStringService);
+  });
+
+  describe('translate', () => {
+    it('should return undefined for null', () => {
+      expect(service.translate(null)).toBeUndefined();
+    });
+
+    it('should return undefined for undefined', () => {
+      expect(service.translate(undefined)).toBeUndefined();
+    });
+
+    it('should return undefined for empty translation object', () => {
+      expect(service.translate({})).toBeUndefined();
+    });
+
+    it('should return number as string', () => {
+      expect(service.translate(123)).toBe('123');
+    });
+
+    it('should return string as is', () => {
+      expect(service.translate('hello')).toBe('hello');
+    });
+
+    it('should return translation for current locale', () => {
+      const translations: UILanguageTranslation = {
+        [UILanguage.nl]: 'hallo',
+        [UILanguage.en]: 'hi',
+      };
+      expect(service.translate(translations)).toBe('hallo');
+    });
+
+    it('should fallback to English if current locale not present', () => {
+      const translations: UILanguageTranslation = {
+        [UILanguage.en]: 'hello',
+        [UILanguage.fr]: 'bonjour',
+      };
+      expect(service.translate(translations)).toBe('hello');
+    });
+
+    it('should return first available translation if no locale or fallback', () => {
+      const translations: UILanguageTranslation = {
+        [UILanguage.fr]: 'bonjour',
+        [UILanguage.es]: 'hola',
+      };
+      expect(service.translate(translations)).toBe('bonjour');
+    });
+  });
+
+  describe('commaSeparatedList', () => {
+    it('should return comma separated string for array of strings', () => {
+      const result = service.commaSeparatedList({ values: ['a', 'b', 'c'] });
+      expect(result).toContain('a');
+      expect(result).toContain('b');
+      expect(result).toContain('c');
+    });
+
+    it('should return comma separated string for array of UILanguageTranslation', () => {
+      const translations: UILanguageTranslation[] = [
+        { [UILanguage.nl]: 'een', [UILanguage.en]: 'one' },
+        { [UILanguage.nl]: 'twee', [UILanguage.en]: 'two' },
+      ];
+      const result = service.commaSeparatedList({ values: translations });
+      expect(result).toContain('een');
+      expect(result).toContain('twee');
+    });
+
+    it('should return a sorted list by default', () => {
+      const translations: UILanguageTranslation[] = [
+        { [UILanguage.nl]: 'een', [UILanguage.en]: 'one' },
+        { [UILanguage.nl]: 'twee', [UILanguage.en]: 'two' },
+        { [UILanguage.nl]: 'drie', [UILanguage.en]: 'three' },
+      ];
+      const result = service.commaSeparatedList({ values: translations });
+      expect(result).toBe('drie, een, twee');
+    });
+
+    it('should return an unsorted list when specified', () => {
+      const translations: UILanguageTranslation[] = [
+        { [UILanguage.nl]: 'een', [UILanguage.en]: 'one' },
+        { [UILanguage.nl]: 'twee', [UILanguage.en]: 'two' },
+        { [UILanguage.nl]: 'drie', [UILanguage.en]: 'three' },
+      ];
+      const result = service.commaSeparatedList({
+        values: translations,
+        sortedAlphabetically: false,
+      });
+      expect(result).toBe('een, twee, drie');
+    });
+
+    it('should handle empty array', () => {
+      expect(service.commaSeparatedList({ values: [] })).toBe('');
+    });
+
+    it('should use correct locale formatting', () => {
+      const translations: UILanguageTranslation[] = [
+        { [UILanguage.nl]: 'een', [UILanguage.en]: 'one' },
+        { [UILanguage.nl]: 'twee', [UILanguage.en]: 'two' },
+        { [UILanguage.nl]: 'drie', [UILanguage.en]: 'three' },
+      ];
+      const result = service.commaSeparatedList({
+        values: translations,
+        style: 'long',
+      });
+      expect(result).toContain('een');
+      expect(result).toContain('twee');
+      expect(result).toContain('drie');
+    });
+  });
+});

--- a/interfaces/portal/src/app/services/translatable-string.service.ts
+++ b/interfaces/portal/src/app/services/translatable-string.service.ts
@@ -49,28 +49,36 @@ export class TranslatableStringService {
     if (fallbackLocaleValue) {
       return fallbackLocaleValue;
     }
+
     // Even the fallback-language is not available.
     // I think TypeScript prevents us from ever reaching this point.
-
-    if (typeof translationMapping !== 'object') {
+    if (
+      typeof translationMapping !== 'object' ||
+      Object.keys(translationMapping).length === 0
+    ) {
       return undefined;
     }
 
-    if (Object.keys(translationMapping).length === 0) {
-      return undefined;
-    }
-
-    // Just the first available language.
+    // Just the first available language as a last resort.
     return translationMapping[Object.keys(translationMapping)[0] as UILanguage];
   }
 
-  commaSeparatedList(
-    values: string[] | UILanguageTranslation[],
-    style: Intl.ListFormatStyle = 'narrow',
-  ): string {
+  commaSeparatedList({
+    values,
+    style = 'narrow',
+    sortedAlphabetically = true,
+  }: {
+    values: string[] | UILanguageTranslation[];
+    style?: Intl.ListFormatStyle;
+    sortedAlphabetically?: boolean;
+  }): string {
     const list = values
       .map(this.translate.bind(this))
       .filter((value): value is string => !!value);
+
+    if (sortedAlphabetically) {
+      list.sort((a, b) => a.localeCompare(b, this.currentLocale));
+    }
 
     const formatter = new Intl.ListFormat(this.currentLocale, {
       style,

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -1228,9 +1228,6 @@
       <trans-unit id="2648503122381983554" datatype="html">
         <source>Duplicated with:</source>
       </trans-unit>
-      <trans-unit id="3358875394209155806" datatype="html">
-        <source>(matching fields: <x equiv-text="{{ translatableStringService.commaSeparatedList( duplicate.attributeNames ) }}" id="INTERPOLATION"/>)</source>
-      </trans-unit>
       <trans-unit id="593137515549076612" datatype="html">
         <source>(Scope - <x equiv-text="{{ duplicate.scope }}" id="INTERPOLATION"/>)</source>
       </trans-unit>
@@ -2017,6 +2014,9 @@
       </trans-unit>
       <trans-unit id="5803191628367780292" datatype="html">
         <source>You are about to retry <x equiv-text="formattedTransactionCount" id="PH"/> transaction(s). The transaction status will change to &apos;Processing&apos; until received by the registration.</source>
+      </trans-unit>
+      <trans-unit id="5484768522828011721" datatype="html">
+        <source>(matching fields: <x equiv-text="{{ matchingFieldNames }}" id="INTERPOLATION"/>)</source>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
[AB#39380](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39380)

## Describe your changes

- We should always sort (human-readable) lists in a locale-aware way
- The `commaSeparatedList`-utility will sort by-default (because, why wouldn't we?)  
  Sometimes, the data should 'dictate the order', so still an option to turn it off
- Always inject the `locale` with the type `Locale`

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have not asked the design team to review these changes
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7616.westeurope.3.azurestaticapps.net

See the actual difference on:

BEFORE:
- https://portal.test.121.global/es/program/3/monitoring/dashboard  
  > **FSP(s):** Albert Heijn voucher WhatsApp, Visa debit card, AAA, WWW, Check y Ha Ha Heel veel geld

- https://portal.test.121.global/sk/program/3/monitoring/dashboard (Manually switch to Slovak!)  
  > **FSP(s):** Albert Heijn voucher WhatsApp, Visa debit card, AAA, WWW, Check a Ha Ha Heel veel geld

AFTER:
- https://happy-rock-0411d2003-7616.westeurope.3.azurestaticapps.net/es/program/3/monitoring/dashboard  
  > **FSP(s):** AAA, Albert Heijn voucher WhatsApp, Check, Ha Ha Heel veel geld, Visa debit card y WWW

  Listed alphabetically, not in order-of-editing. "Check" after "AH Voucher WhatsApp"

- https://happy-rock-0411d2003-7616.westeurope.3.azurestaticapps.net/sk/program/3/monitoring/dashboard (Manually switch to Slovak!)  
  > **FSP(s):** AAA, Albert Heijn voucher WhatsApp, Ha Ha Heel veel geld, Check, Visa debit card a WWW

  Listed alphabetically, not in order-of-editing. "Check" after "Ha Ha Heel veel geld"