### PR TITLE
refactor: Refactor incoming registration validation

### DIFF
--- a/services/121-service/src/registration/interfaces/validate-registration-config.interface.ts
+++ b/services/121-service/src/registration/interfaces/validate-registration-config.interface.ts
@@ -1,4 +1,3 @@
 export interface ValidationRegistrationConfig {
-  readonly validateUniqueReferenceId: boolean;
   readonly validateExistingReferenceId: boolean;
 }

--- a/services/121-service/src/registration/interfaces/validate-registration-error-object.interface.ts
+++ b/services/121-service/src/registration/interfaces/validate-registration-error-object.interface.ts
@@ -1,5 +1,5 @@
 export interface ValidateRegistrationErrorObject {
-  readonly lineNumber: number;
+  readonly index: number;
   readonly column: string;
   readonly error: string;
   readonly value: string | number | undefined | boolean | null;

--- a/services/121-service/src/registration/interfaces/validation-result.interface.ts
+++ b/services/121-service/src/registration/interfaces/validation-result.interface.ts
@@ -1,0 +1,7 @@
+import { ValidateRegistrationErrorObject } from '@121-service/src/registration/interfaces/validate-registration-error-object.interface';
+import { ValidatedRegistrationInput } from '@121-service/src/registration/interfaces/validated-registration-input.interface';
+
+export interface ValidationResult {
+  readonly validRegistrations: ValidatedRegistrationInput[];
+  readonly errors: ValidateRegistrationErrorObject[];
+}

--- a/services/121-service/src/registration/services/registrations-creation.service.ts
+++ b/services/121-service/src/registration/services/registrations-creation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import chunk from 'lodash/chunk';
 import { Equal, Repository } from 'typeorm';
@@ -23,6 +23,7 @@ import {
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { RegistrationValidationInputType } from '@121-service/src/registration/enum/registration-validation-input-type.enum';
 import { ValidationRegistrationConfig } from '@121-service/src/registration/interfaces/validate-registration-config.interface';
+import { ValidateRegistrationErrorObject } from '@121-service/src/registration/interfaces/validate-registration-error-object.interface';
 import { ValidatedRegistrationInput } from '@121-service/src/registration/interfaces/validated-registration-input.interface';
 import { RegistrationDataScopedRepository } from '@121-service/src/registration/modules/registration-data/repositories/registration-data.scoped.repository';
 import { RegistrationUtilsService } from '@121-service/src/registration/modules/registration-utils/registration-utils.service';
@@ -417,34 +418,49 @@ export class RegistrationsCreationService {
       validateUniqueReferenceId: true,
       validateExistingReferenceId: true,
     };
-    const data = await this.registrationsInputValidator.validateAndCleanInput({
-      registrationInputArray: registrationInputToValidate,
-      programId,
-      userId,
-      typeOfInput: RegistrationValidationInputType.create,
-      validationConfig,
-    });
-    return data;
+    const { validRegistrations, errors } =
+      await this.registrationsInputValidator.validateAndCleanInput({
+        registrationInputArray: registrationInputToValidate,
+        programId,
+        userId,
+        typeOfInput: RegistrationValidationInputType.create,
+        validationConfig,
+      });
+    this.throwIfValidationErrors(errors);
+    return validRegistrations;
   }
 
   private async validateBulkUpdateInput(
     csvArray: any[],
     programId: number,
     userId: number,
-  ): Promise<ValidatedRegistrationInput[]> {
+  ): Promise<void> {
     const validationConfig: ValidationRegistrationConfig = {
       validateExistingReferenceId: false,
       validateUniqueReferenceId: false,
     };
-    const result = await this.registrationsInputValidator.validateAndCleanInput(
-      {
+    const { errors } =
+      await this.registrationsInputValidator.validateAndCleanInput({
         registrationInputArray: csvArray,
         programId,
         userId,
         typeOfInput: RegistrationValidationInputType.bulkUpdate,
         validationConfig,
-      },
-    );
-    return result;
+      });
+    this.throwIfValidationErrors(errors);
+  }
+
+  private throwIfValidationErrors(
+    errors: ValidateRegistrationErrorObject[],
+  ): void {
+    if (errors.length > 0) {
+      throw new HttpException(
+        errors.map(({ index, ...rest }) => ({
+          ...rest,
+          lineNumber: index + 1,
+        })),
+        HttpStatus.BAD_REQUEST,
+      );
+    }
   }
 }

