### PR TITLE
chore: E2E fixture, remove accessToken generation

### DIFF
--- a/e2e/portal/fixtures/fixture.ts
+++ b/e2e/portal/fixtures/fixture.ts
@@ -58,7 +58,6 @@ type Fixtures = {
   }) => Promise<void>;
   login: (params?: { username?: string; password?: string }) => Promise<void>;
   onlyResetAndSeedRegistrations: (params) => Promise<void>;
-  accessToken: string;
   exportDataComponent: ExportData;
   tableComponent: TableComponent;
   fspSettingsPage: FspSettingsPage;
@@ -243,11 +242,6 @@ export const customSharedFixture = base.extend<Fixtures>({
       });
     };
     await use(fn);
-  },
-
-  accessToken: async ({}, use) => {
-    const accessToken = await getAccessToken();
-    await use(accessToken);
   },
 
   exportDataComponent: async ({ page }, use) => {

--- a/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithCbe.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithCbe.spec.ts
@@ -4,6 +4,7 @@ import { TransactionStatusEnum } from '@121-service/src/payments/transactions/en
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import CbeProgram from '@121-service/src/seed-data/program/program-cbe.json';
 import { waitForPaymentAndTransactionsToComplete } from '@121-service/test/helpers/program.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import {
   programIdCbe,
   registrationsCbe,
@@ -24,8 +25,8 @@ test('Do successful payment for Cbe fsp', async ({
   page,
   paymentPage,
   paymentsPage,
-  accessToken,
 }) => {
+  const accessToken = await getAccessToken();
   const numberOfPas = registrationsCbe.length;
   const defaultTransferValue = CbeProgram.fixedTransferValue;
   const defaultMaxTransferValue = registrationsCbe.reduce((output, pa) => {

--- a/e2e/portal/tests/EditRegistration/EditRegistration.spec.ts
+++ b/e2e/portal/tests/EditRegistration/EditRegistration.spec.ts
@@ -1,5 +1,6 @@
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { getRegistrationIdByReferenceId } from '@121-service/test/helpers/registration.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import {
   programIdPV,
   registrationPV5,
@@ -23,21 +24,20 @@ test.describe('Edit all the fields in registration Personal Information', () => 
     });
   });
 
-  test.beforeEach(
-    async ({ login, registrationPersonalInformationPage, accessToken }) => {
-      await login();
-      registrationId = await getRegistrationIdByReferenceId({
-        programId: programIdPV,
-        referenceId: registrationPV5.referenceId,
-        accessToken,
-      });
+  test.beforeEach(async ({ login, registrationPersonalInformationPage }) => {
+    await login();
+    const accessToken = await getAccessToken();
+    registrationId = await getRegistrationIdByReferenceId({
+      programId: programIdPV,
+      referenceId: registrationPV5.referenceId,
+      accessToken,
+    });
 
-      await registrationPersonalInformationPage.goto(
-        `/program/${programIdPV}/registrations/${registrationId}/personal-information`,
-      );
-      await registrationPersonalInformationPage.clickEditInformationButton();
-    },
-  );
+    await registrationPersonalInformationPage.goto(
+      `/program/${programIdPV}/registrations/${registrationId}/personal-information`,
+    );
+    await registrationPersonalInformationPage.clickEditInformationButton();
+  });
 
   test('Edit: Dropdown Selection fields', async ({
     registrationPersonalInformationPage,

--- a/e2e/portal/tests/EditRegistration/EditRegistrationFsp.spec.ts
+++ b/e2e/portal/tests/EditRegistration/EditRegistrationFsp.spec.ts
@@ -1,5 +1,6 @@
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { getRegistrationIdByReferenceId } from '@121-service/test/helpers/registration.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import {
   programIdPV,
   registrationPV5,
@@ -15,13 +16,14 @@ import {
 let registrationId: number;
 
 // Arrange
-test.beforeEach(async ({ page, resetDBAndSeedRegistrations, accessToken }) => {
+test.beforeEach(async ({ page, resetDBAndSeedRegistrations }) => {
   await resetDBAndSeedRegistrations({
     seedScript: SeedScript.nlrcMultiple,
     registrations: [registrationPV5],
     programId: programIdPV,
   });
 
+  const accessToken = await getAccessToken();
   registrationId = await getRegistrationIdByReferenceId({
     programId: programIdPV,
     referenceId: registrationPV5.referenceId,

--- a/e2e/portal/tests/ExportRegistrations/ExportCoopbankEmptyVerificationReport.spec.ts
+++ b/e2e/portal/tests/ExportRegistrations/ExportCoopbankEmptyVerificationReport.spec.ts
@@ -1,17 +1,19 @@
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import CoopBank from '@121-service/src/seed-data/program/program-cooperative-bank-of-oromia.json';
 import { startCooperativeBankOfOromiaValidationProcess } from '@121-service/test/helpers/program.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 
 import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
 
 const coopBankProgramId = 1;
 
-test.beforeEach(async ({ resetDBAndSeedRegistrations, accessToken }) => {
+test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   await resetDBAndSeedRegistrations({
     seedScript: SeedScript.cooperativeBankOfOromiaProgram,
     programId: coopBankProgramId,
     skipSeedRegistrations: true,
   });
+  const accessToken = await getAccessToken();
   await startCooperativeBankOfOromiaValidationProcess(
     coopBankProgramId,
     accessToken,

--- a/e2e/portal/tests/ExportRegistrations/ExportCoopbankVerificationReport.spec.ts
+++ b/e2e/portal/tests/ExportRegistrations/ExportCoopbankVerificationReport.spec.ts
@@ -1,18 +1,20 @@
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import CoopBank from '@121-service/src/seed-data/program/program-cooperative-bank-of-oromia.json';
 import { startCooperativeBankOfOromiaValidationProcess } from '@121-service/test/helpers/program.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import { registrationsCooperativeBankOfOromia } from '@121-service/test/registrations/pagination/pagination-data';
 
 import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
 
 const coopBankProgramId = 1;
 
-test.beforeEach(async ({ resetDBAndSeedRegistrations, accessToken }) => {
+test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   await resetDBAndSeedRegistrations({
     seedScript: SeedScript.cooperativeBankOfOromiaProgram,
     registrations: registrationsCooperativeBankOfOromia,
     programId: coopBankProgramId,
   });
+  const accessToken = await getAccessToken();
   await startCooperativeBankOfOromiaValidationProcess(
     coopBankProgramId,
     accessToken,

--- a/e2e/portal/tests/ExportRegistrations/ExportRegistrationsList.spec.ts
+++ b/e2e/portal/tests/ExportRegistrations/ExportRegistrationsList.spec.ts
@@ -1,6 +1,7 @@
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import NLRCProgramPV from '@121-service/src/seed-data/program/program-nlrc-pv.json';
 import { deleteRegistrations } from '@121-service/test/helpers/registration.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import {
   programIdPV,
   registrationPvMaxPayment,
@@ -18,8 +19,9 @@ test.describe('Export registrations with different formats and configurations', 
     });
   });
 
-  test.beforeEach(async ({ login, accessToken }) => {
+  test.beforeEach(async ({ login }) => {
     await login();
+    const accessToken = await getAccessToken();
     await deleteRegistrations({
       programId: programIdPV,
       referenceIds: [registrationPvMaxPayment.referenceId],

--- a/e2e/portal/tests/ManageTeam/UserCannotAssignRolesToSelf.spec.ts
+++ b/e2e/portal/tests/ManageTeam/UserCannotAssignRolesToSelf.spec.ts
@@ -2,17 +2,22 @@ import { expect } from '@playwright/test';
 
 import { env } from '@121-service/src/env';
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
-import { removeProgramAssignment } from '@121-service/test/helpers/utility.helper';
+import {
+  getAccessToken,
+  removeProgramAssignment,
+} from '@121-service/test/helpers/utility.helper';
 
 import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
 
 const programId = 2;
 
-test.beforeEach(async ({ resetDBAndSeedRegistrations, accessToken }) => {
+test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   await resetDBAndSeedRegistrations({
     seedScript: SeedScript.testMultiple,
     skipSeedRegistrations: true,
   });
+
+  const accessToken = await getAccessToken();
 
   // remove assignments of all users except admin again, to create the context for this test
   for (let userId = 2; userId <= 10; userId++) {

--- a/e2e/portal/tests/ProfilePageActivityLog/FilterActivityOverviewTable.spec.ts
+++ b/e2e/portal/tests/ProfilePageActivityLog/FilterActivityOverviewTable.spec.ts
@@ -4,6 +4,7 @@ import {
   getRegistrationIdByReferenceId,
   updateRegistration,
 } from '@121-service/test/helpers/registration.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import {
   programIdPV,
   registrationPV5,
@@ -22,9 +23,11 @@ test.beforeAll(async ({ onlyResetAndSeedRegistrations }) => {
   });
 });
 
-test.beforeEach(async ({ page, login, accessToken }) => {
+test.beforeEach(async ({ page, login }) => {
   // Arrange once because tests don't mutate backend state.
   await login();
+
+  const accessToken = await getAccessToken();
 
   registrationId = await getRegistrationIdByReferenceId({
     programId: programIdPV,

--- a/e2e/portal/tests/ProgramLevelAttachments/DeleteAttachment.spec.ts
+++ b/e2e/portal/tests/ProgramLevelAttachments/DeleteAttachment.spec.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { uploadAttachment } from '@121-service/test/helpers/program-attachments.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import { programIdOCW } from '@121-service/test/registrations/pagination/pagination-data';
 
 import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
@@ -29,12 +30,14 @@ const fileNameToDelete = 'test-document.docx';
 
 // Arrange
 test.describe('Attachments on Program Level', () => {
-  test.beforeEach(async ({ resetDBAndSeedRegistrations, accessToken }) => {
+  test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
     await resetDBAndSeedRegistrations({
       seedScript: SeedScript.nlrcMultiple,
       skipSeedRegistrations: true,
       navigateToPage: `/program/${programIdOCW}/monitoring/files`,
     });
+
+    const accessToken = await getAccessToken();
 
     for (const filePath of testFilePaths) {
       const baseName = path.basename(filePath);

--- a/e2e/portal/tests/ProgramLevelAttachments/DownloadAttachment.spec.ts
+++ b/e2e/portal/tests/ProgramLevelAttachments/DownloadAttachment.spec.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { uploadAttachment } from '@121-service/test/helpers/program-attachments.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import { programIdOCW } from '@121-service/test/registrations/pagination/pagination-data';
 
 import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
@@ -14,12 +15,14 @@ const fileName = 'Test TEST-DOCUMENT file upload.pdf';
 
 // Arrange
 test.describe('Attachments on Program Level', () => {
-  test.beforeEach(async ({ resetDBAndSeedRegistrations, accessToken }) => {
+  test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
     await resetDBAndSeedRegistrations({
       seedScript: SeedScript.nlrcMultiple,
       skipSeedRegistrations: true,
       navigateToPage: `/program/${programIdOCW}/monitoring/files`,
     });
+
+    const accessToken = await getAccessToken();
 
     await uploadAttachment({
       programId: programIdOCW,

--- a/e2e/portal/tests/ProgramMonitoring/DataChangesTabDisplaysCorrectData.spec.ts
+++ b/e2e/portal/tests/ProgramMonitoring/DataChangesTabDisplaysCorrectData.spec.ts
@@ -58,6 +58,7 @@ test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   });
 
   const accessToken = await getAccessToken();
+
   // Make data changes
   const response = await updateRegistration(
     programIdOCW,

--- a/e2e/portal/tests/ProgramSettings/ProgramInformation/EditProgramInformation.spec.ts
+++ b/e2e/portal/tests/ProgramSettings/ProgramInformation/EditProgramInformation.spec.ts
@@ -7,6 +7,7 @@ import {
   getProgram,
   patchProgram,
 } from '@121-service/test/helpers/program.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import { programIdOCW } from '@121-service/test/registrations/pagination/pagination-data';
 
 import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
@@ -15,11 +16,13 @@ const todaysDate = new Date();
 const futureDate = new Date();
 futureDate.setDate(futureDate.getDate() + 1);
 
-test.beforeEach(async ({ resetDBAndSeedRegistrations, accessToken }) => {
+test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   await resetDBAndSeedRegistrations({
     seedScript: SeedScript.nlrcMultiple,
     skipSeedRegistrations: true,
   });
+
+  const accessToken = await getAccessToken();
 
   await patchProgram(
     programIdOCW,
@@ -33,10 +36,7 @@ test.beforeEach(async ({ resetDBAndSeedRegistrations, accessToken }) => {
   );
 });
 
-test('Edit Program Information', async ({
-  programSettingsPage,
-  accessToken,
-}) => {
+test('Edit Program Information', async ({ programSettingsPage }) => {
   const programInfo = {
     name: 'TUiR Warta',
     description: 'TUiR Warta description',
@@ -109,6 +109,7 @@ test('Edit Program Information', async ({
 
     // Also validate the API still returns other language translations for a translatable field
     // It is suboptimal to do this check via the API, but this is for covering a bug that occurred before, by using a combination of the UI and API
+    const accessToken = await getAccessToken();
     const program = await getProgram(programIdOCW, accessToken);
     expect(program.body.titlePortal?.nl).toBeDefined();
   });

--- a/e2e/portal/tests/RegistrationPage/InitiateActions.spec.ts
+++ b/e2e/portal/tests/RegistrationPage/InitiateActions.spec.ts
@@ -2,6 +2,7 @@ import { expect } from '@playwright/test';
 
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { getRegistrationIdByReferenceId } from '@121-service/test/helpers/registration.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import {
   programIdPV,
   registrationPV5,
@@ -12,12 +13,14 @@ import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
 const programId = 2;
 let registrationId: number;
 
-test.beforeEach(async ({ resetDBAndSeedRegistrations, accessToken }) => {
+test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   await resetDBAndSeedRegistrations({
     seedScript: SeedScript.nlrcMultiple,
     registrations: [registrationPV5],
     programId: programIdPV,
   });
+
+  const accessToken = await getAccessToken();
 
   registrationId = await getRegistrationIdByReferenceId({
     programId: programIdPV,

--- a/e2e/portal/tests/RegistrationPage/ViewAvailableActions.spec.ts
+++ b/e2e/portal/tests/RegistrationPage/ViewAvailableActions.spec.ts
@@ -6,7 +6,10 @@ import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 import { DefaultUserRole } from '@121-service/src/user/enum/user-role.enum';
 import { getRegistrationIdByReferenceId } from '@121-service/test/helpers/registration.helper';
-import { addPermissionToRole } from '@121-service/test/helpers/utility.helper';
+import {
+  addPermissionToRole,
+  getAccessToken,
+} from '@121-service/test/helpers/utility.helper';
 import {
   programIdPV,
   registrationPV5,
@@ -18,13 +21,14 @@ let registrationId: number;
 let registrationUrl: string;
 
 test.describe('User actions', () => {
-  test.beforeEach(async ({ onlyResetAndSeedRegistrations, accessToken }) => {
+  test.beforeEach(async ({ onlyResetAndSeedRegistrations }) => {
     await onlyResetAndSeedRegistrations({
       seedScript: SeedScript.nlrcMultiple,
       seedWithStatus: RegistrationStatusEnum.included,
       registrations: [registrationPV5],
       programId: programIdPV,
     });
+    const accessToken = await getAccessToken();
     registrationId = await getRegistrationIdByReferenceId({
       programId: programIdPV,
       referenceId: registrationPV5.referenceId,

--- a/e2e/portal/tests/RegistrationPage/ViewPersonalInformation.spec.ts
+++ b/e2e/portal/tests/RegistrationPage/ViewPersonalInformation.spec.ts
@@ -5,6 +5,7 @@ import {
   getRegistrationIdByReferenceId,
   seedIncludedRegistrations,
 } from '@121-service/test/helpers/registration.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import { registrationWesteros4 } from '@121-service/test/registrations/pagination/pagination-data';
 
 import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
@@ -21,8 +22,8 @@ test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
 
 test('User can view the registration data of registration that has all data types', async ({
   registrationPersonalInformationPage,
-  accessToken,
 }) => {
+  const accessToken = await getAccessToken();
   await seedIncludedRegistrations(
     [registrationWesteros4],
     programId,
@@ -67,8 +68,8 @@ test('User can view the registration data of registration that has all data type
 
 test('User can view the registration data of registration that has only the required data', async ({
   registrationPersonalInformationPage,
-  accessToken,
 }) => {
+  const accessToken = await getAccessToken();
   const registrationWithOnlyRequiredData = {
     referenceId: registrationWesteros4.referenceId,
     programFspConfigurationName:

--- a/e2e/portal/tests/RegistrationPage/ViewRegistrationSummary.spec.ts
+++ b/e2e/portal/tests/RegistrationPage/ViewRegistrationSummary.spec.ts
@@ -2,6 +2,7 @@ import { expect } from '@playwright/test';
 
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { searchRegistrationByReferenceId } from '@121-service/test/helpers/registration.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import { registrationPvScoped } from '@121-service/test/registrations/pagination/pagination-data';
 
 import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
@@ -13,7 +14,6 @@ let registrationProgramId: number;
 test('User should see a summary of a registration', async ({
   registrationActivityLogPage,
   resetDBAndSeedRegistrations,
-  accessToken,
 }) => {
   await resetDBAndSeedRegistrations({
     seedScript: SeedScript.nlrcMultiple,
@@ -21,6 +21,8 @@ test('User should see a summary of a registration', async ({
     registrations: [registrationPvScoped],
     programId,
   });
+
+  const accessToken = await getAccessToken();
 
   const searchRegistrationResponse = await searchRegistrationByReferenceId(
     registrationPvScoped.referenceId,

--- a/e2e/portal/tests/ViewPayment/ErrorOnMissingColumnMatchConfiguration.spec.ts
+++ b/e2e/portal/tests/ViewPayment/ErrorOnMissingColumnMatchConfiguration.spec.ts
@@ -2,6 +2,7 @@ import { FspConfigurationProperties } from '@121-service/src/fsp-integrations/sh
 import { Fsps } from '@121-service/src/fsp-integrations/shared/enum/fsp-name.enum';
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { deleteProgramFspConfigurationProperty } from '@121-service/test/helpers/program-fsp-configuration.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import {
   programIdPV,
   registrationsPvExcel,
@@ -9,13 +10,15 @@ import {
 
 import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
 
-test.beforeEach(async ({ resetDBAndSeedRegistrations, accessToken }) => {
+test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   await resetDBAndSeedRegistrations({
     seedScript: SeedScript.nlrcMultiple,
     registrations: registrationsPvExcel,
     programId: programIdPV,
     navigateToPage: `/program/${programIdPV}/payments`,
   });
+
+  const accessToken = await getAccessToken();
 
   await deleteProgramFspConfigurationProperty({
     programId: programIdPV,

--- a/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
+++ b/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
@@ -3,6 +3,7 @@ import { expect } from '@playwright/test';
 import { env } from '@121-service/src/env';
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { doPaymentAndWaitForCompletion } from '@121-service/test/helpers/registration.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import {
   programIdOCW,
   registrationsOCW,
@@ -20,11 +21,8 @@ test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   });
 });
 
-test('ExportPayments', async ({
-  paymentsPage,
-  exportDataComponent,
-  accessToken,
-}) => {
+test('ExportPayments', async ({ paymentsPage, exportDataComponent }) => {
+  const accessToken = await getAccessToken();
   await test.step('Do payments', async () => {
     for (let i = 0; i < 4; i++) {
       await doPaymentAndWaitForCompletion({

--- a/e2e/portal/tests/ViewPayments/ExportUnusedVouchersSuccessfully.spec.ts
+++ b/e2e/portal/tests/ViewPayments/ExportUnusedVouchersSuccessfully.spec.ts
@@ -1,5 +1,6 @@
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { triggerUnusedVouchersCache } from '@121-service/test/helpers/fsp-specific.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import {
   programIdPV,
   registrationPV5,
@@ -7,7 +8,7 @@ import {
 
 import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
 
-test.beforeEach(async ({ resetDBAndSeedRegistrations, accessToken }) => {
+test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   await resetDBAndSeedRegistrations({
     seedScript: SeedScript.nlrcMultiple,
     seedPaidRegistrations: true,
@@ -16,6 +17,7 @@ test.beforeEach(async ({ resetDBAndSeedRegistrations, accessToken }) => {
     programId: programIdPV,
     navigateToPage: `/program/${programIdPV}/payments`,
   });
+  const accessToken = await getAccessToken();
   // Run cronJob to process unused vouchers
   await triggerUnusedVouchersCache(accessToken);
 });

--- a/e2e/portal/tests/ViewPayments/ValidateSecondPayment.spec.ts
+++ b/e2e/portal/tests/ViewPayments/ValidateSecondPayment.spec.ts
@@ -2,6 +2,7 @@ import { format } from 'date-fns';
 
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { doPaymentAndWaitForCompletion } from '@121-service/test/helpers/registration.helper';
+import { getAccessToken } from '@121-service/test/helpers/utility.helper';
 import {
   programIdOCW,
   registrationsVisa,
@@ -11,7 +12,7 @@ import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
 
 const transferValueForSecondPayment = 10;
 
-test.beforeEach(async ({ resetDBAndSeedRegistrations, accessToken }) => {
+test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   await resetDBAndSeedRegistrations({
     seedScript: SeedScript.nlrcMultiple,
     seedPaidRegistrations: true,
@@ -20,6 +21,8 @@ test.beforeEach(async ({ resetDBAndSeedRegistrations, accessToken }) => {
     programId: programIdOCW,
     navigateToPage: `/program/${programIdOCW}/registrations`,
   });
+
+  const accessToken = await getAccessToken();
 
   // do 2nd payment
   await doPaymentAndWaitForCompletion({


### PR DESCRIPTION
[AB#41024](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/41024) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

The E2E fixture had an `accessToken` fixture and it was created when fixtures were started. This could cause the access token to be generated before reset DB was finished which would end up in the access token being not being valid anymore. So I opted to remove that fixture and just grab the accessToken using `getAccessToken()`. I also chose not to make that part of the reset DB fixture as that was already doing too much. 

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
