### PR TITLE
Add exception for ngx-matomo-client to prevent upgrading before Angular v21

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -91,7 +91,7 @@ updates:
       dependencies:
         patterns:
           - '*'
-        exclude-patterns: # Make sure to exclude all of groups defined above
+        exclude-patterns: # Make sure to exclude all of the groups defined above
           - '@angular*'
           - 'primeng'
           - 'typescript'


### PR DESCRIPTION
[AB#39491](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39491)

## Describe your changes

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] Adding tests is unnecessary/irrelevant
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
