### PR TITLE
Bad request on too large excel export

### DIFF
--- a/services/121-service/src/utils/send-xlsx-response.spec.ts
+++ b/services/121-service/src/utils/send-xlsx-response.spec.ts
@@ -1,0 +1,48 @@
+import * as XLSX from 'xlsx';
+
+import { arrayToXlsx } from '@121-service/src/utils/send-xlsx-response';
+
+describe('arrayToXlsx', () => {
+  it('should convert array to XLSX buffer', () => {
+    // Arrange
+    const testData = [
+      { name: 'John', age: 30, city: 'New York' },
+      { name: 'Jane', age: 25, city: 'Boston' },
+      { name: 'Bob', age: 35, city: 'Chicago' },
+    ];
+
+    // Act
+    const result = arrayToXlsx(testData);
+
+    // Assert
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result.length).toBeGreaterThan(0);
+    const workbook = XLSX.read(result, { type: 'buffer' });
+    expect(workbook.SheetNames).toEqual(['data']);
+    const worksheet = workbook.Sheets['data'];
+    const jsonData = XLSX.utils.sheet_to_json(worksheet);
+    expect(jsonData).toEqual(testData);
+  });
+
+  it('should throw HttpException when array has more than 1,000,000 rows', () => {
+    // Arrange
+    const largeArray = new Array(1_000_001).fill({ test: 'data' });
+
+    // Act & Assert
+    expect(() => arrayToXlsx(largeArray)).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot export more than 1,000,000 rows to XLSX, please use a different filter"`,
+    );
+  });
+
+  it('should handle array with exactly 1,000,000 rows', () => {
+    // Arrange
+    const maxArray = new Array(1_000_000).fill({ test: 'data' });
+
+    // Act
+    const result = arrayToXlsx(maxArray);
+
+    // Assert
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/services/121-service/src/utils/send-xlsx-response.ts
+++ b/services/121-service/src/utils/send-xlsx-response.ts
@@ -1,3 +1,4 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
 import { Response } from 'express';
 import * as XLSX from 'xlsx';
 
@@ -19,6 +20,12 @@ export function sendXlsxReponse(
 }
 
 export function arrayToXlsx(array: any[]): Buffer {
+  if (array.length > 1_000_000) {
+    throw new HttpException(
+      'Cannot export more than 1,000,000 rows to XLSX, please use a different filter',
+      HttpStatus.BAD_REQUEST,
+    );
+  }
   const worksheet: XLSX.WorkSheet = XLSX.utils.json_to_sheet(array, {
     dense: true,
   });


### PR DESCRIPTION
[AB#39578](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39578) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

When exporting an excel that is too large an internal server error occurred. I changed it to a 400 error so the user can see what happened.


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
