### PR TITLE
Add assertions to azure-ad strategy unit tests

### DIFF
--- a/services/121-service/src/strategies/azure-ad.strategy.spec.ts
+++ b/services/121-service/src/strategies/azure-ad.strategy.spec.ts
@@ -119,9 +119,8 @@ describe('AzureAdStrategy', () => {
       });
 
       it('should process unique_name correctly', async () => {
-        await expect(
-          strategy.validate(mockRequest, mockPayload),
-        ).resolves.not.toThrow();
+        const result = await strategy.validate(mockRequest, mockPayload);
+        expect(result).toBeDefined();
       });
 
       it('should process preferred_username when unique_name is not available', async () => {
@@ -131,9 +130,8 @@ describe('AzureAdStrategy', () => {
           isOrganizationAdmin: false,
         };
 
-        await expect(
-          strategy.validate(mockRequest, payload),
-        ).resolves.not.toThrow();
+        const result = await strategy.validate(mockRequest, payload);
+        expect(result).toBeDefined();
       });
 
       it('should handle username with mail# prefix', async () => {
@@ -143,9 +141,8 @@ describe('AzureAdStrategy', () => {
           isOrganizationAdmin: false,
         };
 
-        await expect(
-          strategy.validate(mockRequest, payload),
-        ).resolves.not.toThrow();
+        const result = await strategy.validate(mockRequest, payload);
+        expect(result).toBeDefined();
       });
 
       it('should convert username to lowercase', async () => {
@@ -155,9 +152,8 @@ describe('AzureAdStrategy', () => {
           isOrganizationAdmin: false,
         };
 
-        await expect(
-          strategy.validate(mockRequest, payload),
-        ).resolves.not.toThrow();
+        const result = await strategy.validate(mockRequest, payload);
+        expect(result).toBeDefined();
       });
     });
 


### PR DESCRIPTION
[AB#39785](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39785) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Fixes issues that were raised by GitHub validation by adding explicit assertions to the tests.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code (and addressed any Copilot comments)
- [x]  Adding tests is unnecessary/irrelevant
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
