### PR TITLE
chore(deps): bump Angular packages from 21.2.1 to 21.2.5

### DIFF
--- a/interfaces/portal/package-lock.json
+++ b/interfaces/portal/package-lock.json
@@ -41,8 +41,8 @@
         "zone.js": "~0.15.1"
       },
       "devDependencies": {
-        "@angular/build": "^21.2.0",
-        "@angular/cli": "^21.2.0",
+        "@angular/build": "^21.2.3",
+        "@angular/cli": "^21.2.3",
         "@angular/compiler-cli": "^21.2.5",
         "@angular/localize": "^21.2.5",
         "@azure/static-web-apps-cli": "^2.0.8",
@@ -10225,9 +10225,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/interfaces/portal/package.json
+++ b/interfaces/portal/package.json
@@ -76,8 +76,8 @@
     "zone.js": "~0.15.1"
   },
   "devDependencies": {
-    "@angular/build": "^21.2.0",
-    "@angular/cli": "^21.2.0",
+    "@angular/build": "^21.2.3",
+    "@angular/cli": "^21.2.3",
     "@angular/compiler-cli": "^21.2.5",
     "@angular/localize": "^21.2.5",
     "@azure/static-web-apps-cli": "^2.0.8",

--- a/interfaces/portal/src/app/components/page-layout-payment/page-layout-payment.component.html
+++ b/interfaces/portal/src/app/components/page-layout-payment/page-layout-payment.component.html
@@ -112,7 +112,7 @@
               data-testid="approval-flow-row"
             >
               <span
-                class="me-3 flex h-6.5 w-6.5 items-center justify-center rounded-full"
+                class="me-3 flex size-6.5 items-center justify-center rounded-full"
                 [ngClass]="{
                   'bg-purple-700 text-white':
                     approvalStep.rank === firstPendingApprovalRank(),

--- a/interfaces/portal/src/app/domains/domain-api.service.ts
+++ b/interfaces/portal/src/app/domains/domain-api.service.ts
@@ -105,7 +105,7 @@ export abstract class DomainApiService {
           endpoint,
           deSignalizedParams,
           responseAsBlob,
-          paginateQuery && paginateQuery(),
+          paginateQuery?.(),
           processResponse,
         ],
         queryFn: async () => {

--- a/interfaces/portal/src/app/services/registration-attribute.service.ts
+++ b/interfaces/portal/src/app/services/registration-attribute.service.ts
@@ -277,7 +277,7 @@ export class RegistrationAttributeService {
         queryKey: [
           'registrationAttributes',
           programId(),
-          registrationId && registrationId(),
+          registrationId?.(),
           $localize,
           RegistrationAttributeTypes.text,
         ],

--- a/interfaces/portal/src/app/services/registrations-table-column.service.ts
+++ b/interfaces/portal/src/app/services/registrations-table-column.service.ts
@@ -74,7 +74,6 @@ export class RegistrationsTableColumnService {
   getColumns(programId: Signal<number | string>) {
     return () =>
       queryOptions<QueryTableColumn<Registration>[]>({
-        // eslint-disable-next-line @tanstack/query/exhaustive-deps -- eslint is complaining about missing programId for some reason but it's wrong
         queryKey: ['RegistrationsTableColumns', programId().toString()],
         queryFn: async () => {
           const program = await this.queryClient.fetchQuery(


### PR DESCRIPTION
Upgrade all Angular packages together to resolve the ERESOLVE peer dependency conflict that occurred when only @angular/compiler was bumped to 21.2.5 while @angular/compiler-cli remained at 21.2.1.

See [AB#41036](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/41036)


Agent-Logs-Url: https://github.com/global-121/121-platform/sessions/6ce98eb1-7c08-481a-8568-7dcf126a3605

[AB#41036](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/41036) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8010.westeurope.3.azurestaticapps.net
