### PR TITLE
ci: Make lint/type checks fail sooner, before all shards start

### DIFF
--- a/.github/workflows/test_service_api.yml
+++ b/.github/workflows/test_service_api.yml
@@ -21,7 +21,7 @@ permissions:
   id-token: write
 
 env:
-  workingDirectory: services/121-service/
+  workingDirectory: services/121-service
 
 jobs:
   path-filter:
@@ -121,7 +121,7 @@ jobs:
         with:
           name: integration-test-coverage-report-${{ matrix.shard }}
           path: |
-            ${{ env.workingDirectory }}coverage
+            ${{ env.workingDirectory }}/coverage
 
       - name: Docker logs
         if: always()
@@ -186,7 +186,7 @@ jobs:
         with:
           command: publish
           oidc: true
-          add-prefix: ${{ env.workingDirectory }}
+          add-prefix: ${{ env.workingDirectory }}/
           tag: 121-service
           files: coverage/**/lcov.info
           verbose: true


### PR DESCRIPTION
[AB#40537](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/40537)

See also: [AB#38150](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38150)

## Describe your changes

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] The change IS the test
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
