### PR TITLE
fix: Make sure all Swagger-UIs are still recognizable (even in Dark Mode)

### DIFF
--- a/services/121-service/src/config.ts
+++ b/services/121-service/src/config.ts
@@ -28,7 +28,7 @@ if (env.ENV_ICON) {
 export const APP_FAVICON = favIconUrl;
 export const SWAGGER_CUSTOM_CSS = `
   html.dark-mode .swagger-ui .topbar,
-  .swagger-ui .topbar { background: ${headerStyle};}
+  .swagger-ui .topbar { background: ${headerStyle}; }
   .swagger-ui .topbar .topbar-wrapper { justify-content: end; min-height: 3rem; }
   .swagger-ui .topbar .link,
   .swagger-ui .scheme-container { display: none; }

--- a/services/mock-service/src/config.ts
+++ b/services/mock-service/src/config.ts
@@ -25,7 +25,7 @@ export const APP_FAVICON = favIconUrl;
 
 export const SWAGGER_CUSTOM_CSS = `
   html.dark-mode .swagger-ui .topbar,
-  .swagger-ui .topbar { background: ${headerStyle};}
+  .swagger-ui .topbar { background: ${headerStyle}; }
   .swagger-ui .topbar .topbar-wrapper { justify-content: end; min-height: 3rem; }
   .swagger-ui .topbar .link,
   .swagger-ui .scheme-container { display: none; }


### PR DESCRIPTION
[AB#40970](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/40970)

## Describe your changes

To prevent confusion between multiple windows of the Swagger-UI(s).

Also in "dark mode", the top of the page will be recognisable for each instance.

(Additionally, some tweaks to the layout/positioning is done to put the "dark mode switch"/lightbulb in an expected position (top-right)

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes will fix the UI/DX
- [x] Adding tests is not really feasable
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
