### PR TITLE
feat: only include CBE pa's in validation report

### DIFF
--- a/services/121-service/src/registration/repositories/registration-view-scoped.repository.ts
+++ b/services/121-service/src/registration/repositories/registration-view-scoped.repository.ts
@@ -106,7 +106,7 @@ export class RegistrationViewScopedRepository extends RegistrationScopedBaseRepo
     return this.createQueryBuilder('registration').andWhere(
       'registration.status IS DISTINCT FROM :deletedStatus',
       {
-        deletedStatus: RegistrationStatusEnum.deleted, // The not opereator does not work with null values so we use IS DISTINCT FROM
+        deletedStatus: RegistrationStatusEnum.deleted, // The NOT-operator does not work with null values so we use IS DISTINCT FROM
       },
     );
   }


### PR DESCRIPTION
[AB#39681](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39681)

## Describe your changes
- only include CBE PA's
- employs generic code as also done in coopbank validation report
- I did not find it needed to extend the test to make sure it does not include non-CBE PA's, as it's all rather trivial and non-breaking.
- after copilot's comment on 'paused', I did add a test on that

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
