### PR TITLE
fix double swagger tags

### DIFF
--- a/services/121-service/src/registration-events/registration-events.controller.ts
+++ b/services/121-service/src/registration-events/registration-events.controller.ts
@@ -31,6 +31,7 @@ import { RegistrationEventsService } from '@121-service/src/registration-events/
 import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 import { sendXlsxReponse } from '@121-service/src/utils/send-xlsx-response';
 
+@ApiTags('programs/registration-events')
 @UseGuards(AuthenticatedUserGuard)
 @Controller()
 export class RegistrationEventsController {

--- a/services/121-service/src/registration/controllers/registrations-redline.controller.ts
+++ b/services/121-service/src/registration/controllers/registrations-redline.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { AuthenticatedUser } from '@121-service/src/guards/authenticated-user.decorator';
+import { AuthenticatedUserGuard } from '@121-service/src/guards/authenticated-user.guard';
+import { RegistrationsService } from '@121-service/src/registration/services/registrations.service';
+import { ScopedUserRequest } from '@121-service/src/shared/scoped-user-request';
+import { RequestHelper } from '@121-service/src/utils/request-helper/request-helper.helper';
+
+// This has a seperate controller to clearly separate the Redline integration endpoint because these have a global program overencompassing scope
+// and should not be mixed with the normal registrations endpoints that are always scoped to a program which have a different @ApiTags
+// If you add api tags at endpoint level they appear multiple times in the swagger docs which is not desired.
+@ApiTags('registrations-redline')
+@UseGuards(AuthenticatedUserGuard)
+@Controller()
+export class RegistrationsRedlineController {
+  public constructor(
+    private readonly registrationsService: RegistrationsService,
+  ) {}
+
+  @AuthenticatedUser()
+  @ApiTags('registrations')
+  // There's no permission check here because there's a check included in the queries done to fetch data.
+  @ApiOperation({
+    summary:
+      '[SCOPED] Find registration by phone-number for Redline integration and FieldValidation',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description:
+      'Return registrations that match the exact phone-number - NOTE: this endpoint is scoped, depending on program configuration it only returns/modifies data the logged in user has access to.',
+  })
+  @ApiQuery({
+    name: 'phonenumber',
+    required: true,
+    type: 'string',
+  })
+  @Get('/registrations')
+  public async searchRegistration(
+    @Query('phonenumber') phonenumber: string,
+    @Req() req: ScopedUserRequest,
+  ) {
+    const userId = RequestHelper.getUserId(req);
+
+    if (typeof phonenumber !== 'string') {
+      throw new HttpException(
+        'phonenumber is not a string',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    return await this.registrationsService.searchRegistration(
+      phonenumber,
+      userId,
+    );
+  }
+}

--- a/services/121-service/src/registration/controllers/registrations.controller.spec.ts
+++ b/services/121-service/src/registration/controllers/registrations.controller.spec.ts
@@ -2,9 +2,9 @@ import { TestBed } from '@automock/jest';
 import { HttpStatus } from '@nestjs/common';
 import { PaginateQuery } from 'nestjs-paginate';
 
+import { RegistrationsController } from '@121-service/src/registration/controllers/registrations.controller';
 import { RegistrationStatusPatchDto } from '@121-service/src/registration/dto/registration-status-patch.dto';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
-import { RegistrationsController } from '@121-service/src/registration/registrations.controller';
 import { RegistrationsBulkService } from '@121-service/src/registration/services/registrations-bulk.service';
 import { RegistrationsPaginationService } from '@121-service/src/registration/services/registrations-pagination.service';
 import { ScopedUserRequest } from '@121-service/src/shared/scoped-user-request';

--- a/services/121-service/src/registration/controllers/registrations.controller.ts
+++ b/services/121-service/src/registration/controllers/registrations.controller.ts
@@ -66,6 +66,7 @@ import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 import { FinancialAttributes } from '@121-service/src/user/enum/registration-financial-attributes.const';
 import { RequestHelper } from '@121-service/src/utils/request-helper/request-helper.helper';
 
+@ApiTags('programs/registrations')
 @UseGuards(AuthenticatedUserGuard)
 @Controller()
 export class RegistrationsController {
@@ -75,7 +76,6 @@ export class RegistrationsController {
     private readonly registrationsBulkService: RegistrationsBulkService,
   ) {}
 
-  @ApiTags('programs/registrations')
   @AuthenticatedUser({ permissions: [PermissionEnum.RegistrationCREATE] })
   @ApiOperation({
     summary: 'Import set of new PAs, from CSV',
@@ -99,7 +99,6 @@ export class RegistrationsController {
     );
   }
 
-  @ApiTags('programs/registrations')
   @AuthenticatedUser({ permissions: [PermissionEnum.RegistrationCREATE] })
   @ApiOperation({
     summary: '[EXTERNALLY USED] Import set of new PAs',
@@ -124,7 +123,6 @@ export class RegistrationsController {
     );
   }
 
-  @ApiTags('programs/registrations')
   @AuthenticatedUser({ permissions: [PermissionEnum.RegistrationREAD] })
   @ApiOperation({
     summary:
@@ -168,7 +166,6 @@ export class RegistrationsController {
   @AuthenticatedUser({
     permissions: [PermissionEnum.RegistrationBulkUPDATE],
   })
-  @ApiTags('programs/registrations')
   @ApiOperation({
     summary: `Bulk update registration using a CSV file. The columns in the CSV file should contain at least referenceId and the columns you want to update. If you leave a cell empty the corresponding registration data will be update with an empty string. Max file length is 100k rows. We do not support updating phone numbers or referenceId.`,
   })
@@ -193,7 +190,6 @@ export class RegistrationsController {
     );
   }
 
-  @ApiTags('programs/registrations')
   @AuthenticatedUser({
     permissions: [PermissionEnum.RegistrationImportTemplateREAD],
   })
@@ -211,7 +207,6 @@ export class RegistrationsController {
   }
 
   @AuthenticatedUser()
-  @ApiTags('programs/registrations')
   @ApiResponse({
     status: HttpStatus.OK,
     description:
@@ -344,7 +339,6 @@ export class RegistrationsController {
   }
 
   @AuthenticatedUser()
-  @ApiTags('programs/registrations')
   @ApiOperation({
     summary:
       '[SCOPED] [EXTERNALLY USED] Update provided attributes of registration (Used by Aidworker)',
@@ -428,43 +422,6 @@ export class RegistrationsController {
     });
   }
 
-  @AuthenticatedUser()
-  @ApiTags('registrations')
-  // There's no permission check here because there's a check included in the queries done to fetch data.
-  @ApiOperation({
-    summary:
-      '[SCOPED] Find registration by phone-number for Redline integration and FieldValidation',
-  })
-  @ApiResponse({
-    status: HttpStatus.OK,
-    description:
-      'Return registrations that match the exact phone-number - NOTE: this endpoint is scoped, depending on program configuration it only returns/modifies data the logged in user has access to.',
-  })
-  @ApiQuery({
-    name: 'phonenumber',
-    required: true,
-    type: 'string',
-  })
-  @Get('/registrations')
-  public async searchRegistration(
-    @Query('phonenumber') phonenumber: string,
-    @Req() req: ScopedUserRequest,
-  ) {
-    const userId = RequestHelper.getUserId(req);
-
-    if (typeof phonenumber !== 'string') {
-      throw new HttpException(
-        'phonenumber is not a string',
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-    return await this.registrationsService.searchRegistration(
-      phonenumber,
-      userId,
-    );
-  }
-
-  @ApiTags('programs/registrations')
   @ApiResponse({
     status: HttpStatus.OK,
     description:
@@ -541,7 +498,6 @@ export class RegistrationsController {
     return result;
   }
 
-  @ApiTags('programs/registrations')
   @ApiResponse({
     status: HttpStatus.OK,
     description:
@@ -630,7 +586,6 @@ export class RegistrationsController {
     return result;
   }
 
-  @ApiTags('programs/registrations')
   @AuthenticatedUser({ permissions: [PermissionEnum.RegistrationPersonalREAD] })
   @ApiOperation({
     summary: '[SCOPED] Gets duplicate registrations for a registration',
@@ -683,7 +638,7 @@ export class RegistrationsController {
   }
 
   // This "wildcard" endpoint needs to be at the bottom of the file to avoid conflicts with other endpoints
-  @ApiTags('programs/registrations')
+
   @AuthenticatedUser({ permissions: [PermissionEnum.RegistrationREAD] })
   @ApiOperation({
     summary:

--- a/services/121-service/src/registration/registrations.module.ts
+++ b/services/121-service/src/registration/registrations.module.ts
@@ -21,12 +21,13 @@ import { ProgramEntity } from '@121-service/src/programs/entities/program.entity
 import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/entities/program-registration-attribute.entity';
 import { ProgramModule } from '@121-service/src/programs/programs.module';
 import { QueuesRegistryModule } from '@121-service/src/queues-registry/queues-registry.module';
+import { RegistrationsController } from '@121-service/src/registration/controllers/registrations.controller';
+import { RegistrationsRedlineController } from '@121-service/src/registration/controllers/registrations-redline.controller';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { RegistrationAttributeDataEntity } from '@121-service/src/registration/entities/registration-attribute-data.entity';
 import { UniqueRegistrationPairEntity } from '@121-service/src/registration/entities/unique-registration-pair.entity';
 import { RegistrationDataModule } from '@121-service/src/registration/modules/registration-data/registration-data.module';
 import { RegistrationUtilsModule } from '@121-service/src/registration/modules/registration-utils/registration-utils.module';
-import { RegistrationsController } from '@121-service/src/registration/registrations.controller';
 import { RegistrationScopedRepository } from '@121-service/src/registration/repositories/registration-scoped.repository';
 import { RegistrationViewScopedRepository } from '@121-service/src/registration/repositories/registration-view-scoped.repository';
 import { UniqueRegistrationPairRepository } from '@121-service/src/registration/repositories/unique-registration-pair.repository';
@@ -93,7 +94,7 @@ import { createScopedRepositoryProvider } from '@121-service/src/utils/scope/cre
     createScopedRepositoryProvider(RegistrationEventEntity),
     UniqueRegistrationPairRepository,
   ],
-  controllers: [RegistrationsController],
+  controllers: [RegistrationsController, RegistrationsRedlineController],
   exports: [
     RegistrationsService,
     RegistrationsBulkService,

--- a/services/121-service/src/user/controllers/roles.controller.ts
+++ b/services/121-service/src/user/controllers/roles.controller.ts
@@ -1,0 +1,100 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { AuthenticatedUser } from '@121-service/src/guards/authenticated-user.decorator';
+import { AuthenticatedUserGuard } from '@121-service/src/guards/authenticated-user.guard';
+import { CreateUserRoleDto } from '@121-service/src/user/dto/create-user-role.dto';
+import { UpdateUserRoleDto } from '@121-service/src/user/dto/update-user-role.dto';
+import { UserRoleResponseDTO } from '@121-service/src/user/dto/userrole-response.dto';
+import { UserService } from '@121-service/src/user/user.service';
+
+@ApiTags('roles')
+@UseGuards(AuthenticatedUserGuard)
+@Controller()
+export class RolesController {
+  private readonly userService: UserService;
+  public constructor(userService: UserService) {
+    this.userService = userService;
+  }
+
+  @AuthenticatedUser()
+  @ApiOperation({ summary: 'Get all user roles' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Returns a list of roles and their permissions',
+    type: [UserRoleResponseDTO],
+  })
+  @Get('roles')
+  public async getUserRoles(): Promise<UserRoleResponseDTO[]> {
+    return await this.userService.getUserRoles();
+  }
+
+  @AuthenticatedUser({ isAdmin: true })
+  @ApiOperation({ summary: 'Create new user role' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Returns the created role',
+    type: UserRoleResponseDTO,
+  })
+  @Post('roles')
+  public async addUserRole(
+    @Body() userRoleData: CreateUserRoleDto,
+  ): Promise<UserRoleResponseDTO> {
+    return await this.userService.addUserRole(userRoleData);
+  }
+
+  @AuthenticatedUser({ isAdmin: true })
+  @ApiOperation({ summary: 'Update existing user role' })
+  @ApiParam({ name: 'userRoleId', required: true, type: 'integer' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Returns the updated user role',
+    type: UserRoleResponseDTO,
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Role already exists',
+  })
+  @Put('roles/:userRoleId')
+  public async updateUserRole(
+    @Param() params,
+    @Body() userRoleData: UpdateUserRoleDto,
+  ): Promise<UserRoleResponseDTO> {
+    return await this.userService.updateUserRole(
+      params.userRoleId,
+      userRoleData,
+    );
+  }
+
+  @AuthenticatedUser({ isAdmin: true })
+  @ApiOperation({ summary: 'Delete existing user role' })
+  @ApiParam({ name: 'userRoleId', required: true, type: 'integer' })
+  // TODO: REFACTOR: rename to /users/roles/
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Returns the deleted role',
+    type: UserRoleResponseDTO,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'No role found',
+  })
+  @Delete('roles/:userRoleId')
+  public async deleteUserRole(
+    @Param('userRoleId', ParseIntPipe)
+    userRoleId: number,
+  ): Promise<UserRoleResponseDTO> {
+    return await this.userService.deleteUserRole(userRoleId);
+  }
+}

--- a/services/121-service/src/user/controllers/user-assignments.controller.ts
+++ b/services/121-service/src/user/controllers/user-assignments.controller.ts
@@ -1,0 +1,180 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Put,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { AuthenticatedUser } from '@121-service/src/guards/authenticated-user.decorator';
+import { AuthenticatedUserGuard } from '@121-service/src/guards/authenticated-user.guard';
+import { ScopedUserRequest } from '@121-service/src/shared/scoped-user-request';
+import {
+  CreateProgramAssignmentDto,
+  DeleteProgramAssignmentDto,
+  UpdateProgramAssignmentDto,
+} from '@121-service/src/user/dto/assign-aw-to-program.dto';
+import { GetUserReponseDto } from '@121-service/src/user/dto/get-user-response.dto';
+import { AssignmentResponseDTO } from '@121-service/src/user/dto/userrole-response.dto';
+import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
+import { throwIfSelfUpdate } from '@121-service/src/user/helpers/throw-if-self-update';
+import { UserService } from '@121-service/src/user/user.service';
+
+@ApiTags('user-assignments')
+@UseGuards(AuthenticatedUserGuard)
+@Controller()
+export class UserAssignmentsController {
+  private readonly userService: UserService;
+  public constructor(userService: UserService) {
+    this.userService = userService;
+  }
+
+  @AuthenticatedUser({ isAdmin: true })
+  @ApiOperation({ summary: 'Get roles for given user program assignment' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Returns program assignment including roles and scope',
+    type: AssignmentResponseDTO,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'No roles found for user',
+  })
+  @Get('programs/:programId/users/:userId')
+  public async getAidworkerProgramAssignment(
+    @Param('programId', ParseIntPipe)
+    programId: number,
+
+    @Param('userId', ParseIntPipe)
+    userId: number,
+  ): Promise<AssignmentResponseDTO> {
+    return await this.userService.getAidworkerProgramAssignment(
+      programId,
+      userId,
+    );
+  }
+
+  @AuthenticatedUser({ permissions: [PermissionEnum.AidWorkerProgramUPDATE] })
+  @ApiOperation({
+    summary: 'Create or OVERWRITE program assignment including roles and scope',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description:
+      'Returns the created or overwritten program assignment including roles and scope',
+    type: AssignmentResponseDTO,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'User, program or role(s) not found',
+  })
+  @Put('programs/:programId/users/:userId')
+  public async assignAidworkerToProgram(
+    @Param('programId', ParseIntPipe)
+    programId: number,
+
+    @Param('userId', ParseIntPipe)
+    userIdToUpdate: number,
+
+    @Body()
+    assignAidworkerToProgram: CreateProgramAssignmentDto,
+
+    @Req() req: ScopedUserRequest,
+  ): Promise<AssignmentResponseDTO> {
+    throwIfSelfUpdate(req, userIdToUpdate);
+    return await this.userService.assignAidworkerToProgram(
+      programId,
+      userIdToUpdate,
+      assignAidworkerToProgram,
+    );
+  }
+
+  @AuthenticatedUser({ permissions: [PermissionEnum.AidWorkerProgramUPDATE] })
+  @ApiOperation({
+    summary:
+      'Update existing program assignment with new roles (UNION of existing and new roles) and/or overwrite scope',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Returns program assignment with all roles and scope',
+    type: AssignmentResponseDTO,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'User, program or role(s) not found',
+  })
+  @Patch('programs/:programId/users/:userId')
+  public async updateAidworkerProgramAssignment(
+    @Param('programId', ParseIntPipe)
+    programId: number,
+    @Param('userId', ParseIntPipe)
+    userIdToUpdate: number,
+    @Body() assignAidworkerToProgram: UpdateProgramAssignmentDto,
+    @Req() req: ScopedUserRequest,
+  ): Promise<AssignmentResponseDTO> {
+    throwIfSelfUpdate(req, userIdToUpdate);
+    return await this.userService.updateAidworkerProgramAssignment(
+      programId,
+      userIdToUpdate,
+      assignAidworkerToProgram,
+    );
+  }
+
+  @AuthenticatedUser({ permissions: [PermissionEnum.AidWorkerProgramUPDATE] })
+  @ApiOperation({
+    summary:
+      'Remove roles from program-assignment (pass roles to delete in body) or remove assignment (no body)',
+  })
+  @ApiBody({ type: DeleteProgramAssignmentDto, required: false })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description:
+      'Returns the program assignment with the remaining roles or nothing (if program assignment removed)',
+    type: AssignmentResponseDTO,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'User, program, role(s) or assignment not found',
+  })
+  @Delete('programs/:programId/users/:userId')
+  public async deleteAidworkerRolesOrAssignment(
+    @Param('programId', ParseIntPipe)
+    programId: number,
+
+    @Param('userId', ParseIntPipe)
+    userIdToUpdate: number,
+
+    @Req() req: ScopedUserRequest,
+    @Body() deleteProgramAssignment?: DeleteProgramAssignmentDto,
+  ): Promise<AssignmentResponseDTO | void> {
+    throwIfSelfUpdate(req, userIdToUpdate);
+
+    return await this.userService.deleteAidworkerRolesOrAssignment({
+      programId,
+      userId: userIdToUpdate,
+      roleNamesToDelete: deleteProgramAssignment?.rolesToDelete,
+    });
+  }
+
+  @AuthenticatedUser({ permissions: [PermissionEnum.AidWorkerProgramREAD] })
+  @ApiOperation({ summary: 'Get all users by programId' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Returns a list of users assigned to a program',
+    type: [GetUserReponseDto],
+  })
+  @Get('programs/:programId/users')
+  public async getUsersInProgram(
+    @Param('programId', ParseIntPipe)
+    programId: number,
+  ): Promise<GetUserReponseDto[]> {
+    return await this.userService.getUsersInProgram(programId);
+  }
+}

--- a/services/121-service/src/user/user.module.ts
+++ b/services/121-service/src/user/user.module.ts
@@ -3,10 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { ProgramAidworkerAssignmentEntity } from '@121-service/src/programs/entities/program-aidworker.entity';
+import { RolesController } from '@121-service/src/user/controllers/roles.controller';
+import { UserController } from '@121-service/src/user/controllers/user.controller';
+import { UserAssignmentsController } from '@121-service/src/user/controllers/user-assignments.controller';
 import { PermissionEntity } from '@121-service/src/user/entities/permissions.entity';
 import { UserEntity } from '@121-service/src/user/entities/user.entity';
 import { UserRoleEntity } from '@121-service/src/user/entities/user-role.entity';
-import { UserController } from '@121-service/src/user/user.controller';
 import { UserService } from '@121-service/src/user/user.service';
 import { UserEmailsModule } from '@121-service/src/user/user-emails/user-emails.module';
 
@@ -22,7 +24,7 @@ import { UserEmailsModule } from '@121-service/src/user/user-emails/user-emails.
     UserEmailsModule,
   ],
   providers: [UserService],
-  controllers: [UserController],
+  controllers: [UserController, UserAssignmentsController, RolesController],
   exports: [UserService],
 })
 export class UserModule {}

--- a/services/121-service/swagger.json
+++ b/services/121-service/swagger.json
@@ -76,33 +76,6 @@
   },
   {
     "method": "get",
-    "path": "/api/roles",
-    "params": []
-  },
-  {
-    "method": "post",
-    "path": "/api/roles",
-    "params": [],
-    "returnType": "UserRoleResponseDTO"
-  },
-  {
-    "method": "put",
-    "path": "/api/roles/{userRoleId}",
-    "params": [
-      "userRoleId"
-    ],
-    "returnType": "UserRoleResponseDTO"
-  },
-  {
-    "method": "delete",
-    "path": "/api/roles/{userRoleId}",
-    "params": [
-      "userRoleId"
-    ],
-    "returnType": "UserRoleResponseDTO"
-  },
-  {
-    "method": "get",
     "path": "/api/users",
     "params": []
   },
@@ -202,6 +175,33 @@
     "params": [
       "programId"
     ]
+  },
+  {
+    "method": "get",
+    "path": "/api/roles",
+    "params": []
+  },
+  {
+    "method": "post",
+    "path": "/api/roles",
+    "params": [],
+    "returnType": "UserRoleResponseDTO"
+  },
+  {
+    "method": "put",
+    "path": "/api/roles/{userRoleId}",
+    "params": [
+      "userRoleId"
+    ],
+    "returnType": "UserRoleResponseDTO"
+  },
+  {
+    "method": "delete",
+    "path": "/api/roles/{userRoleId}",
+    "params": [
+      "userRoleId"
+    ],
+    "returnType": "UserRoleResponseDTO"
   },
   {
     "method": "get",
@@ -631,13 +631,6 @@
     ]
   },
   {
-    "method": "get",
-    "path": "/api/registrations",
-    "params": [
-      "phonenumber"
-    ]
-  },
-  {
     "method": "post",
     "path": "/api/programs/{programId}/registrations/message",
     "params": [
@@ -689,6 +682,13 @@
     "params": [
       "programId",
       "id"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/registrations",
+    "params": [
+      "phonenumber"
     ]
   },
   {


### PR DESCRIPTION
[AB#39940](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39940) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Why this problem was here: 

Swagger will implicitly create a tag based on the controller class name if the class has no explicit tag. So basically in controller classes that had no @ApiTag() on controller class level, but only on individual endpoint lvl (because some endpoint in the same controller required a different tag)

I found no way around this so up serveral controllers. You can argue that it may be cleaner to have seperate modules, but I think this outside of the 2 hour scope for this item

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
