### PR TITLE
Also return number of submissions

### DIFF
--- a/services/121-service/src/kobo/dtos/kobo-integration-result.dto.ts
+++ b/services/121-service/src/kobo/dtos/kobo-integration-result.dto.ts
@@ -13,4 +13,10 @@ export class KoboIntegrationResultDto {
     nullable: true,
   })
   public readonly name: string | null;
+
+  @ApiProperty({
+    example: 42,
+    description: 'The current number of submissions in the Kobo form',
+  })
+  public readonly submissionCount: number;
 }

--- a/services/121-service/src/kobo/kobo.controller.ts
+++ b/services/121-service/src/kobo/kobo.controller.ts
@@ -126,6 +126,7 @@ export class KoboController {
     return {
       message: result.message,
       name: result.name,
+      submissionCount: result.submissionCount,
     };
   }
 

--- a/services/121-service/src/kobo/services/kobo-api.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo-api.service.spec.ts
@@ -460,7 +460,7 @@ describe('KoboApiService', () => {
     });
   });
 
-  describe('getAllSubmissions', () => {
+  describe('getSubmissions', () => {
     const mockSubmissionsData = [
       {
         _id: 1,
@@ -489,10 +489,11 @@ describe('KoboApiService', () => {
       });
 
       // Act
-      const result = await service.getSubmissionsUpToLimit({
+      const result = await service.getSubmissions({
         token: mockToken,
         assetUid: mockAssetUid,
         baseUrl: mockBaseUrl,
+        limit: 1000,
       });
 
       // Assert
@@ -512,7 +513,7 @@ describe('KoboApiService', () => {
       });
       // Check that the limit query parameter is included in the request URL
       const calledUrl = httpService.get.mock.calls[0]![0] as string;
-      expect(calledUrl).toContain('limit=');
+      expect(calledUrl).toContain('limit=1000');
     });
 
     // Not all error scenarios are covered here as most of the error handling is delegated in a private function which is tested via other public methods
@@ -526,10 +527,11 @@ describe('KoboApiService', () => {
       });
 
       // Act
-      const promise = service.getSubmissionsUpToLimit({
+      const promise = service.getSubmissions({
         token: mockToken,
         assetUid: mockAssetUid,
         baseUrl: mockBaseUrl,
+        limit: 1000,
       });
 
       // Assert

--- a/services/121-service/src/kobo/services/kobo-api.service.ts
+++ b/services/121-service/src/kobo/services/kobo-api.service.ts
@@ -7,7 +7,6 @@ import { KoboAssetDto } from '@121-service/src/kobo/dtos/kobo-api/kobo-asset.dto
 import { KoboAssetResponseDto } from '@121-service/src/kobo/dtos/kobo-api/kobo-asset-response.dto';
 import { KoboSubmissionDto } from '@121-service/src/kobo/dtos/kobo-api/kobo-submission.dto';
 import { KoboSubmissionsResponseDto } from '@121-service/src/kobo/dtos/kobo-api/kobo-submissions-response.dto';
-import { MAX_IMPORT_RECORDS } from '@121-service/src/registration/services/registrations-creation.service';
 import { CustomHttpService } from '@121-service/src/shared/services/custom-http.service';
 
 @Injectable()
@@ -198,19 +197,21 @@ export class KoboApiService {
     });
   }
 
-  public async getSubmissionsUpToLimit({
+  public async getSubmissions({
     token,
     assetUid,
     baseUrl,
+    limit,
   }: {
     token: string;
     assetUid: string;
     baseUrl: string;
+    limit: number;
   }): Promise<{ count: number; submissions: KoboSubmissionDto[] }> {
     const apiUrl = new URL(
       joinURL(baseUrl, 'api/v2/assets', assetUid, 'data/'),
     );
-    apiUrl.searchParams.set('limit', String(MAX_IMPORT_RECORDS));
+    apiUrl.searchParams.set('limit', String(limit));
 
     const headers = new Headers({ Authorization: `Token ${token}` });
 

--- a/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
@@ -87,7 +87,7 @@ describe('KoboSubmissionService', () => {
           provide: KoboApiService,
           useValue: {
             getSubmission: jest.fn(),
-            getSubmissionsUpToLimit: jest.fn(),
+            getSubmissions: jest.fn(),
           },
         },
         {
@@ -308,7 +308,7 @@ describe('KoboSubmissionService', () => {
     it('should successfully import new submissions (happy flow)', async () => {
       // Arrange
       koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
-      koboApiService.getSubmissionsUpToLimit.mockResolvedValue({
+      koboApiService.getSubmissions.mockResolvedValue({
         count: 2,
         submissions: [mockSubmission, mockSubmission2],
       });
@@ -357,7 +357,7 @@ describe('KoboSubmissionService', () => {
     it('should throw HttpException when there are too many submissions to import', async () => {
       // Arrange
       koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
-      koboApiService.getSubmissionsUpToLimit.mockResolvedValue({
+      koboApiService.getSubmissions.mockResolvedValue({
         count: 1001,
         submissions: [],
       });
@@ -383,7 +383,7 @@ describe('KoboSubmissionService', () => {
       const newerVersionId = 'v2';
       const newerDateDeployed = new Date('2025-06-01');
       koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
-      koboApiService.getSubmissionsUpToLimit.mockResolvedValue({
+      koboApiService.getSubmissions.mockResolvedValue({
         count: 1,
         submissions: [{ ...mockSubmission, __version__: newerVersionId }],
       });
@@ -417,7 +417,7 @@ describe('KoboSubmissionService', () => {
     it('should not update program when all submissions have the current form version', async () => {
       // Arrange
       koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
-      koboApiService.getSubmissionsUpToLimit.mockResolvedValue({
+      koboApiService.getSubmissions.mockResolvedValue({
         count: 1,
         submissions: [mockSubmission], // __version__: 'v1' matches stored versionId: 'v1'
       });
@@ -437,7 +437,7 @@ describe('KoboSubmissionService', () => {
     it('should filter out already existing registrations', async () => {
       // Arrange
       koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
-      koboApiService.getSubmissionsUpToLimit.mockResolvedValue({
+      koboApiService.getSubmissions.mockResolvedValue({
         count: 2,
         submissions: [mockSubmission, mockSubmission2],
       });

--- a/services/121-service/src/kobo/services/kobo-submission.service.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.ts
@@ -97,12 +97,12 @@ export class KoboSubmissionService {
     });
     this.assertKoboIntegrationExistsOrThrow(koboIntegration);
 
-    const { submissions, count } =
-      await this.koboApiService.getSubmissionsUpToLimit({
-        token: koboIntegration.token,
-        assetUid: koboIntegration.assetUid,
-        baseUrl: koboIntegration.url,
-      });
+    const { submissions, count } = await this.koboApiService.getSubmissions({
+      token: koboIntegration.token,
+      assetUid: koboIntegration.assetUid,
+      baseUrl: koboIntegration.url,
+      limit: MAX_IMPORT_RECORDS,
+    });
 
     const submissionWithDifferentVersion = submissions.find(
       (s) => s.__version__ !== koboIntegration.versionId,

--- a/services/121-service/src/kobo/services/kobo.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo.service.spec.ts
@@ -92,6 +92,9 @@ describe('KoboService', () => {
             getDeployedAssetOrThrow: jest.fn(),
             getExistingKoboWebhooks: jest.fn(),
             createKoboWebhook: jest.fn(),
+            getSubmissions: jest
+              .fn()
+              .mockResolvedValue({ count: 0, submissions: [] }),
           },
         },
         {
@@ -230,6 +233,7 @@ describe('KoboService', () => {
       message: 'Kobo form integrated successfully',
       name: 'Test Form',
       dryRun: false,
+      submissionCount: 0,
     });
   });
 
@@ -473,6 +477,7 @@ describe('KoboService', () => {
         message: 'Kobo form integrated successfully',
         name: 'Test Form',
         dryRun: false,
+        submissionCount: 0,
       });
     });
   });

--- a/services/121-service/src/kobo/services/kobo.service.ts
+++ b/services/121-service/src/kobo/services/kobo.service.ts
@@ -65,6 +65,7 @@ export class KoboService {
     message: string;
     dryRun: boolean;
     name: string | null;
+    submissionCount: number;
   }> {
     await this.programService.findProgramOrThrow(programId);
     const fspConfigs = await this.programFspConfigurationRepository.count({
@@ -102,11 +103,21 @@ export class KoboService {
       programId,
     });
 
+    const { count: submissionCount } = await this.koboApiService.getSubmissions(
+      {
+        token,
+        assetUid,
+        baseUrl: url,
+        limit: 0,
+      },
+    );
+
     if (dryRun) {
       return {
         message: 'Dry run successful - validation passed',
         name: formDefinition.name,
         dryRun: true,
+        submissionCount,
       };
     }
 
@@ -141,6 +152,7 @@ export class KoboService {
       message: 'Kobo form integrated successfully',
       name: formDefinition.name,
       dryRun: false,
+      submissionCount,
     };
   }
 

--- a/services/121-service/test/kobo/kobo-load-form-definition.test.ts
+++ b/services/121-service/test/kobo/kobo-load-form-definition.test.ts
@@ -136,6 +136,7 @@ describe('Import a Kobo form definition', () => {
      {
        "message": "Kobo form integrated successfully",
        "name": "25042025 Prototype Sprint",
+       "submissionCount": 1,
      }
     `);
     expect(linkKoboResponse.status).toBe(HttpStatus.CREATED);
@@ -275,6 +276,7 @@ describe('Import a Kobo form definition', () => {
     expect(linkKoboResponse.body.message).toEqual(
       'Dry run successful - validation passed',
     );
+    expect(linkKoboResponse.body.submissionCount).toBe(1);
 
     // Verify program registration attributes were NOT updated
     const getProgramResponseAfter = await getProgram(programId, accessToken);


### PR DESCRIPTION
When importing existing Kobo submissions via the PATCH endpoint, check if
any submission has a newer form version than what is stored and update the
program accordingly — mirroring the behaviour already present in the webhook flow.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>AB#XXXX <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have addressed all Copilot comments
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [ ] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [ ] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
