### PR TITLE
chore: Prevent double slashes in paths

### DIFF
--- a/.github/workflows/test_interface_portal.yml
+++ b/.github/workflows/test_interface_portal.yml
@@ -26,7 +26,7 @@ permissions:
   id-token: write
 
 env:
-  interfacePath: interfaces/portal/
+  interfacePath: interfaces/portal
 
 jobs:
   test:


### PR DESCRIPTION
[AB#40292](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/40292)

## Describe your changes

The path is used to concatenate the location of the coverage-report, which would result in the path: (the error/warning is not relevant here; only the path is!¡)
<img width="796" height="80" alt="image" src="https://github.com/user-attachments/assets/b49ead90-f628-48fc-91f2-40a16eab6f02" />


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
