### PR TITLE
fix: Add generic Guards-decorator to Controller-class

### DIFF
--- a/services/121-service/src/cronjob/cronjob.controller.ts
+++ b/services/121-service/src/cronjob/cronjob.controller.ts
@@ -22,6 +22,7 @@ import { CronjobExecutionService } from '@121-service/src/cronjob/services/cronj
 import { CronjobInitiateService } from '@121-service/src/cronjob/services/cronjob-initiate.service';
 import { RemoveDeprecatedImageCodesDto } from '@121-service/src/fsp-integrations/integrations/intersolve-voucher/dto/remove-deprecated-image-codes-dto';
 import { AuthenticatedUser } from '@121-service/src/guards/authenticated-user.decorator';
+import { AuthenticatedUserGuard } from '@121-service/src/guards/authenticated-user.guard';
 
 @ApiTags('cronjobs')
 @Controller('cronjobs')


### PR DESCRIPTION
[AB#40318](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/40318)

## Describe your changes

This should make the "cronjob-endpoints" only accessible for logged-in users;

> [!NOTE]
> We should probable write an API-test to verify this.
> (Maybe for all endpoints? Or in a more generic way?)

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [ ] I have added tests for my changes
- [x] I have made sure that all automated checks pass before requesting a review
- [ ] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary
- [ ] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
