### PR TITLE
Add fix for failing ValidateAddingAllFsps E2E test

### DIFF
--- a/e2e/portal/pages/FspSettingsPage.ts
+++ b/e2e/portal/pages/FspSettingsPage.ts
@@ -85,17 +85,26 @@ class FspSettingsPage extends BasePage {
     fspNames: string[];
     visible?: boolean;
   }) {
-    // There is no explicit count for checking if an FSP is available more than once
-    // Because playwright does it implicitly when checking visibility of an element
-    // (e.g. if there are 2 elements with the same text and we check for visibility,
-    // it will fail because it doesn't know which one to check)
     for (const fspName of fspNames) {
       const fspLocator = this.fspCard.filter({ hasText: fspName });
       if (visible) {
-        await expect(fspLocator.first()).toBeVisible();
+        await expect(fspLocator).toBeVisible();
       } else {
-        await expect(fspLocator.first()).toBeHidden();
+        await expect(fspLocator).toBeHidden();
       }
+    }
+  }
+
+  async validateVisibilityOfOnlyConfiguredFsps({
+    fspNames,
+  }: {
+    fspNames: string[];
+  }) {
+    for (const fspName of fspNames) {
+      const fspLocator = this.fspCard
+        .filter({ hasText: fspName })
+        .getByText('Click to reconfigure');
+      await expect(fspLocator).toBeVisible();
     }
   }
 

--- a/e2e/portal/tests/ProgramSettings/FSP configuration/ValidateAddingAllFsps.spec.ts
+++ b/e2e/portal/tests/ProgramSettings/FSP configuration/ValidateAddingAllFsps.spec.ts
@@ -79,7 +79,7 @@ test('Add all available FSPs', async ({
   });
 
   await test.step('Validate that only selected FSPs were configured', async () => {
-    await fspSettingsPage.validateFspVisibility({
+    await fspSettingsPage.validateVisibilityOfOnlyConfiguredFsps({
       fspNames: fspsConfiguredInKobo,
     });
   });


### PR DESCRIPTION
[AB#41015](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/41015) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

I Added selecting ```validateVisibilityOfOnlyConfiguredFsps()``` which only checks for configured FSPs by getting element by text ```Click to reconfigure``` which is only present by configured FSPs. This should limit or eliminate flakiness of the test since during setup phase we can only configure uniquely named FSPs.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
