### PR TITLE
Bugfix: prevent voucher being set to 'send' when twilio message fails

### DIFF
--- a/services/121-service/src/fsp-integrations/integrations/intersolve-voucher/services/intersolve-voucher.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-voucher/services/intersolve-voucher.service.ts
@@ -657,10 +657,8 @@ export class IntersolveVoucherService {
 
     intersolveVoucher.lastRequestedBalance = realBalance;
     intersolveVoucher.updatedLastRequestedBalance = new Date();
-    //TODO: voucher send is set to true
     if (realBalance !== intersolveVoucher.transferValue) {
       intersolveVoucher.balanceUsed = true;
-      // does this make sense? send is set to true when balance is used?
       intersolveVoucher.send = true;
     }
     await this.intersolveVoucherScopedRepository.save(intersolveVoucher);
@@ -718,13 +716,11 @@ export class IntersolveVoucherService {
     newTransactionStatus,
     errorMessage,
     messageSid,
-    intersolveVoucherId: _intersolveVoucherId,
   }: {
     transactionId: number;
     newTransactionStatus: TransactionStatusEnum;
     errorMessage: string | null;
     messageSid?: string;
-    intersolveVoucherId: number;
   }): Promise<void> {
     await this.transactionsService.saveProgressFromExternalSource({
       transactionId,

--- a/services/121-service/src/notifications/services/message.service.ts
+++ b/services/121-service/src/notifications/services/message.service.ts
@@ -283,8 +283,6 @@ export class MessageService {
           newTransactionStatus,
           errorMessage,
           messageSid,
-          intersolveVoucherId:
-            messageJobDto.customData.transactionData.intersolveVoucherId!,
         },
       );
     }


### PR DESCRIPTION
[AB#40039](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/40039) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Sometimes a voucher is being claimed by a registration answering our message with "yes" before Twilio successfully sent the voucher to the registration. To prevent this, this PR moves the logic, that sets a voucher to claimed (send), to where we can check if the voucher is successfully sent.

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have addressed all Copilot comments
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary
- [ ] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [ ] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
