### PR TITLE
Chore: mirror Portal domains to match new backend FSP structure

### DIFF
--- a/interfaces/portal/src/app/components/colored-chip/colored-chip.helper.ts
+++ b/interfaces/portal/src/app/components/colored-chip/colored-chip.helper.ts
@@ -4,6 +4,7 @@ import { DuplicateStatus } from '@121-service/src/registration/enum/duplicate-st
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 
 import { ChipVariant } from '~/components/colored-chip/colored-chip.component';
+import { VISA_CARD_STATUS_LABELS } from '~/domains/fsp-account-management/intersolve-visa.helper';
 import {
   convertTwilioMessageStatusToMessageStatus,
   MESSAGE_STATUS_LABELS,
@@ -12,7 +13,6 @@ import {
 import {
   DUPLICATE_STATUS_LABELS,
   REGISTRATION_STATUS_LABELS,
-  VISA_CARD_STATUS_LABELS,
 } from '~/domains/registration/registration.helper';
 import { TRANSACTION_STATUS_LABELS } from '~/domains/transaction/transaction.helper';
 

--- a/interfaces/portal/src/app/domains/fsp-account-management/intersolve-visa.api.service.ts
+++ b/interfaces/portal/src/app/domains/fsp-account-management/intersolve-visa.api.service.ts
@@ -1,0 +1,146 @@
+import { Injectable, Signal } from '@angular/core';
+
+import { DomainApiService } from '~/domains/domain-api.service';
+import { WalletWithCards } from '~/domains/fsp-account-management/intersolve-visa.model';
+
+const BASE_ENDPOINT = (programId: Signal<number | string>) => [
+  'programs',
+  programId,
+  'registrations',
+];
+
+@Injectable({
+  providedIn: 'root',
+})
+export class IntersolveVisaApiService extends DomainApiService {
+  getWalletWithCardsByReferenceId(
+    programId: Signal<number | string>,
+    referenceId: Signal<string | undefined>,
+  ) {
+    return this.generateQueryOptions<WalletWithCards>({
+      path: [
+        ...BASE_ENDPOINT(programId),
+        referenceId,
+        'fsps',
+        'intersolve-visa',
+        'wallet',
+      ],
+      method: 'PATCH',
+      enabled: () => !!referenceId(),
+    });
+  }
+
+  changeCardPauseStatus({
+    programId,
+    referenceId,
+    tokenCode,
+    pauseStatus,
+  }: {
+    programId: Signal<number | string>;
+    referenceId: string;
+    tokenCode: string;
+    pauseStatus: boolean;
+  }) {
+    const endpoint = this.pathToQueryKey([
+      ...BASE_ENDPOINT(programId),
+      referenceId,
+      'fsps',
+      'intersolve-visa',
+      'wallet',
+      'cards',
+      tokenCode,
+    ]).join('/');
+
+    return this.httpWrapperService.perform121ServiceRequest({
+      method: 'PATCH',
+      endpoint,
+      httpParams: {
+        pause: pauseStatus,
+      },
+    });
+  }
+
+  replaceCardByMail({
+    programId,
+    referenceId,
+  }: {
+    programId: Signal<number | string>;
+    referenceId: string;
+  }) {
+    const endpoint = this.pathToQueryKey([
+      ...BASE_ENDPOINT(programId),
+      referenceId,
+      'fsps',
+      'intersolve-visa',
+      'wallet',
+      'cards',
+      'by-mail',
+      'replace',
+    ]).join('/');
+
+    return this.httpWrapperService.perform121ServiceRequest({
+      method: 'POST',
+      endpoint,
+    });
+  }
+
+  public linkCardToRegistration({
+    programId,
+    referenceId,
+    tokenCode,
+  }: {
+    programId: Signal<number | string>;
+    referenceId: Signal<string | undefined>;
+    tokenCode: string;
+  }) {
+    const endpoint = this.pathToQueryKey([
+      ...BASE_ENDPOINT(programId),
+      referenceId,
+      'fsps',
+      'intersolve-visa',
+      'wallet',
+      'cards',
+      'on-site',
+      'link',
+    ]).join('/');
+
+    const body = { tokenCode };
+
+    return this.httpWrapperService.perform121ServiceRequest({
+      method: 'POST',
+      endpoint,
+      body,
+    });
+  }
+
+  public replaceCardOnSite({
+    programId,
+    referenceId,
+    tokenCode,
+  }: {
+    programId: Signal<number | string>;
+    referenceId: Signal<string | undefined>;
+    tokenCode: string;
+  }) {
+    const endpoint = this.pathToQueryKey([
+      ...BASE_ENDPOINT(programId),
+      referenceId,
+      'fsps',
+      'intersolve-visa',
+      'wallet',
+      'cards',
+      'on-site',
+      'replace',
+    ]).join('/');
+
+    const body = { tokenCode };
+
+    const req = this.httpWrapperService.perform121ServiceRequest({
+      method: 'POST',
+      endpoint,
+      body,
+    });
+
+    return req;
+  }
+}

--- a/interfaces/portal/src/app/domains/fsp-account-management/intersolve-visa.helper.ts
+++ b/interfaces/portal/src/app/domains/fsp-account-management/intersolve-visa.helper.ts
@@ -1,0 +1,12 @@
+import { VisaCard121Status } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/wallet-status-121.enum';
+
+export const VISA_CARD_STATUS_LABELS: Record<VisaCard121Status, string> = {
+  [VisaCard121Status.Active]: $localize`:@@debit-card-status-active:Active`,
+  [VisaCard121Status.Issued]: $localize`:@@debit-card-status-issued:Issued`,
+  [VisaCard121Status.Blocked]: $localize`:@@debit-card-status-blocked:Blocked`,
+  [VisaCard121Status.Paused]: $localize`:@@debit-card-status-paused:Paused`,
+  [VisaCard121Status.SuspectedFraud]: $localize`:@@debit-card-status-suspected-fraud:Suspected fraud`,
+  [VisaCard121Status.Unknown]: $localize`:@@debit-card-status-unknown:Unknown`,
+  [VisaCard121Status.Substituted]: $localize`:@@debit-card-status-substituted:Substituted`,
+  [VisaCard121Status.CardDataMissing]: $localize`:@@debit-card-status-card-data-missing:Debit card data missing`,
+};

--- a/interfaces/portal/src/app/domains/fsp-account-management/intersolve-visa.model.ts
+++ b/interfaces/portal/src/app/domains/fsp-account-management/intersolve-visa.model.ts
@@ -1,0 +1,5 @@
+import { IntersolveVisaWalletDto } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/dtos/internal/intersolve-visa-wallet.dto';
+
+import { Dto } from '~/utils/dto-type';
+
+export type WalletWithCards = Dto<IntersolveVisaWalletDto>;

--- a/interfaces/portal/src/app/domains/registration/registration.api.service.ts
+++ b/interfaces/portal/src/app/domains/registration/registration.api.service.ts
@@ -14,7 +14,6 @@ import {
   FindAllRegistrationsResult,
   Registration,
   SendMessageData,
-  WalletWithCards,
 } from '~/domains/registration/registration.model';
 import { PaginateQuery } from '~/services/paginate-query.service';
 import { Dto } from '~/utils/dto-type';
@@ -264,77 +263,6 @@ export class RegistrationApiService extends DomainApiService {
     });
   }
 
