### PR TITLE
Each test shard gets its own db schema

### DIFF
--- a/.github/workflows/test_service_api.yml
+++ b/.github/workflows/test_service_api.yml
@@ -65,10 +65,16 @@ jobs:
       - name: Set ENV-variables for test-environment
         run: |
           cp ./services/.env.example services/.env
-          grep -v "^#\|^$" services/.env.example >> $GITHUB_ENV
-          # override the default value for COVERAGE_DEV_STARTUP_SUFFIX from .env.example
-          # this is needed to collect coverage data during integration tests
-          echo "COVERAGE_DEV_STARTUP_SUFFIX=:collect-coverage" >> $GITHUB_ENV
+          {
+            grep -v "^#\|^$" services/.env.example
+            # override the default value for COVERAGE_DEV_STARTUP_SUFFIX from .env.example
+            # this is needed to collect coverage data during integration tests
+            echo "COVERAGE_DEV_STARTUP_SUFFIX=:collect-coverage"
+            # set schema name per shard to isolate each test shard's data
+            echo "POSTGRES_SCHEMA=121-service-${{ matrix.shard }}"
+            # use CI init script to create all shard schemas
+            echo "INIT_SQL_FILE=init.ci.sql"
+          } >> $GITHUB_ENV
 
       - name: Run Services with Docker
         run: |

--- a/services/.env.example
+++ b/services/.env.example
@@ -95,6 +95,8 @@ POSTGRES_PORT=
 POSTGRES_USER=global121
 POSTGRES_PASSWORD=global121
 POSTGRES_DBNAME=global121
+# Overridden in CI for test shards: 121-service-1, 121-service-2, etc.
+POSTGRES_SCHEMA=121-service
 
 
 # --------

--- a/services/121-service/src/env.ts
+++ b/services/121-service/src/env.ts
@@ -228,6 +228,7 @@ export const env = createEnv({
     POSTGRES_USER: z.string(),
     POSTGRES_PASSWORD: z.string(),
     POSTGRES_DBNAME: z.string(),
+    POSTGRES_SCHEMA: z.string().default('121-service'),
 
     // Queue/Redis
     REDIS_HOST: z.string().default('121-redis'),

--- a/services/121-service/src/ormconfig.ts
+++ b/services/121-service/src/ormconfig.ts
@@ -36,7 +36,7 @@ export const ORMConfig: DataSourceOptions = {
   username: env.POSTGRES_USER,
   password: env.POSTGRES_PASSWORD,
   database: env.POSTGRES_DBNAME,
-  schema: '121-service',
+  schema: env.POSTGRES_SCHEMA,
   entities: ['dist/**/*.entity.js'],
   subscribers: ['dist/**/*.subscriber.js'],
   migrationsTableName: 'custom_migration_table',

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DBNAME}
     volumes:
       - './postgresql.conf:/etc/postgresql.conf'
-      - './init.sql:/docker-entrypoint-initdb.d/init.sql'
+      - './${INIT_SQL_FILE:-init.sql}:/docker-entrypoint-initdb.d/init.sql'
     ports:
       - '5438:5432'
     restart: unless-stopped

--- a/services/init.ci.sql
+++ b/services/init.ci.sql
@@ -1,0 +1,9 @@
+CREATE SCHEMA IF NOT EXISTS "121-service";
+
+-- Create schemas for test shards to enable parallel test execution with isolated data
+CREATE SCHEMA IF NOT EXISTS "121-service-1";
+CREATE SCHEMA IF NOT EXISTS "121-service-2";
+CREATE SCHEMA IF NOT EXISTS "121-service-3";
+CREATE SCHEMA IF NOT EXISTS "121-service-4";
+CREATE SCHEMA IF NOT EXISTS "121-service-5";
+CREATE SCHEMA IF NOT EXISTS "121-service-6";


### PR DESCRIPTION
[AB#39998](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39998) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Make db schema name dynamic. In CI use separate schema per shard so we don't get concurrent writes.

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have addressed all Copilot comments
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary
- [ ] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [ ] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