--- a/services/121-service/src/registration/services/registrations-creation.service.ts
+++ b/services/121-service/src/registration/services/registrations-creation.service.ts
@@ -415,9 +415,11 @@ export class RegistrationsCreationService {
     userId: MessageSenderUserId,
   ): Promise<ValidatedRegistrationInput[]> {
     const validationConfig: ValidationRegistrationConfig = {
-      validateUniqueReferenceId: true,
       validateExistingReferenceId: true,
     };
+    this.registrationsInputValidator.validateUniqueReferenceIds(
+      registrationInputToValidate,
+    );
     const { validRegistrations, errors } =
       await this.registrationsInputValidator.validateAndCleanInput({
         registrationInputArray: registrationInputToValidate,
@@ -437,7 +439,6 @@ export class RegistrationsCreationService {
   ): Promise<void> {
     const validationConfig: ValidationRegistrationConfig = {
       validateExistingReferenceId: false,
-      validateUniqueReferenceId: false,
     };
     const { errors } =
       await this.registrationsInputValidator.validateAndCleanInput({

--- a/services/121-service/src/registration/services/registrations.service.ts
+++ b/services/121-service/src/registration/services/registrations.service.ts
@@ -344,52 +344,29 @@ export class RegistrationsService {
       ...updateRegistrationDto.data,
     };
 
-    let validateRegistrationPatchData;
-    try {
-      validateRegistrationPatchData =
-        await this.registrationsInputValidator.validateAndCleanInput({
-          registrationInputArray: [updateDataWithReferenceId],
-          programId,
-          userId,
-          typeOfInput: RegistrationValidationInputType.update,
-          validationConfig,
-        });
-    } catch (error) {
-      if (error instanceof HttpException) {
-        this.processHttpExceptionOnRegistrationUpdate(error);
-      } else {
-        throw error;
-      }
+    const { validRegistrations, errors } =
+      await this.registrationsInputValidator.validateAndCleanInput({
+        registrationInputArray: [updateDataWithReferenceId],
+        programId,
+        userId,
+        typeOfInput: RegistrationValidationInputType.update,
+        validationConfig,
+      });
+
+    if (errors.length > 0) {
+      const errorMessage = errors
+        .map((err) => `${err.column}: ${err.error}`)
+        .join(', ');
+      throw new HttpException(errorMessage, HttpStatus.BAD_REQUEST);
     }
 
     // if all valid, process update
     return await this.updateRegistration({
       programId,
       referenceId,
-      validatedRegistrationInput: validateRegistrationPatchData[0],
+      validatedRegistrationInput: validRegistrations[0],
       reason: updateRegistrationDto.reason,
     });
-  }
-
-  // TODO: Refactor this, it works around the fact that registrationsInputValidator throws Http exception with line numbers and columns names
-  // May be better to solve this in the registrationsInputValidator depending on the type of validation
-  private processHttpExceptionOnRegistrationUpdate(
-    error: HttpException,
-  ): never {
-    if (error.getStatus() === 400) {
-      const errorResponse = error.getResponse();
-      let errorMessage: object | string = '';
-      if (Array.isArray(errorResponse)) {
-        errorMessage = errorResponse
-          .map((err) => `${err.column}: ${err.error}`)
-          .join(', ');
-      } else {
-        errorMessage = errorResponse;
-      }
-      throw new HttpException(errorMessage, HttpStatus.BAD_REQUEST);
-    } else {
-      throw error; // Re-throw the error if it's not an HttpException with status 400
-    }
   }
 
   public async updateRegistration({

--- a/services/121-service/src/registration/services/registrations.service.ts
+++ b/services/121-service/src/registration/services/registrations.service.ts
@@ -336,7 +336,6 @@ export class RegistrationsService {
     userId: number;
   }): Promise<MappedPaginatedRegistrationDto | undefined> {
     const validationConfig: ValidationRegistrationConfig = {
-      validateUniqueReferenceId: false,
       validateExistingReferenceId: false,
     };
     const updateDataWithReferenceId = {

--- a/services/121-service/src/registration/validators/registrations-input-validator.spec.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.spec.ts
@@ -1,4 +1,3 @@
-import { HttpException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -186,7 +185,7 @@ describe('RegistrationsInputValidator', () => {
       },
     ];
 
-    const result = await validator.validateAndCleanInput({
+    const { validRegistrations } = await validator.validateAndCleanInput({
       registrationInputArray: csvArray,
       programId,
       userId,
@@ -197,24 +196,24 @@ describe('RegistrationsInputValidator', () => {
       },
     });
 
-    expect(result).toBeInstanceOf(Array);
-    expect(result.length).toBe(1);
-    expect(result[0]).toHaveProperty(
+    expect(validRegistrations).toBeInstanceOf(Array);
+    expect(validRegistrations.length).toBe(1);
+    expect(validRegistrations[0]).toHaveProperty(
       'referenceId',
       '00dc9451-1273-484c-b2e8-ae21b51a96ab',
     );
-    expect(result[0]).toHaveProperty(
+    expect(validRegistrations[0]).toHaveProperty(
       'programFspConfigurationName',
       Fsps.intersolveVoucherWhatsapp,
     );
-    expect(result[0]).toHaveProperty('paymentAmountMultiplier', 2);
-    expect(result[0]).toHaveProperty(
+    expect(validRegistrations[0]).toHaveProperty('paymentAmountMultiplier', 2);
+    expect(validRegistrations[0]).toHaveProperty(
       'preferredLanguage',
       RegistrationPreferredLanguage.en,
     );
   });
 
-  it('should throw an error for invalid reference ID format', async () => {
+  it('should return errors for invalid reference ID format', async () => {
     const csvArray = [
       {
         referenceId: '!@#$',
@@ -231,8 +230,8 @@ describe('RegistrationsInputValidator', () => {
       },
     ];
 
-    await expect(
-      validator.validateAndCleanInput({
+    const { errors, validRegistrations } =
+      await validator.validateAndCleanInput({
         registrationInputArray: csvArray,
         programId,
         userId,
@@ -241,8 +240,10 @@ describe('RegistrationsInputValidator', () => {
           validateUniqueReferenceId: true,
           validateExistingReferenceId: true,
         },
-      }),
-    ).rejects.toThrow(HttpException);
+      });
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(validRegistrations.length).toBe(0);
   });
 
   it('should report errors for rows missing mandatory fields on import', async () => {
@@ -255,8 +256,8 @@ describe('RegistrationsInputValidator', () => {
     const programId = 1;
     const userId = 1;
 
-    await expect(
-      validator.validateAndCleanInput({
+    const { errors, validRegistrations } =
+      await validator.validateAndCleanInput({
         registrationInputArray: csvArray,
         programId,
         userId,
@@ -265,11 +266,13 @@ describe('RegistrationsInputValidator', () => {
           validateUniqueReferenceId: true,
           validateExistingReferenceId: true,
         },
-      }),
-    ).rejects.toThrow(HttpException);
+      });
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(validRegistrations.length).toBe(0);
   });
 
-  it('should not report errors for rows missing mandatory fields on bulk update', async () => {
+  it('should report errors for rows missing mandatory fields on bulk update', async () => {
     const csvArray = [
       {
         programFspConfigurationName: Fsps.intersolveVoucherWhatsapp,
@@ -277,8 +280,8 @@ describe('RegistrationsInputValidator', () => {
       },
     ];
 
-    await expect(
-      validator.validateAndCleanInput({
+    const { errors, validRegistrations } =
+      await validator.validateAndCleanInput({
         registrationInputArray: csvArray,
         programId,
         userId,
@@ -287,8 +290,10 @@ describe('RegistrationsInputValidator', () => {
           validateExistingReferenceId: false,
           validateUniqueReferenceId: false,
         },
-      }),
-    ).rejects.toThrow(HttpException);
+      });
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(validRegistrations.length).toBe(0);
   });
 
   it('should report errors for a missing phonenumber when it is not allowed', async () => {
@@ -305,26 +310,28 @@ describe('RegistrationsInputValidator', () => {
       },
     ];
 
-    await expect(
-      validator.validateAndCleanInput({
-        registrationInputArray: csvArray,
-        programId,
-        userId,
-        typeOfInput: RegistrationValidationInputType.create,
-        validationConfig: {
-          validateExistingReferenceId: true,
-          validateUniqueReferenceId: true,
-        },
-      }),
-    ).rejects.toHaveProperty('response', [
-      {
-        lineNumber: 1,
-        column: GenericRegistrationAttributes.phoneNumber,
-        value: undefined,
-        error:
-          'PhoneNumber is required when creating a new registration for this program. Set allowEmptyPhoneNumber to true in the program settings to allow empty phone numbers',
+    const { errors } = await validator.validateAndCleanInput({
+      registrationInputArray: csvArray,
+      programId,
+      userId,
+      typeOfInput: RegistrationValidationInputType.create,
+      validationConfig: {
+        validateExistingReferenceId: true,
+        validateUniqueReferenceId: true,
       },
-    ]);
+    });
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        {
+          index: 0,
+          column: GenericRegistrationAttributes.phoneNumber,
+          value: undefined,
+          error:
+            'PhoneNumber is required when creating a new registration for this program. Set allowEmptyPhoneNumber to true in the program settings to allow empty phone numbers',
+        },
+      ]),
+    );
   });
 
   it('should add max payment when its null', async () => {
@@ -334,7 +341,7 @@ describe('RegistrationsInputValidator', () => {
       },
     ];
 
-    const result = await validator.validateAndCleanInput({
+    const { validRegistrations } = await validator.validateAndCleanInput({
       registrationInputArray: csvArray,
       programId,
       userId,
@@ -345,8 +352,8 @@ describe('RegistrationsInputValidator', () => {
       },
     });
 
-    expect(result[0]).toHaveProperty('maxPayments');
-    expect(result[0].maxPayments).toBe(null);
+    expect(validRegistrations[0]).toHaveProperty('maxPayments');
+    expect(validRegistrations[0].maxPayments).toBe(null);
   });
 
   // When columns are left empty in a csv they are read as empty string
@@ -377,7 +384,7 @@ describe('RegistrationsInputValidator', () => {
       },
     ];
 
-    const result = await validator.validateAndCleanInput({
+    const { validRegistrations } = await validator.validateAndCleanInput({
       registrationInputArray: csvArray,
       programId,
       userId,
@@ -404,7 +411,7 @@ describe('RegistrationsInputValidator', () => {
       programFspConfigurationName: 'Excel',
     };
 
-    expect(result[0]).toEqual(expected);
+    expect(validRegistrations[0]).toEqual(expected);
   });
 
   it('should only return the value you try to validate', async () => {
@@ -414,7 +421,7 @@ describe('RegistrationsInputValidator', () => {
         fullName,
       },
     ];
-    const result = await validator.validateAndCleanInput({
+    const { validRegistrations } = await validator.validateAndCleanInput({
       registrationInputArray: csvArray,
       programId,
       userId,
@@ -429,7 +436,7 @@ describe('RegistrationsInputValidator', () => {
         fullName,
       },
     };
-    expect(result[0]).toEqual(expectedResult);
+    expect(validRegistrations[0]).toEqual(expectedResult);
   });
 
   it.each([
@@ -449,9 +456,9 @@ describe('RegistrationsInputValidator', () => {
         },
       ];
 
-      // Act & Assert
-      await expect(
-        validator.validateAndCleanInput({
+      // Act
+      const { errors, validRegistrations } =
+        await validator.validateAndCleanInput({
           registrationInputArray: csvArray,
           programId,
           userId: null,
@@ -460,8 +467,11 @@ describe('RegistrationsInputValidator', () => {
             validateUniqueReferenceId: true,
             validateExistingReferenceId: true,
           },
-        }),
-      ).resolves.not.toThrow();
+        });
+
+      // Assert
+      expect(errors.length).toBe(0);
+      expect(validRegistrations.length).toBe(1);
     },
   );
 });

--- a/services/121-service/src/registration/validators/registrations-input-validator.spec.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.spec.ts
@@ -1,3 +1,4 @@
+import { HttpException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -474,4 +475,76 @@ describe('RegistrationsInputValidator', () => {
       expect(validRegistrations.length).toBe(1);
     },
   );
+
+  it('should throw when the input contains duplicate referenceIds', async () => {
+    const duplicateReferenceId = '00dc9451-1273-484c-b2e8-ae21b51a96ab';
+    const csvArray = [
+      { referenceId: duplicateReferenceId },
+      { referenceId: duplicateReferenceId },
+    ];
+
+    await expect(
+      validator.validateAndCleanInput({
+        registrationInputArray: csvArray,
+        programId,
+        userId,
+        typeOfInput: RegistrationValidationInputType.create,
+        validationConfig: {
+          validateUniqueReferenceId: true,
+          validateExistingReferenceId: false,
+        },
+      }),
+    ).rejects.toThrow(HttpException);
+  });
+
+  it('should stop processing and cap errors at 5000', async () => {
+    const csvArray = [
+      { fullName: 'Alice' }, // valid row, should still appear in validRegistrations
+      ...Array.from({ length: 5001 }, () => ({ house: 'not-a-valid-house' })),
+    ];
+
+    const { errors, validRegistrations } =
+      await validator.validateAndCleanInput({
+        registrationInputArray: csvArray,
+        programId,
+        userId,
+        typeOfInput: RegistrationValidationInputType.update,
+        validationConfig: {
+          validateUniqueReferenceId: false,
+          validateExistingReferenceId: false,
+        },
+      });
+
+    expect(errors.length).toBe(5000);
+    expect(validRegistrations.length).toBe(1);
+  });
+
+  it('should return an error when a referenceId already exists in the database', async () => {
+    const existingReferenceId = '00dc9451-1273-484c-b2e8-ae21b51a96ac';
+    mockRegistrationRepository.findOne = jest
+      .fn()
+      .mockResolvedValue({ referenceId: existingReferenceId });
+
+    const { errors, validRegistrations } =
+      await validator.validateAndCleanInput({
+        registrationInputArray: [{ referenceId: existingReferenceId }],
+        programId,
+        userId,
+        typeOfInput: RegistrationValidationInputType.create,
+        validationConfig: {
+          validateUniqueReferenceId: false,
+          validateExistingReferenceId: true,
+        },
+      });
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          column: GenericRegistrationAttributes.referenceId,
+          error: 'referenceId already exists in database',
+        }),
+      ]),
+    );
+    expect(validRegistrations.length).toBe(0);
+  });
 });

--- a/services/121-service/src/registration/validators/registrations-input-validator.spec.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.spec.ts
@@ -270,7 +270,7 @@ describe('RegistrationsInputValidator', () => {
     expect(validRegistrations.length).toBe(0);
   });
 
-  it('should report errors for rows missing mandatory fields on bulk update', async () => {
+  it('should report errors for rows missing mandatory fields on update', async () => {
     const csvArray = [
       {
         programFspConfigurationName: Fsps.intersolveVoucherWhatsapp,

--- a/services/121-service/src/registration/validators/registrations-input-validator.spec.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.spec.ts
@@ -192,7 +192,6 @@ describe('RegistrationsInputValidator', () => {
       userId,
       typeOfInput: RegistrationValidationInputType.create,
       validationConfig: {
-        validateUniqueReferenceId: true,
         validateExistingReferenceId: true,
       },
     });
@@ -238,7 +237,6 @@ describe('RegistrationsInputValidator', () => {
         userId,
         typeOfInput: RegistrationValidationInputType.create,
         validationConfig: {
-          validateUniqueReferenceId: true,
           validateExistingReferenceId: true,
         },
       });
@@ -264,7 +262,6 @@ describe('RegistrationsInputValidator', () => {
         userId,
         typeOfInput: RegistrationValidationInputType.create,
         validationConfig: {
-          validateUniqueReferenceId: true,
           validateExistingReferenceId: true,
         },
       });
@@ -289,7 +286,6 @@ describe('RegistrationsInputValidator', () => {
         typeOfInput: RegistrationValidationInputType.update,
         validationConfig: {
           validateExistingReferenceId: false,
-          validateUniqueReferenceId: false,
         },
       });
 
@@ -318,7 +314,6 @@ describe('RegistrationsInputValidator', () => {
       typeOfInput: RegistrationValidationInputType.create,
       validationConfig: {
         validateExistingReferenceId: true,
-        validateUniqueReferenceId: true,
       },
     });
 
@@ -349,7 +344,6 @@ describe('RegistrationsInputValidator', () => {
       typeOfInput: RegistrationValidationInputType.update,
       validationConfig: {
         validateExistingReferenceId: true,
-        validateUniqueReferenceId: true,
       },
     });
 
@@ -391,7 +385,6 @@ describe('RegistrationsInputValidator', () => {
       userId,
       typeOfInput: RegistrationValidationInputType.create,
       validationConfig: {
-        validateUniqueReferenceId: true,
         validateExistingReferenceId: true,
       },
     });
@@ -428,7 +421,6 @@ describe('RegistrationsInputValidator', () => {
       userId,
       typeOfInput: RegistrationValidationInputType.update,
       validationConfig: {
-        validateUniqueReferenceId: true,
         validateExistingReferenceId: true,
       },
     });
@@ -465,7 +457,6 @@ describe('RegistrationsInputValidator', () => {
           userId: null,
           typeOfInput: RegistrationValidationInputType.create,
           validationConfig: {
-            validateUniqueReferenceId: true,
             validateExistingReferenceId: true,
           },
         });
@@ -483,18 +474,9 @@ describe('RegistrationsInputValidator', () => {
       { referenceId: duplicateReferenceId },
     ];
 
-    await expect(
-      validator.validateAndCleanInput({
-        registrationInputArray: csvArray,
-        programId,
-        userId,
-        typeOfInput: RegistrationValidationInputType.create,
-        validationConfig: {
-          validateUniqueReferenceId: true,
-          validateExistingReferenceId: false,
-        },
-      }),
-    ).rejects.toThrow(HttpException);
+    expect(() => validator.validateUniqueReferenceIds(csvArray)).toThrow(
+      HttpException,
+    );
   });
 
   it('should stop processing and cap errors at 5000', async () => {
@@ -510,7 +492,6 @@ describe('RegistrationsInputValidator', () => {
         userId,
         typeOfInput: RegistrationValidationInputType.update,
         validationConfig: {
-          validateUniqueReferenceId: false,
           validateExistingReferenceId: false,
         },
       });
@@ -532,7 +513,6 @@ describe('RegistrationsInputValidator', () => {
         userId,
         typeOfInput: RegistrationValidationInputType.create,
         validationConfig: {
-          validateUniqueReferenceId: false,
           validateExistingReferenceId: true,
         },
       });

--- a/services/121-service/src/registration/validators/registrations-input-validator.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.ts
@@ -19,6 +19,7 @@ import { RegistrationValidationInputType } from '@121-service/src/registration/e
 import { ValidationRegistrationConfig } from '@121-service/src/registration/interfaces/validate-registration-config.interface';
 import { ValidateRegistrationErrorObject } from '@121-service/src/registration/interfaces/validate-registration-error-object.interface';
 import { ValidatedRegistrationInput } from '@121-service/src/registration/interfaces/validated-registration-input.interface';
+import { ValidationResult } from '@121-service/src/registration/interfaces/validation-result.interface';
 import { RegistrationsPaginationService } from '@121-service/src/registration/services/registrations-pagination.service';
 import { RegistrationPreferredLanguage } from '@121-service/src/shared/enum/registration-preferred-language.enum';
 import { UserService } from '@121-service/src/user/user.service';
@@ -51,7 +52,7 @@ export class RegistrationsInputValidator {
     userId: MessageSenderUserId;
     typeOfInput: RegistrationValidationInputType;
     validationConfig: ValidationRegistrationConfig;
-  }): Promise<ValidatedRegistrationInput[]> {
+  }): Promise<ValidationResult> {
     // empty map
     let originalRegistrationsMap = new Map<
       string,
@@ -69,7 +70,6 @@ export class RegistrationsInputValidator {
       );
     }
 
-    const errors: ValidateRegistrationErrorObject[] = [];
     const phoneNumberLookupResults: Record<string, string | undefined> = {};
 
     // If the registration was not created by the user we assume a scope that can access anything (like on a new kobo submission) therefore a ''
@@ -94,7 +94,8 @@ export class RegistrationsInputValidator {
       program.languages as unknown as string[],
     );
 
-    const validatedArray: any = [];
+    const validRegistrations: ValidatedRegistrationInput[] = [];
+    const allErrors: ValidateRegistrationErrorObject[] = [];
 
     for (const [i, row] of registrationInputArray.entries()) {
       const originalRegistration = [
@@ -107,6 +108,8 @@ export class RegistrationsInputValidator {
       const validatedRegistrationInput: ValidatedRegistrationInput = {
         data: {},
       };
+
+      const rowErrors: ValidateRegistrationErrorObject[] = [];
 
       /*
        * =============================================================
@@ -124,7 +127,7 @@ export class RegistrationsInputValidator {
           i,
         });
         if (errorObjPaymentAmountMultiplier) {
-          errors.push(errorObjPaymentAmountMultiplier);
+          rowErrors.push(errorObjPaymentAmountMultiplier);
         } else {
           validatedRegistrationInput.paymentAmountMultiplier =
             validatedPaymentAmountMultiplier;
@@ -139,7 +142,7 @@ export class RegistrationsInputValidator {
             i,
           });
         if (errorObjMaxPayments) {
-          errors.push(errorObjMaxPayments);
+          rowErrors.push(errorObjMaxPayments);
         } else {
           validatedRegistrationInput.maxPayments = validatedMaxPayments;
         }
@@ -158,7 +161,7 @@ export class RegistrationsInputValidator {
           typeOfInput,
         });
         if (errorObjScope) {
-          errors.push(errorObjScope);
+          rowErrors.push(errorObjScope);
         } else if (program.enableScope) {
           validatedRegistrationInput.scope = String(
             row[AdditionalAttributes.scope] ?? '',
@@ -176,7 +179,7 @@ export class RegistrationsInputValidator {
         typeOfInput,
       });
       if (errorObjLanguage) {
-        errors.push(errorObjLanguage);
+        rowErrors.push(errorObjLanguage);
       }
       if (preferredLanguage) {
         validatedRegistrationInput.preferredLanguage = preferredLanguage;
@@ -188,7 +191,7 @@ export class RegistrationsInputValidator {
         validationConfig,
       });
       if (errorObjReferenceId) {
-        errors.push(errorObjReferenceId);
+        rowErrors.push(errorObjReferenceId);
       } else if (row.referenceId != null) {
         validatedRegistrationInput.referenceId = row.referenceId as string;
       }
@@ -200,7 +203,7 @@ export class RegistrationsInputValidator {
         typeOfInput,
       });
       if (errorObjValidatePhoneNr) {
-        errors.push(errorObjValidatePhoneNr);
+        rowErrors.push(errorObjValidatePhoneNr);
       } else if (row.phoneNumber !== undefined) {
         validatedRegistrationInput.phoneNumber = row.phoneNumber
           ? String(row.phoneNumber)
@@ -220,7 +223,7 @@ export class RegistrationsInputValidator {
         typeOfInput,
       });
       if (errorObjFspConfig) {
-        errors.push(errorObjFspConfig);
+        rowErrors.push(errorObjFspConfig);
       } else if (
         row[AdditionalAttributes.programFspConfigurationName] as string
       ) {
@@ -237,7 +240,7 @@ export class RegistrationsInputValidator {
           i,
         },
       );
-      errors.push(...errorObjsFspRequiredAttributes);
+      rowErrors.push(...errorObjsFspRequiredAttributes);
 
       /*
        * =============================================
@@ -289,7 +292,7 @@ export class RegistrationsInputValidator {
                   phoneNumberLookupResults,
                 });
               if (errorObj) {
-                errors.push(errorObj);
+                rowErrors.push(errorObj);
               } else if (row[att.name]) {
                 // we can assume here that the original value is a string else it would not have returned an error object
                 phoneNumberLookupResults[row[att.name] as string] = sanitized;
@@ -322,12 +325,12 @@ export class RegistrationsInputValidator {
                 ? optionNames.join(', ')
                 : 'No options available';
             const errorObj = {
-              lineNumber: i + 1,
+              index: i,
               column: att.name,
               value: row[att.name],
               error: `Value '${row[att.name]}' is not in the allowed options: '${optionNamesErrorString}' for attribute '${att.name}'`,
             };
-            errors.push(errorObj);
+            rowErrors.push(errorObj);
 
             return;
           }
@@ -348,7 +351,7 @@ export class RegistrationsInputValidator {
             i,
           });
           if (errorObj && Object.keys(row).includes(att.name)) {
-            errors.push(errorObj);
+            rowErrors.push(errorObj);
           } else if (row[att.name] !== undefined) {
             validatedRegistrationInput.data[att.name] = row[att.name] as
               | string
@@ -359,8 +362,9 @@ export class RegistrationsInputValidator {
       );
 
       // Break the loop and stop processing if file has too many errors
-      if (errors.length >= 5000) {
-        throw new HttpException(errors, HttpStatus.BAD_REQUEST);
+      if (allErrors.length + rowErrors.length >= 5000) {
+        allErrors.push(...rowErrors);
+        return { validRegistrations, errors: allErrors };
       }
 
       const result = await validate(
@@ -374,23 +378,22 @@ export class RegistrationsInputValidator {
         }
 
         const errorObj = {
-          lineNumber: i + 1,
+          index: i,
           column: result[0].property,
           value: result[0].value,
           error,
         };
-        errors.push(errorObj);
+        rowErrors.push(errorObj);
       }
 
-      validatedArray.push(validatedRegistrationInput);
+      if (rowErrors.length > 0) {
+        allErrors.push(...rowErrors);
+      } else {
+        validRegistrations.push(validatedRegistrationInput);
+      }
     }
 
-    // Throw the errors at once
-    if (errors.length > 0) {
-      throw new HttpException(errors, HttpStatus.BAD_REQUEST);
-    }
-
-    return validatedArray;
+    return { validRegistrations, errors: allErrors };
   }
 
   private validateUniqueReferenceIds(
@@ -465,7 +468,7 @@ export class RegistrationsInputValidator {
       )
     ) {
       return {
-        lineNumber: i,
+        index: i,
         value: programFspName,
         column: AdditionalAttributes.programFspConfigurationName,
         error: `FspConfigurationName ${programFspName} not found in program. Allowed values: ${programFspConfigurations
@@ -539,7 +542,7 @@ export class RegistrationsInputValidator {
       )
     ) {
       return {
-        lineNumber: i + 1,
+        index: i,
         column: AdditionalAttributes.preferredLanguage,
         value: preferredLanguage,
         error: `Language error: Allowed values of this program for ${AdditionalAttributes.preferredLanguage}: ${Object.values(
@@ -589,7 +592,7 @@ export class RegistrationsInputValidator {
     });
     if (!correctScope) {
       return {
-        lineNumber: i + 1,
+        index: i,
         column: AdditionalAttributes.scope,
         value: row[AdditionalAttributes.scope],
         error: `User has program scope ${userScope} and does not have access to registration scope ${
@@ -646,7 +649,7 @@ export class RegistrationsInputValidator {
     }
     if (typeof row.referenceId !== 'string') {
       return {
-        lineNumber: i + 1,
+        index: i,
         column: GenericRegistrationAttributes.referenceId,
         value: row.referenceId,
         error: 'referenceId must be a string',
@@ -655,7 +658,7 @@ export class RegistrationsInputValidator {
 
     if (row.referenceId.includes('$')) {
       return {
-        lineNumber: i + 1,
+        index: i,
         column: GenericRegistrationAttributes.referenceId,
         value: row.referenceId,
         error: `${GenericRegistrationAttributes.referenceId} contains a $ character`,
@@ -664,7 +667,7 @@ export class RegistrationsInputValidator {
 
     if (row.referenceId.length < 5 || row.referenceId.length > 200) {
       return {
-        lineNumber: i + 1,
+        index: i,
         column: GenericRegistrationAttributes.referenceId,
         value: row.referenceId,
         error: 'referenceId must be between 5 and 200 characters',
@@ -676,7 +679,7 @@ export class RegistrationsInputValidator {
       });
       if (registration) {
         return {
-          lineNumber: i + 1,
+          index: i,
           column: GenericRegistrationAttributes.referenceId,
           value: row.referenceId,
           error: 'referenceId already exists in database',
@@ -705,7 +708,7 @@ export class RegistrationsInputValidator {
       !row.phoneNumber
     ) {
       return {
-        lineNumber: i + 1,
+        index: i,
         column: GenericRegistrationAttributes.phoneNumber,
         value: undefined,
         error:
@@ -719,7 +722,7 @@ export class RegistrationsInputValidator {
     ) {
       // on an update phonenumber can be empty if it is not being updated
       return {
-        lineNumber: i + 1,
+        index: i,
         column: GenericRegistrationAttributes.phoneNumber,
         value: row.phoneNumber,
         error:
@@ -749,7 +752,7 @@ export class RegistrationsInputValidator {
     }
     if (!sanitized && !!value) {
       const errorObj: ValidateRegistrationErrorObject = {
-        lineNumber: i + 1,
+        index: i,
         column: 'phoneNumber',
         value,
         error:
@@ -794,7 +797,7 @@ export class RegistrationsInputValidator {
       if (Object.prototype.hasOwnProperty.call(row, attribute)) {
         if (row[attribute] == null || row[attribute] === '') {
           errors.push({
-            lineNumber: i + 1,
+            index: i,
             column: attribute,
             value: row[attribute],
             error: `Cannot update/set ${attribute} with a nullable value as it is required for the FSP: ${relevantFspConfigName}`,
@@ -812,7 +815,7 @@ export class RegistrationsInputValidator {
           !this.isRequiredAttributeInObject(attribute, originalRegistration)
         ) {
           errors.push({
-            lineNumber: i + 1,
+            index: i,
             column: attribute,
             value: undefined,
             error: `Cannot update '${attribute}' is required for the FSP: '${relevantFspConfigName}'`,
@@ -912,7 +915,7 @@ export class RegistrationsInputValidator {
     }
     if (!isValid) {
       return {
-        lineNumber: i + 1,
+        index: i,
         column: attribute,
         value: Array.isArray(value) ? value.toString() : value,
         error: message
@@ -967,7 +970,7 @@ export class RegistrationsInputValidator {
     if (programPaymentAmountMultiplierFormula && value != null) {
       return {
         errorOjb: {
-          lineNumber: i + 1,
+          index: i,
           column: GenericRegistrationAttributes.paymentAmountMultiplier,
           value,
           error:
@@ -984,7 +987,7 @@ export class RegistrationsInputValidator {
     if (isNaN(+value) || +value <= 0) {
       return {
         errorOjb: {
-          lineNumber: i + 1,
+          index: i,
           column: GenericRegistrationAttributes.paymentAmountMultiplier,
           value,
           error: 'this field must be a positive number',
@@ -1014,7 +1017,7 @@ export class RegistrationsInputValidator {
     if (isNaN(+value) || +value <= 0) {
       return {
         errorObj: {
-          lineNumber: i + 1,
+          index: i,
           column: GenericRegistrationAttributes.maxPayments,
           value,
           error: 'MaxPayments must be a positive number or left empty',
@@ -1024,7 +1027,7 @@ export class RegistrationsInputValidator {
     if (originalRegistration && +value < originalRegistration.paymentCount) {
       return {
         errorObj: {
-          lineNumber: i + 1,
+          index: i,
           column: GenericRegistrationAttributes.maxPayments,
           value,
           error: `MaxPayments cannot be lower than the current paymentCount (${originalRegistration.paymentCount})`,

--- a/services/121-service/src/registration/validators/registrations-input-validator.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.ts
@@ -81,6 +81,8 @@ export class RegistrationsInputValidator {
       );
     }
 
+    // Always throws rather than returning errors: duplicate referenceIds in a
+    // single import file is a structural error, not a per-row validation failure.
     if (validationConfig.validateUniqueReferenceId) {
       this.validateUniqueReferenceIds(registrationInputArray);
     }

--- a/services/121-service/src/registration/validators/registrations-input-validator.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.ts
@@ -81,12 +81,6 @@ export class RegistrationsInputValidator {
       );
     }
 
-    // Always throws rather than returning errors: duplicate referenceIds in a
-    // single import file is a structural error, not a per-row validation failure.
-    if (validationConfig.validateUniqueReferenceId) {
-      this.validateUniqueReferenceIds(registrationInputArray);
-    }
-
     const program = await this.programRepository.findOneOrFail({
       where: { id: Equal(programId) },
       relations: ['programFspConfigurations', 'programRegistrationAttributes'],
@@ -398,7 +392,7 @@ export class RegistrationsInputValidator {
     return { validRegistrations, errors: allErrors };
   }
 
-  private validateUniqueReferenceIds(
+  public validateUniqueReferenceIds(
     csvArray: Record<string, InputAttributeType>[],
   ): void {
     const allReferenceIds = csvArray
@@ -430,9 +424,10 @@ export class RegistrationsInputValidator {
         languageAbbr.substring(0, 2),
       );
       if (!fullNameLanguage) {
-        throw new HttpException(
+        // We throw an error here because we do not expect this to happen as cash-im team is at this point responsible for setting the program languages
+        // We don't want to throw a bad request because this would only confuse our users, while an error triggers a monitoring error to the dev team
+        throw new Error(
           `Language ${languageAbbr} not found in createLanguageMapping`,
-          HttpStatus.BAD_REQUEST,
         );
       }
       const cleanedFullNameLanguage = fullNameLanguage.trim().toLowerCase();


### PR DESCRIPTION
[AB#41596](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/41596)

## Describe your changes

What is done: 
## What is done

Refactor incoming registration validation logic.

- `validateAndCleanInput` no longer throws on validation errors. Instead it returns `{ validRegistrations, errors }` via a new `ValidationResult` interface.
- Callers (`validateImportRegistrationsInput`, `validateBulkUpdateInput`, `validateInputAndUpdateRegistration`) now inspect the returned `errors` array and throw an `HttpException` themselves when appropriate, converting `index` back to `lineNumber` for CSV-based flows.
- The `processHttpExceptionOnRegistrationUpdate` workaround in `registrations.service.ts` has been removed since the caller can now handle errors directly without try/catch.
- The error object uses `index` (0-based) instead of `lineNumber` (1-based). Index is a more generic term that can be used by the Kobo service to determine which registration the errors belong to, since the Kobo flow needs errors grouped by submission.

## Why is this needed

In the Kobo flow, errors are handled differently than when importing registrations from a CSV file:

- **CSV import**: When there are one or more errors, none of the data is imported. The user can fix the CSV and re-upload.
- **Kobo**: Submissions with errors are not imported, but other submissions without errors are still imported.

The reason for this difference is that a CSV file is easy to edit and re-upload. Already submitted Kobo submissions are not easy to edit. For those, our support team would prepare a CSV to import them outside of Kobo, or redo the submissions.

This refactor makes that possible by returning valid registrations separately from errors, so the Kobo caller can import the valid ones and report the errors without blocking the entire batch.

<img width="2276" height="1316" alt="image" src="https://github.com/user-attachments/assets/fee6f55b-4b9b-4049-a363-d16515cf0bad" />



## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->