-  getWalletWithCardsByReferenceId(
-    programId: Signal<number | string>,
-    referenceId: Signal<string | undefined>,
-  ) {
-    return this.generateQueryOptions<WalletWithCards>({
-      path: [
-        ...BASE_ENDPOINT(programId),
-        referenceId,
-        'fsps',
-        'intersolve-visa',
-        'wallet',
-      ],
-      method: 'PATCH',
-      enabled: () => !!referenceId(),
-    });
-  }
-
-  changeCardPauseStatus({
-    programId,
-    referenceId,
-    tokenCode,
-    pauseStatus,
-  }: {
-    programId: Signal<number | string>;
-    referenceId: string;
-    tokenCode: string;
-    pauseStatus: boolean;
-  }) {
-    const endpoint = this.pathToQueryKey([
-      ...BASE_ENDPOINT(programId),
-      referenceId,
-      'fsps',
-      'intersolve-visa',
-      'wallet',
-      'cards',
-      tokenCode,
-    ]).join('/');
-
-    return this.httpWrapperService.perform121ServiceRequest({
-      method: 'PATCH',
-      endpoint,
-      httpParams: {
-        pause: pauseStatus,
-      },
-    });
-  }
-
-  replaceCardByMail({
-    programId,
-    referenceId,
-  }: {
-    programId: Signal<number | string>;
-    referenceId: string;
-  }) {
-    const endpoint = this.pathToQueryKey([
-      ...BASE_ENDPOINT(programId),
-      referenceId,
-      'fsps',
-      'intersolve-visa',
-      'wallet',
-      'cards',
-      'by-mail',
-      'replace',
-    ]).join('/');
-
-    return this.httpWrapperService.perform121ServiceRequest({
-      method: 'POST',
-      endpoint,
-    });
-  }
-
   getRegistrationsByPhonenumber({
     phonenumber,
   }: {
@@ -346,65 +274,5 @@ export class RegistrationApiService extends DomainApiService {
         phonenumber,
       },
     });
