### PR TITLE
Fix see more than 20 data changes per profile page

### DIFF
--- a/services/121-service/src/registration-events/registration-events.service.ts
+++ b/services/121-service/src/registration-events/registration-events.service.ts
@@ -32,6 +32,8 @@ interface RegistrationViewWithId extends Partial<RegistrationViewEntity> {
   id: number;
 }
 
+const exportLimit = 500_000;
+
 @Injectable()
 export class RegistrationEventsService {
   @Inject(getScopedRepositoryProviderName(RegistrationEventEntity))
@@ -61,9 +63,8 @@ export class RegistrationEventsService {
         },
       );
 
-    const limit = 100_000;
     const paginateQuery = {
-      limit,
+      limit: exportLimit,
     } as PaginateQuery;
     return this.getPaginatedRegistrationEvents({
       paginateQuery,
@@ -99,7 +100,6 @@ export class RegistrationEventsService {
         },
       );
 
-    const exportLimit = 500_000;
     const paginateQuery = {
       limit: exportLimit,
     } as PaginateQuery;


### PR DESCRIPTION
[AB#40036](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/40036) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

- Before the default limit of 20 was used to get data changes for the profile page
- I changed this to 500.000 (the same limit we have for exports)

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
