### PR TITLE
fix: Use explicit Node.js-version instead of exception via ENV-variable

### DIFF
--- a/.github/workflows/test_workflows.yml
+++ b/.github/workflows/test_workflows.yml
@@ -18,10 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up Node.js version
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+
       - name: Lint GitHub Action workflows
         uses: raven-actions/actionlint@v2
-        env:
-          NPM_CONFIG_ENGINE_STRICT: false # Allows "@actions/tool-cache" to install, as it fails to on Node.js v24 with the "engine-strict"-setting
         with:
           group-result: false
           shellcheck: true


### PR DESCRIPTION
[AB#40093](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/40093)

## Describe your changes

Maybe this removes the need of making the weird exception-via-an-ENV-variable...

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
