### PR TITLE
fix: prevent showing link card dialog if no permissions

### DIFF
--- a/interfaces/portal/src/app/pages/program-registration-debit-cards/program-registration-debit-cards.page.ts
+++ b/interfaces/portal/src/app/pages/program-registration-debit-cards/program-registration-debit-cards.page.ts
@@ -115,16 +115,25 @@ export class ProgramRegistrationDebitCardsPageComponent {
   );
 
   readonly cardDistributionByMailEnabled = computed(() => {
-    const props: FspConfigurationProperty[] =
-      this.fspConfigurationProperties.data() ?? [];
+    // TODO: this is a temporary patch until we fixed permission issues in getFspConfigurationProperties
+    if (!this.fspConfigurationProperties.isSuccess()) {
+      return true;
+    }
 
-    const cardDistributionByMailProperty = props.find(
+    const props: FspConfigurationProperty[] =
+      this.fspConfigurationProperties.data();
+
+    const distributionByMailEnabled = props.find(
       (property) =>
         property.name ===
         (IntersolveVisaFspConfigurationProperties.cardDistributionByMail as string),
     );
+    // TODO: this is a temporary patch until we fixed permission issues in getFspConfigurationProperties
+    if (distributionByMailEnabled === undefined) {
+      return true;
+    }
 
-    return cardDistributionByMailProperty?.value === 'true';
+    return distributionByMailEnabled.value === 'true';
   });
 
   readonly cardByMailDisabledAndNoCurrentCards = computed(() => {


### PR DESCRIPTION
[AB#39993](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39993) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have addressed all Copilot comments
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary
- [ ] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [ ] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7737.westeurope.3.azurestaticapps.net
