### PR TITLE
Catch specific range error

### DIFF
--- a/services/121-service/src/utils/send-xlsx-response.ts
+++ b/services/121-service/src/utils/send-xlsx-response.ts
@@ -33,7 +33,20 @@ export function arrayToXlsx(array: any[]): Buffer {
     Sheets: { data: worksheet },
     SheetNames: ['data'],
   };
-  return XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' });
+  try {
+    return XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' });
+  } catch (error) {
+    if (
+      error instanceof RangeError &&
+      error.message.includes('Invalid string length')
+    ) {
+      throw new HttpException(
+        'Export too large to generate, please use a different filter',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    throw error;
+  }
 }
 
 function toExportFileName(excelFileName: string): string {


### PR DESCRIPTION
[AB#39731](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39731) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

This catches a `RangeError: Invalid string length` thrown by SheetJS when generating very large XLSX exports.  
Without this, oversized exports could crash the request with an unhandled 500 error 400 response asking users to narrow their filter instead.

This relates to #7645 however, apparently that fix was not enough as not only the number of rows can cause a range error, but also the absolute number of chars


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
