### PR TITLE
Allow killing the server, which should allow qlty report to be genera…

### DIFF
--- a/services/121-service/src/utils/test-helpers/test.controller.ts
+++ b/services/121-service/src/utils/test-helpers/test.controller.ts
@@ -14,6 +14,7 @@ import { IS_DEVELOPMENT } from '@121-service/src/config';
 import { env } from '@121-service/src/env';
 import { AuthenticatedUser } from '@121-service/src/guards/authenticated-user.decorator';
 import { AuthenticatedUserGuard } from '@121-service/src/guards/authenticated-user.guard';
+import { NoUserAuthenticationEndpoint } from '@121-service/src/guards/no-user-authentication.decorator';
 import { indirectRelationConfig } from '@121-service/src/scoped.repository';
 import { SecretDto } from '@121-service/src/scripts/scripts.controller';
 
@@ -23,7 +24,9 @@ import { SecretDto } from '@121-service/src/scripts/scripts.controller';
 export class TestController {
   constructor(private readonly dataSource: DataSource) {}
 
-  @AuthenticatedUser({ isAdmin: true })
+  @NoUserAuthenticationEndpoint(
+    'This endpoint is for testing purposes only and does not require authentication. It is protected by a secret and disabled in production. Authentication is intentionally bypassed as this endpoint is used to terminate the service for generating qlty reports.',
+  )
   @ApiOperation({
     summary:
       'WARNING: Kills 121-service. Only works in DEBUG-mode. Only used for testing purposes.',


### PR DESCRIPTION

[AB#40536](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/40536) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Remove auth for killing the server in test, which should allow qlty report to be generated again

See this in the 'check have passed menu'

<img width="544" height="38" alt="image" src="https://github.com/user-attachments/assets/7ff777b6-f6e9-46b1-aac6-a0cad8c38d3f" />


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/global-121/121-internal-documentation/blob/main/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