-  }
-
-  public linkCardToRegistration({
-    programId,
-    referenceId,
-    tokenCode,
-  }: {
-    programId: Signal<number | string>;
-    referenceId: Signal<string | undefined>;
-    tokenCode: string;
-  }) {
-    const endpoint = this.pathToQueryKey([
-      ...BASE_ENDPOINT(programId),
-      referenceId,
-      'fsps',
-      'intersolve-visa',
-      'wallet',
-      'cards',
-      'on-site',
-      'link',
-    ]).join('/');
-
-    const body = { tokenCode };
-
-    return this.httpWrapperService.perform121ServiceRequest({
-      method: 'POST',
-      endpoint,
-      body,
-    });
-  }
-
-  public replaceCardOnSite({
-    programId,
-    referenceId,
-    tokenCode,
-  }: {
-    programId: Signal<number | string>;
-    referenceId: Signal<string | undefined>;
-    tokenCode: string;
-  }) {
-    const endpoint = this.pathToQueryKey([
-      ...BASE_ENDPOINT(programId),
-      referenceId,
-      'fsps',
-      'intersolve-visa',
-      'wallet',
-      'cards',
-      'on-site',
-      'replace',
-    ]).join('/');
-
-    const body = { tokenCode };
-
-    const req = this.httpWrapperService.perform121ServiceRequest({
-      method: 'POST',
-      endpoint,
-      body,
-    });
-
-    return req;
   }
 }

--- a/interfaces/portal/src/app/domains/registration/registration.helper.ts
+++ b/interfaces/portal/src/app/domains/registration/registration.helper.ts
@@ -1,5 +1,4 @@
 import { ActivityTypeEnum } from '@121-service/src/activities/enum/activity-type.enum';
-import { VisaCard121Status } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/wallet-status-121.enum';
 import { DuplicateStatus } from '@121-service/src/registration/enum/duplicate-status.enum';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 
@@ -43,17 +42,6 @@ export const REGISTRATION_STATUS_VERB: Record<RegistrationStatusEnum, string> =
 export const DUPLICATE_STATUS_LABELS: Record<DuplicateStatus, string> = {
   [DuplicateStatus.duplicate]: $localize`:@@duplicate-status-duplicate:Duplicate`,
   [DuplicateStatus.unique]: $localize`:@@duplicate-status-unique:Unique`,
-};
-
-export const VISA_CARD_STATUS_LABELS: Record<VisaCard121Status, string> = {
-  [VisaCard121Status.Active]: $localize`:@@debit-card-status-active:Active`,
-  [VisaCard121Status.Issued]: $localize`:@@debit-card-status-issued:Issued`,
-  [VisaCard121Status.Blocked]: $localize`:@@debit-card-status-blocked:Blocked`,
-  [VisaCard121Status.Paused]: $localize`:@@debit-card-status-paused:Paused`,
-  [VisaCard121Status.SuspectedFraud]: $localize`:@@debit-card-status-suspected-fraud:Suspected fraud`,
-  [VisaCard121Status.Unknown]: $localize`:@@debit-card-status-unknown:Unknown`,
-  [VisaCard121Status.Substituted]: $localize`:@@debit-card-status-substituted:Substituted`,
-  [VisaCard121Status.CardDataMissing]: $localize`:@@debit-card-status-card-data-missing:Debit card data missing`,
 };
 
 export const ACTIVITY_LOG_ITEM_TYPE_LABELS: Record<ActivityTypeEnum, string> = {

--- a/interfaces/portal/src/app/domains/registration/registration.model.ts
+++ b/interfaces/portal/src/app/domains/registration/registration.model.ts
@@ -6,7 +6,6 @@ import { MessageActivity } from '@121-service/src/activities/interfaces/message-
 import { NoteActivity } from '@121-service/src/activities/interfaces/note-activity.interface';
 import { StatusChangeActivity } from '@121-service/src/activities/interfaces/status-change-activity.interface';
 import { TransactionActivity } from '@121-service/src/activities/interfaces/transaction-activity.interface';
-import { IntersolveVisaWalletDto } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/dtos/internal/intersolve-visa-wallet.dto';
 import { BulkActionResultDto } from '@121-service/src/registration/dto/bulk-action-result.dto';
 import { DuplicateReponseDto } from '@121-service/src/registration/dto/duplicate-response.dto';
 import { FindAllRegistrationsResultDto } from '@121-service/src/registration/dto/find-all-registrations-result.dto';
@@ -38,8 +37,6 @@ export type Activity =
 export type ActitivitiesResponse = {
   data: Activity[];
 } & Dto<Omit<ActivitiesDto, 'data'>>;
-
-export type WalletWithCards = Dto<IntersolveVisaWalletDto>;
 
 export type SendMessageData =
   | { customMessage: string }

--- a/interfaces/portal/src/app/pages/program-registration-debit-cards/components/link-card-on-site-dialog/link-card-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-registration-debit-cards/components/link-card-on-site-dialog/link-card-dialog.component.ts
@@ -16,7 +16,7 @@ import { DialogModule } from 'primeng/dialog';
 import { InputMask } from 'primeng/inputmask';
 
 import { FormErrorComponent } from '~/components/form-error/form-error.component';
-import { RegistrationApiService } from '~/domains/registration/registration.api.service';
+import { IntersolveVisaApiService } from '~/domains/fsp-account-management/intersolve-visa.api.service';
 import { LinkCardDialogStates } from '~/pages/program-registration-debit-cards/components/link-card-on-site-dialog/enums/link-card-dialog-states.enum';
 import { ToastService } from '~/services/toast.service';
 import { isErrorWithStatusCode } from '~/utils/is-error-with-status-code.helper';
@@ -29,7 +29,7 @@ import { isErrorWithStatusCode } from '~/utils/is-error-with-status-code.helper'
 })
 export class LinkCardDialogComponent {
   private readonly toastService = inject(ToastService);
-  private readonly registrationApiService = inject(RegistrationApiService);
+  private readonly intersolveVisaApiService = inject(IntersolveVisaApiService);
   readonly currentTokenCode = input<string>();
   readonly previousTokenCodes = input.required<string[]>();
   readonly programId = input.required<Signal<number | string>>();
@@ -164,13 +164,13 @@ export class LinkCardDialogComponent {
 
     try {
       if (this.currentTokenCode()) {
-        await this.registrationApiService.replaceCardOnSite({
+        await this.intersolveVisaApiService.replaceCardOnSite({
           programId: this.programId(),
           referenceId: this.referenceId(),
           tokenCode: tokenCodeWithoutDashes,
         });
       } else {
-        await this.registrationApiService.linkCardToRegistration({
+        await this.intersolveVisaApiService.linkCardToRegistration({
           programId: this.programId(),
           referenceId: this.referenceId(),
           tokenCode: tokenCodeWithoutDashes,

--- a/interfaces/portal/src/app/pages/program-registration-debit-cards/program-registration-debit-cards.page.ts
+++ b/interfaces/portal/src/app/pages/program-registration-debit-cards/program-registration-debit-cards.page.ts
@@ -26,6 +26,7 @@ import {
 } from '~/components/data-list/data-list.component';
 import { FormDialogComponent } from '~/components/form-dialog/form-dialog.component';
 import { PageLayoutRegistrationComponent } from '~/components/page-layout-registration/page-layout-registration.component';
+import { IntersolveVisaApiService } from '~/domains/fsp-account-management/intersolve-visa.api.service';
 import { FspConfigurationApiService } from '~/domains/fsp-configuration/fsp-configuration.api.service';
 import {
   FspConfigurationProperty,
@@ -62,6 +63,7 @@ export class ProgramRegistrationDebitCardsPageComponent {
   readonly registrationId = input.required<string>();
 
   private readonly registrationApiService = inject(RegistrationApiService);
+  private readonly intersolveVisaApiService = inject(IntersolveVisaApiService);
   private readonly toastService = inject(ToastService);
   private readonly programApiService = inject(ProgramApiService);
   private readonly fspConfigurationApiService = inject(
@@ -80,7 +82,7 @@ export class ProgramRegistrationDebitCardsPageComponent {
   readonly referenceId = computed(() => this.registration.data()?.referenceId);
 
   walletWithCards = injectQuery(
-    this.registrationApiService.getWalletWithCardsByReferenceId(
+    this.intersolveVisaApiService.getWalletWithCardsByReferenceId(
       this.programId,
       this.referenceId,
     ),
@@ -258,7 +260,7 @@ export class ProgramRegistrationDebitCardsPageComponent {
         throw new Error('ReferenceId or tokenCode is missing');
       }
 
-      return this.registrationApiService.changeCardPauseStatus({
+      return this.intersolveVisaApiService.changeCardPauseStatus({
         programId: this.programId,
         referenceId,
         tokenCode,
@@ -281,7 +283,7 @@ export class ProgramRegistrationDebitCardsPageComponent {
         throw new Error('ReferenceId is missing');
       }
 
-      return this.registrationApiService.replaceCardByMail({
+      return this.intersolveVisaApiService.replaceCardByMail({
         programId: this.programId,
         referenceId,
       });


### PR DESCRIPTION
[AB#39646](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/39646) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Added a FSP account management domain in Portal and moved Intersolve Visa related account management code from the registrations domain to the new one.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-7749.westeurope.3.azurestaticapps.net
