### PR TITLE
Kobo import submissions granular results

### DIFF
--- a/services/121-service/src/kobo/dtos/import-existing-submissions-result.dto.ts
+++ b/services/121-service/src/kobo/dtos/import-existing-submissions-result.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class SubmissionValidationError {
+class SubmissionValidationError {
   @ApiProperty({
     description: 'The reference ID of the submission that failed validation',
     example: 'abc-123-def',

--- a/services/121-service/src/kobo/dtos/import-existing-submissions-result.dto.ts
+++ b/services/121-service/src/kobo/dtos/import-existing-submissions-result.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export interface SubmissionValidationError {
+  readonly column: string;
+  readonly error: string;
+}
+
+export class ImportExistingSubmissionsResultDto {
+  @ApiProperty({
+    description: 'Total number of submissions on the Kobo form',
+  })
+  public numberOfSubmissionsOnForm: number;
+
+  @ApiProperty({
+    description: 'Number of submissions successfully imported',
+  })
+  public numberOfSubmissionsImported: number;
+
+  @ApiProperty({
+    description:
+      'Number of submissions skipped because they were already imported',
+  })
+  public numberOfSubmissionsSkipped: number;
+
+  @ApiProperty({
+    description: 'Number of submissions that failed validation',
+  })
+  public numberOfSubmissionsFailed: number;
+
+  @ApiProperty({
+    description:
+      'Validation errors grouped by submission identifier (Kobo UUID). Each key is a submission UUID, and the value is an array of validation errors for that submission.',
+    example: {
+      'abc-123-def': [
+        { column: 'phoneNumber', error: 'Value is not valid' },
+        { column: 'fullName', error: 'Value is required' },
+      ],
+    },
+  })
+  public validationErrorsPerSubmission: Record<
+    string,
+    SubmissionValidationError[]
+  >;
+}

--- a/services/121-service/src/kobo/dtos/import-existing-submissions-result.dto.ts
+++ b/services/121-service/src/kobo/dtos/import-existing-submissions-result.dto.ts
@@ -1,8 +1,23 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export interface SubmissionValidationError {
-  readonly column: string;
-  readonly error: string;
+export class SubmissionValidationError {
+  @ApiProperty({
+    description: 'The reference ID of the submission that failed validation',
+    example: 'abc-123-def',
+  })
+  public readonly referenceId: string;
+
+  @ApiProperty({
+    description: 'The column that failed validation',
+    example: 'phoneNumber',
+  })
+  public readonly column: string;
+
+  @ApiProperty({
+    description: 'The error message describing the validation failure',
+    example: 'Value is not valid',
+  })
+  public readonly error: string;
 }
 
 export class ImportExistingSubmissionsResultDto {
@@ -28,17 +43,9 @@ export class ImportExistingSubmissionsResultDto {
   public numberOfSubmissionsFailed: number;
 
   @ApiProperty({
+    type: [SubmissionValidationError],
     description:
-      'Validation errors grouped by submission identifier (Kobo UUID). Each key is a submission UUID, and the value is an array of validation errors for that submission.',
-    example: {
-      'abc-123-def': [
-        { column: 'phoneNumber', error: 'Value is not valid' },
-        { column: 'fullName', error: 'Value is required' },
-      ],
-    },
+      'Flat list of validation errors. Each entry includes the submission referenceId, the column that failed, and the error message.',
   })
-  public validationErrorsPerSubmission: Record<
-    string,
-    SubmissionValidationError[]
-  >;
+  public validationErrors: SubmissionValidationError[];
 }

--- a/services/121-service/src/kobo/dtos/import-existing-submissions-result.dto.ts
+++ b/services/121-service/src/kobo/dtos/import-existing-submissions-result.dto.ts
@@ -5,7 +5,7 @@ class SubmissionValidationError {
     description: 'The reference ID of the submission that failed validation',
     example: 'abc-123-def',
   })
-  public readonly referenceId: string;
+  public readonly referenceId?: string;
 
   @ApiProperty({
     description: 'The column that failed validation',

--- a/services/121-service/src/kobo/dtos/import-existing-submissions-result.dto.ts
+++ b/services/121-service/src/kobo/dtos/import-existing-submissions-result.dto.ts
@@ -5,7 +5,7 @@ class SubmissionValidationError {
     description: 'The reference ID of the submission that failed validation',
     example: 'abc-123-def',
   })
-  public readonly referenceId?: string;
+  public readonly referenceId: string;
 
   @ApiProperty({
     description: 'The column that failed validation',

--- a/services/121-service/src/kobo/interfaces/kobo-registration-input.interface.ts
+++ b/services/121-service/src/kobo/interfaces/kobo-registration-input.interface.ts
@@ -1,0 +1,11 @@
+/**
+ * Represents registration data produced by mapping a Kobo submission.
+ * Used as input for validation and import of Kobo submissions into registrations.
+ *
+ * `referenceId` is always defined because {@link KoboSubmissionMapper.mapSubmissionToRegistrationData}
+ * initialises it from `koboSubmission._uuid`, which is a required field on every Kobo submission.
+ */
+export type KoboRegistrationInput = { referenceId: string } & Record<
+  string,
+  string | boolean | number
+>;

--- a/services/121-service/src/kobo/kobo.controller.ts
+++ b/services/121-service/src/kobo/kobo.controller.ts
@@ -30,13 +30,13 @@ import { AuthenticatedUser } from '@121-service/src/guards/authenticated-user.de
 import { AuthenticatedUserGuard } from '@121-service/src/guards/authenticated-user.guard';
 import { NoUserAuthenticationEndpoint } from '@121-service/src/guards/no-user-authentication.decorator';
 import { CreateKoboDto } from '@121-service/src/kobo/dtos/create-kobo.dto';
+import { ImportExistingSubmissionsResultDto } from '@121-service/src/kobo/dtos/import-existing-submissions-result.dto';
 import { KoboIntegrationResultDto } from '@121-service/src/kobo/dtos/kobo-integration-result.dto';
 import { KoboResponseDto } from '@121-service/src/kobo/dtos/kobo-response.dto';
 import { KoboWebhookIncomingSubmission } from '@121-service/src/kobo/dtos/kobo-webhook-incoming-submission.dto';
 import { KoboWebhookBasicAuthGuard } from '@121-service/src/kobo/guards/kobo-webhook-basic-auth.guard';
 import { KoboService } from '@121-service/src/kobo/services/kobo.service';
 import { KoboSubmissionService } from '@121-service/src/kobo/services/kobo-submission.service';
-import { ImportResult } from '@121-service/src/registration/dto/bulk-import.dto';
 import { MAX_IMPORT_RECORDS } from '@121-service/src/registration/services/registrations-creation.service';
 import { ScopedUserRequest } from '@121-service/src/shared/scoped-user-request';
 import { RequestHelper } from '@121-service/src/utils/request-helper/request-helper.helper';
@@ -184,7 +184,7 @@ export class KoboController {
     status: HttpStatus.OK,
     description:
       'New submissions have been successfully imported as registrations',
-    type: ImportResult,
+    type: ImportExistingSubmissionsResultDto,
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
@@ -200,7 +200,7 @@ export class KoboController {
     @Param('programId', ParseIntPipe)
     programId: number,
     @Req() req: ScopedUserRequest,
-  ): Promise<ImportResult> {
+  ): Promise<ImportExistingSubmissionsResultDto> {
     const userId = RequestHelper.getUserId(req);
     return this.koboSubmissionService.importNewSubmissions({
       programId,

--- a/services/121-service/src/kobo/kobo.controller.ts
+++ b/services/121-service/src/kobo/kobo.controller.ts
@@ -202,7 +202,7 @@ export class KoboController {
     @Req() req: ScopedUserRequest,
   ): Promise<ImportExistingSubmissionsResultDto> {
     const userId = RequestHelper.getUserId(req);
-    return this.koboSubmissionService.importNewSubmissions({
+    return this.koboSubmissionService.importExistingSubmissions({
       programId,
       userId,
     });

--- a/services/121-service/src/kobo/kobo.controller.ts
+++ b/services/121-service/src/kobo/kobo.controller.ts
@@ -196,7 +196,7 @@ export class KoboController {
       'Too many new submissions to import. Use CSV import and split the data into smaller batches.',
   })
   @Patch('programs/:programId/kobo/submissions')
-  public async importNewKoboSubmissions(
+  public async importExistingSubmissions(
     @Param('programId', ParseIntPipe)
     programId: number,
     @Req() req: ScopedUserRequest,

--- a/services/121-service/src/kobo/kobo.controller.ts
+++ b/services/121-service/src/kobo/kobo.controller.ts
@@ -170,8 +170,8 @@ export class KoboController {
 
   @AuthenticatedUser({ isAdmin: true })
   @ApiOperation({
-    summary: 'Import new Kobo submissions as registrations',
-    description: `Fetches all submissions from the linked Kobo form, filters out submissions that have already been imported (by matching Kobo submission UUID against registration referenceId), and imports the remaining new submissions as registrations. Returns an error if the total number of submissions on the form exceeds the maximum fetch limit (${MAX_IMPORT_RECORDS}).`,
+    summary: 'Import existing Kobo submissions as registrations',
+    description: `Fetches all submissions from the linked Kobo form, filters out submissions that have already been imported (by matching Kobo submission UUID against registration referenceId), and imports the remaining existing submissions as registrations. Returns an error if the total number of submissions on the form exceeds the maximum fetch limit (${MAX_IMPORT_RECORDS}).`,
   })
   @ApiParam({
     name: 'programId',
@@ -183,7 +183,7 @@ export class KoboController {
   @ApiResponse({
     status: HttpStatus.OK,
     description:
-      'New submissions have been successfully imported as registrations',
+      'Existing submissions have been successfully imported as registrations',
     type: ImportExistingSubmissionsResultDto,
   })
   @ApiResponse({
@@ -193,7 +193,7 @@ export class KoboController {
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description:
-      'Too many new submissions to import. Use CSV import and split the data into smaller batches.',
+      'Too many submissions to import. Use CSV import and split the data into smaller batches.',
   })
   @Patch('programs/:programId/kobo/submissions')
   public async importExistingSubmissions(

--- a/services/121-service/src/kobo/mappers/kobo-submission.mapper.ts
+++ b/services/121-service/src/kobo/mappers/kobo-submission.mapper.ts
@@ -1,5 +1,6 @@
 import { KoboAttachmentDto } from '@121-service/src/kobo/dtos/kobo-api/kobo-attachment.dto';
 import { KoboSubmissionDto } from '@121-service/src/kobo/dtos/kobo-api/kobo-submission.dto';
+import { KoboRegistrationInput } from '@121-service/src/kobo/interfaces/kobo-registration-input.interface';
 import { KoboFormDefinitionMapper } from '@121-service/src/kobo/mappers/kobo-form-definition.mapper';
 import { fspQuestionName } from '@121-service/src/kobo/services/kobo.service';
 import { RegistrationViewEntity } from '@121-service/src/registration/entities/registration-view.entity';
@@ -9,8 +10,10 @@ export class KoboSubmissionMapper {
     koboSubmission,
   }: {
     koboSubmission: KoboSubmissionDto;
-  }): Record<string, string | boolean | number> {
-    const registrationData: Record<string, string | boolean | number> = {};
+  }): KoboRegistrationInput {
+    const registrationData: KoboRegistrationInput = {
+      referenceId: koboSubmission._uuid,
+    };
     const attachments = koboSubmission._attachments ?? [];
 
     Object.entries(koboSubmission).forEach(([key, value]) => {

--- a/services/121-service/src/kobo/services/kobo-api.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo-api.service.spec.ts
@@ -493,6 +493,7 @@ describe('KoboApiService', () => {
         token: mockToken,
         assetUid: mockAssetUid,
         baseUrl: mockBaseUrl,
+        limit: 1000,
       });
 
       // Assert
@@ -530,6 +531,7 @@ describe('KoboApiService', () => {
         token: mockToken,
         assetUid: mockAssetUid,
         baseUrl: mockBaseUrl,
+        limit: 1000,
       });
 
       // Assert

--- a/services/121-service/src/kobo/services/kobo-api.service.ts
+++ b/services/121-service/src/kobo/services/kobo-api.service.ts
@@ -7,7 +7,6 @@ import { KoboAssetDto } from '@121-service/src/kobo/dtos/kobo-api/kobo-asset.dto
 import { KoboAssetResponseDto } from '@121-service/src/kobo/dtos/kobo-api/kobo-asset-response.dto';
 import { KoboSubmissionDto } from '@121-service/src/kobo/dtos/kobo-api/kobo-submission.dto';
 import { KoboSubmissionsResponseDto } from '@121-service/src/kobo/dtos/kobo-api/kobo-submissions-response.dto';
-import { MAX_IMPORT_RECORDS } from '@121-service/src/registration/services/registrations-creation.service';
 import { CustomHttpService } from '@121-service/src/shared/services/custom-http.service';
 
 @Injectable()
@@ -202,15 +201,17 @@ export class KoboApiService {
     token,
     assetUid,
     baseUrl,
+    limit,
   }: {
     token: string;
     assetUid: string;
     baseUrl: string;
+    limit: number;
   }): Promise<{ count: number; submissions: KoboSubmissionDto[] }> {
     const apiUrl = new URL(
       joinURL(baseUrl, 'api/v2/assets', assetUid, 'data/'),
     );
-    apiUrl.searchParams.set('limit', String(MAX_IMPORT_RECORDS));
+    apiUrl.searchParams.set('limit', String(limit));
 
     const headers = new Headers({ Authorization: `Token ${token}` });
 
@@ -220,7 +221,7 @@ export class KoboApiService {
 
     if (this.isValidKoboResponse<KoboSubmissionsResponseDto>(response)) {
       return {
-        count: response.data.count,
+        count: response.data.count, // Represents the total number of submissions on the form, not just the count of returned submissions
         submissions: response.data.results,
       };
     }

--- a/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
@@ -498,7 +498,6 @@ describe('KoboSubmissionService', () => {
         userId: 42,
         typeOfInput: 'create',
         validationConfig: {
-          validateUniqueReferenceId: true,
           validateExistingReferenceId: true,
         },
       });

--- a/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
@@ -348,7 +348,7 @@ describe('KoboSubmissionService', () => {
           "numberOfSubmissionsImported": 1,
           "numberOfSubmissionsOnForm": 2,
           "numberOfSubmissionsSkipped": 1,
-          "validationErrorsPerSubmission": {},
+          "validationErrors": [],
         }
       `);
     });
@@ -504,7 +504,7 @@ describe('KoboSubmissionService', () => {
       });
     });
 
-    it('should populate validationErrorsPerSubmission when a submission fails validation', async () => {
+    it('should populate validationErrors when a submission fails validation', async () => {
       // Arrange
       koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
       koboApiService.getSubmissionsUpToLimit.mockResolvedValue({
@@ -517,6 +517,7 @@ describe('KoboSubmissionService', () => {
         errors: [
           {
             index: 0,
+            referenceId: successSubmissionUuid,
             column: 'programFspConfigurationName',
             error: 'FspConfigurationName Invalid-FSP not found in program.',
             value: 'Invalid-FSP',
@@ -534,14 +535,13 @@ describe('KoboSubmissionService', () => {
       });
 
       // Assert
-      expect(result.validationErrorsPerSubmission).toEqual({
-        [successSubmissionUuid]: [
-          {
-            column: 'programFspConfigurationName',
-            error: 'FspConfigurationName Invalid-FSP not found in program.',
-          },
-        ],
-      });
+      expect(result.validationErrors).toEqual([
+        {
+          referenceId: successSubmissionUuid,
+          column: 'programFspConfigurationName',
+          error: 'FspConfigurationName Invalid-FSP not found in program.',
+        },
+      ]);
     });
 
     it('should exclude failed submissions from numberOfSubmissionsImported and count them in numberOfSubmissionsFailed', async () => {
@@ -557,6 +557,7 @@ describe('KoboSubmissionService', () => {
         errors: [
           {
             index: 0,
+            referenceId: successSubmissionUuid,
             column: 'programFspConfigurationName',
             error: 'FspConfigurationName Invalid-FSP not found in program.',
             value: 'Invalid-FSP',

--- a/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
@@ -12,6 +12,7 @@ import { KoboSubmissionService } from '@121-service/src/kobo/services/kobo-submi
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { RegistrationsCreationService } from '@121-service/src/registration/services/registrations-creation.service';
+import { RegistrationsInputValidator } from '@121-service/src/registration/validators/registrations-input-validator';
 
 import '@121-service/src/utils/test-helpers/matchers/httpExceptionMatcher';
 
@@ -21,6 +22,7 @@ describe('KoboSubmissionService', () => {
   let koboApiService: jest.Mocked<KoboApiService>;
   let koboService: jest.Mocked<KoboService>;
   let registrationsCreationService: jest.Mocked<RegistrationsCreationService>;
+  let registrationsInputValidator: jest.Mocked<RegistrationsInputValidator>;
   let registrationRepository: jest.Mocked<Repository<RegistrationEntity>>;
 
   const successSubmissionUuid = 'success-submission-uuid';
@@ -101,6 +103,13 @@ describe('KoboSubmissionService', () => {
           provide: RegistrationsCreationService,
           useValue: {
             importRegistrations: jest.fn(),
+            importValidatedRegistrations: jest.fn(),
+          },
+        },
+        {
+          provide: RegistrationsInputValidator,
+          useValue: {
+            validateAndCleanInput: jest.fn(),
           },
         },
         {
@@ -117,6 +126,7 @@ describe('KoboSubmissionService', () => {
     koboApiService = module.get(KoboApiService);
     koboService = module.get(KoboService);
     registrationsCreationService = module.get(RegistrationsCreationService);
+    registrationsInputValidator = module.get(RegistrationsInputValidator);
     registrationRepository = module.get(getRepositoryToken(RegistrationEntity));
   });
 
@@ -315,9 +325,15 @@ describe('KoboSubmissionService', () => {
       registrationRepository.find.mockResolvedValue([
         { referenceId: successSubmissionUuid } as RegistrationEntity,
       ]);
-      registrationsCreationService.importRegistrations.mockResolvedValue({
-        aggregateImportResult: { countImported: 1 },
+      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
+        validRegistrations: [],
+        errors: [],
       });
+      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
+        {
+          aggregateImportResult: { countImported: 1 },
+        },
+      );
 
       // Act
       const result = await service.importNewSubmissions({
@@ -328,9 +344,11 @@ describe('KoboSubmissionService', () => {
       // Assert
       expect(result).toMatchInlineSnapshot(`
         {
-          "aggregateImportResult": {
-            "countImported": 1,
-          },
+          "numberOfSubmissionsFailed": 0,
+          "numberOfSubmissionsImported": 1,
+          "numberOfSubmissionsOnForm": 2,
+          "numberOfSubmissionsSkipped": 1,
+          "validationErrorsPerSubmission": {},
         }
       `);
     });
@@ -396,9 +414,15 @@ describe('KoboSubmissionService', () => {
         versionId: newerVersionId,
       });
       koboService.validateFormAndUpdateProgram.mockResolvedValue(undefined);
-      registrationsCreationService.importRegistrations.mockResolvedValue({
-        aggregateImportResult: { countImported: 1 },
+      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
+        validRegistrations: [],
+        errors: [],
       });
+      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
+        {
+          aggregateImportResult: { countImported: 1 },
+        },
+      );
 
       // Act
       await service.importNewSubmissions({ programId: 1, userId: 42 });
@@ -422,9 +446,15 @@ describe('KoboSubmissionService', () => {
         submissions: [mockSubmission], // __version__: 'v1' matches stored versionId: 'v1'
       });
       registrationRepository.find.mockResolvedValue([]);
-      registrationsCreationService.importRegistrations.mockResolvedValue({
-        aggregateImportResult: { countImported: 0 },
+      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
+        validRegistrations: [],
+        errors: [],
       });
+      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
+        {
+          aggregateImportResult: { countImported: 0 },
+        },
+      );
 
       // Act
       await service.importNewSubmissions({ programId: 1, userId: 42 });
@@ -446,21 +476,107 @@ describe('KoboSubmissionService', () => {
         { referenceId: successSubmissionUuid } as RegistrationEntity,
         { referenceId: 'new-submission-uuid' } as RegistrationEntity,
       ]);
-      registrationsCreationService.importRegistrations.mockResolvedValue({
-        aggregateImportResult: { countImported: 0 },
+      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
+        validRegistrations: [],
+        errors: [],
       });
+      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
+        {
+          aggregateImportResult: { countImported: 0 },
+        },
+      );
 
       // Act
       await service.importNewSubmissions({ programId: 1, userId: 42 });
 
       // Assert
       expect(
-        registrationsCreationService.importRegistrations,
+        registrationsInputValidator.validateAndCleanInput,
       ).toHaveBeenCalledWith({
-        inputRegistrations: [],
-        program: mockProgram,
+        registrationInputArray: [],
+        programId: mockProgram.id,
+        userId: 42,
+        typeOfInput: 'create',
+        validationConfig: {
+          validateUniqueReferenceId: true,
+          validateExistingReferenceId: true,
+        },
+      });
+    });
+
+    it('should populate validationErrorsPerSubmission when a submission fails validation', async () => {
+      // Arrange
+      koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
+      koboApiService.getSubmissionsUpToLimit.mockResolvedValue({
+        count: 1,
+        submissions: [mockSubmission],
+      });
+      registrationRepository.find.mockResolvedValue([]);
+      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
+        validRegistrations: [],
+        errors: [
+          {
+            index: 0,
+            column: 'programFspConfigurationName',
+            error: 'FspConfigurationName Invalid-FSP not found in program.',
+            value: 'Invalid-FSP',
+          },
+        ],
+      });
+      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
+        { aggregateImportResult: { countImported: 0 } },
+      );
+
+      // Act
+      const result = await service.importNewSubmissions({
+        programId: 1,
         userId: 42,
       });
+
+      // Assert
+      expect(result.validationErrorsPerSubmission).toEqual({
+        [successSubmissionUuid]: [
+          {
+            column: 'programFspConfigurationName',
+            error: 'FspConfigurationName Invalid-FSP not found in program.',
+          },
+        ],
+      });
+    });
+
+    it('should exclude failed submissions from numberOfSubmissionsImported and count them in numberOfSubmissionsFailed', async () => {
+      // Arrange
+      koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
+      koboApiService.getSubmissionsUpToLimit.mockResolvedValue({
+        count: 2,
+        submissions: [mockSubmission, mockSubmission2],
+      });
+      registrationRepository.find.mockResolvedValue([]);
+      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
+        validRegistrations: [],
+        errors: [
+          {
+            index: 0,
+            column: 'programFspConfigurationName',
+            error: 'FspConfigurationName Invalid-FSP not found in program.',
+            value: 'Invalid-FSP',
+          },
+        ],
+      });
+      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
+        { aggregateImportResult: { countImported: 1 } },
+      );
+
+      // Act
+      const result = await service.importNewSubmissions({
+        programId: 1,
+        userId: 42,
+      });
+
+      // Assert
+      expect(result.numberOfSubmissionsImported).toBe(1);
+      expect(result.numberOfSubmissionsFailed).toBe(1);
+      expect(result.numberOfSubmissionsOnForm).toBe(2);
     });
   });
 });

--- a/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
@@ -578,5 +578,34 @@ describe('KoboSubmissionService', () => {
       expect(result.numberOfSubmissionsFailed).toBe(1);
       expect(result.numberOfSubmissionsOnForm).toBe(2);
     });
+
+    it('should throw when a validation error has no referenceId', async () => {
+      // Arrange
+      koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
+      koboApiService.getSubmissionsUpToLimit.mockResolvedValue({
+        count: 1,
+        submissions: [mockSubmission],
+      });
+      registrationRepository.find.mockResolvedValue([]);
+      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
+        validRegistrations: [],
+        errors: [
+          {
+            index: 0,
+            referenceId: undefined,
+            column: 'phoneNumber',
+            error: 'Value is not valid',
+            value: 'invalid',
+          },
+        ],
+      });
+
+      // Act & Assert
+      await expect(
+        service.importNewSubmissions({ programId: 1, userId: 42 }),
+      ).rejects.toThrow(
+        "Expected referenceId on all Kobo validation errors, but column 'phoneNumber' had none",
+      );
+    });
   });
 });

--- a/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
@@ -305,7 +305,7 @@ describe('KoboSubmissionService', () => {
     });
   });
 
-  describe('importNewSubmissions', () => {
+  describe('import existing submissions', () => {
     const mockSubmission2 = {
       ...mockSubmission,
       _id: 2,
@@ -336,7 +336,7 @@ describe('KoboSubmissionService', () => {
       );
 
       // Act
-      const result = await service.importNewSubmissions({
+      const result = await service.importExistingSubmissions({
         programId: 1,
         userId: 42,
       });
@@ -360,7 +360,7 @@ describe('KoboSubmissionService', () => {
       // Act
       let error: any;
       try {
-        await service.importNewSubmissions({ programId: 1, userId: 42 });
+        await service.importExistingSubmissions({ programId: 1, userId: 42 });
       } catch (e) {
         error = e;
       }
@@ -384,7 +384,7 @@ describe('KoboSubmissionService', () => {
       // Act
       let error: any;
       try {
-        await service.importNewSubmissions({ programId: 1, userId: 42 });
+        await service.importExistingSubmissions({ programId: 1, userId: 42 });
       } catch (e) {
         error = e;
       }
@@ -425,7 +425,7 @@ describe('KoboSubmissionService', () => {
       );
 
       // Act
-      await service.importNewSubmissions({ programId: 1, userId: 42 });
+      await service.importExistingSubmissions({ programId: 1, userId: 42 });
 
       // Assert
       expect(koboService.validateFormAndUpdateProgram).toHaveBeenCalledWith({
@@ -457,7 +457,7 @@ describe('KoboSubmissionService', () => {
       );
 
       // Act
-      await service.importNewSubmissions({ programId: 1, userId: 42 });
+      await service.importExistingSubmissions({ programId: 1, userId: 42 });
 
       // Assert
       expect(koboService.getFormDefinitionOrThrow).not.toHaveBeenCalled();
@@ -487,7 +487,7 @@ describe('KoboSubmissionService', () => {
       );
 
       // Act
-      await service.importNewSubmissions({ programId: 1, userId: 42 });
+      await service.importExistingSubmissions({ programId: 1, userId: 42 });
 
       // Assert
       expect(
@@ -528,7 +528,7 @@ describe('KoboSubmissionService', () => {
       );
 
       // Act
-      const result = await service.importNewSubmissions({
+      const result = await service.importExistingSubmissions({
         programId: 1,
         userId: 42,
       });
@@ -568,7 +568,7 @@ describe('KoboSubmissionService', () => {
       );
 
       // Act
-      const result = await service.importNewSubmissions({
+      const result = await service.importExistingSubmissions({
         programId: 1,
         userId: 42,
       });
@@ -602,7 +602,7 @@ describe('KoboSubmissionService', () => {
 
       // Act & Assert
       await expect(
-        service.importNewSubmissions({ programId: 1, userId: 42 }),
+        service.importExistingSubmissions({ programId: 1, userId: 42 }),
       ).rejects.toThrow(
         "Expected referenceId on all Kobo validation errors, but column 'phoneNumber' had none",
       );

--- a/services/121-service/src/kobo/services/kobo-submission.service.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.ts
@@ -3,17 +3,24 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Equal, In, Repository } from 'typeorm';
 
 import { IS_DEVELOPMENT } from '@121-service/src/config';
+import {
+  ImportExistingSubmissionsResultDto,
+  SubmissionValidationError,
+} from '@121-service/src/kobo/dtos/import-existing-submissions-result.dto';
 import { KoboWebhookIncomingSubmission } from '@121-service/src/kobo/dtos/kobo-webhook-incoming-submission.dto';
 import { KoboEntity } from '@121-service/src/kobo/entities/kobo.entity';
+import { KoboRegistrationInput } from '@121-service/src/kobo/interfaces/kobo-registration-input.interface';
 import { KoboSubmissionMapper } from '@121-service/src/kobo/mappers/kobo-submission.mapper';
 import { KoboService } from '@121-service/src/kobo/services/kobo.service';
 import { KoboApiService } from '@121-service/src/kobo/services/kobo-api.service';
-import { ImportResult } from '@121-service/src/registration/dto/bulk-import.dto';
+import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
+import { RegistrationValidationInputType } from '@121-service/src/registration/enum/registration-validation-input-type.enum';
 import {
   MAX_IMPORT_RECORDS,
   RegistrationsCreationService,
 } from '@121-service/src/registration/services/registrations-creation.service';
+import { RegistrationsInputValidator } from '@121-service/src/registration/validators/registrations-input-validator';
 
 @Injectable()
 export class KoboSubmissionService {
@@ -26,6 +33,7 @@ export class KoboSubmissionService {
     private readonly koboApiService: KoboApiService,
     private readonly koboService: KoboService,
     private readonly registrationsCreationService: RegistrationsCreationService,
+    private readonly registrationsInputValidator: RegistrationsInputValidator,
   ) {}
 
   public async processKoboWebhookCall(
@@ -82,7 +90,7 @@ export class KoboSubmissionService {
   }: {
     programId: number;
     userId: number;
-  }): Promise<ImportResult> {
+  }): Promise<ImportExistingSubmissionsResultDto> {
     const koboIntegration = await this.koboRepository.findOne({
       where: { programId: Equal(programId) },
       select: {
@@ -103,6 +111,13 @@ export class KoboSubmissionService {
         assetUid: koboIntegration.assetUid,
         baseUrl: koboIntegration.url,
       });
+
+    if (count > MAX_IMPORT_RECORDS) {
+      throw new HttpException(
+        `The Kobo form has ${count} total submissions, which exceeds the maximum of ${MAX_IMPORT_RECORDS} that can be fetched at once. Not all submissions could be retrieved, so some new ones may be missing. Please use the CSV import instead and split the data into smaller batches.`,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
 
     const submissionWithDifferentVersion = submissions.find(
       (s) => s.__version__ !== koboIntegration.versionId,
@@ -130,24 +145,89 @@ export class KoboSubmissionService {
       (submission) => !existingReferenceIds.has(submission._uuid),
     );
 
-    if (count > MAX_IMPORT_RECORDS) {
-      throw new HttpException(
-        `The Kobo form has ${count} total submissions, which exceeds the maximum of ${MAX_IMPORT_RECORDS} that can be fetched at once. Not all submissions could be retrieved, so some new ones may be missing. Please use the CSV import instead and split the data into smaller batches.`,
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-
     const registrationDataArray = newSubmissions.map((submission) =>
       KoboSubmissionMapper.mapSubmissionToRegistrationData({
         koboSubmission: submission,
       }),
     );
 
-    return this.registrationsCreationService.importRegistrations({
-      inputRegistrations: registrationDataArray,
+    return this.validateImportAndBuildResult({
+      registrationDataArray,
       program: koboIntegration.program,
       userId,
+      numberOfSubmissionsOnForm: count,
+      numberOfSubmissionsSkipped: existingReferenceIds.size,
     });
+  }
+
+  private async validateImportAndBuildResult({
+    registrationDataArray,
+    program,
+    userId,
+    numberOfSubmissionsOnForm,
+    numberOfSubmissionsSkipped,
+  }: {
+    registrationDataArray: KoboRegistrationInput[];
+    program: ProgramEntity;
+    userId: number;
+    numberOfSubmissionsOnForm: number;
+    numberOfSubmissionsSkipped: number;
+  }): Promise<ImportExistingSubmissionsResultDto> {
+    const { validRegistrations, errors: validationErrors } =
+      await this.registrationsInputValidator.validateAndCleanInput({
+        registrationInputArray: registrationDataArray,
+        programId: program.id,
+        userId,
+        typeOfInput: RegistrationValidationInputType.create,
+        validationConfig: {
+          validateUniqueReferenceId: true,
+          validateExistingReferenceId: true,
+        },
+      });
+
+    const { aggregateImportResult } =
+      await this.registrationsCreationService.importValidatedRegistrations({
+        validatedImportRecords: validRegistrations,
+        program,
+        userId,
+      });
+
+    const validationErrorsPerSubmission = this.groupErrorsBySubmissionId({
+      validationErrors,
+      registrationDataArray,
+    });
+
+    return {
+      numberOfSubmissionsOnForm,
+      numberOfSubmissionsImported: aggregateImportResult.countImported,
+      numberOfSubmissionsSkipped,
+      numberOfSubmissionsFailed: Object.keys(validationErrorsPerSubmission)
+        .length,
+      validationErrorsPerSubmission,
+    };
+  }
+
+  private groupErrorsBySubmissionId({
+    validationErrors,
+    registrationDataArray,
+  }: {
+    validationErrors: { index: number; column: string; error: string }[];
+    registrationDataArray: KoboRegistrationInput[];
+  }): Record<string, SubmissionValidationError[]> {
+    const resultingErrors: Record<string, SubmissionValidationError[]> = {};
+    for (const validationError of validationErrors) {
+      const { referenceId } = registrationDataArray[validationError.index];
+
+      // If there are no errors recorded for this referenceId yet, initialize an empty array
+      if (!resultingErrors[referenceId]) {
+        resultingErrors[referenceId] = [];
+      }
+      resultingErrors[referenceId].push({
+        column: validationError.column,
+        error: validationError.error,
+      });
+    }
+    return resultingErrors;
   }
 
   private async getExistingReferenceIds(

--- a/services/121-service/src/kobo/services/kobo-submission.service.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.ts
@@ -13,6 +13,7 @@ import { KoboApiService } from '@121-service/src/kobo/services/kobo-api.service'
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { RegistrationValidationInputType } from '@121-service/src/registration/enum/registration-validation-input-type.enum';
+import { ValidateRegistrationErrorObject } from '@121-service/src/registration/interfaces/validate-registration-error-object.interface';
 import {
   MAX_IMPORT_RECORDS,
   RegistrationsCreationService,
@@ -181,6 +182,12 @@ export class KoboSubmissionService {
         },
       });
 
+    // Kobo submissions always have a referenceId (derived from the Kobo _uuid).
+    // The shared validator types it as optional because other callers (e.g. CSV
+    // import) may not provide one. This assertion narrows the type so downstream
+    // code can rely on referenceId being present.
+    this.assertErrorsHaveReferenceId(validationErrors);
+
     const { aggregateImportResult } =
       await this.registrationsCreationService.importValidatedRegistrations({
         validatedImportRecords: validRegistrations,
@@ -188,8 +195,6 @@ export class KoboSubmissionService {
         userId,
       });
 
-    // The Kobo error DTO does not include validator-only fields such as index.
-    // Map the validator errors to only the fields returned in the response.
     const validationErrorDtos = validationErrors.map((validationError) => ({
       referenceId: validationError.referenceId,
       column: validationError.column,
@@ -220,6 +225,19 @@ export class KoboSubmissionService {
       select: { referenceId: true },
     });
     return new Set(registrations.map((r) => r.referenceId));
+  }
+
+  private assertErrorsHaveReferenceId(
+    errors: ValidateRegistrationErrorObject[],
+  ): asserts errors is (ValidateRegistrationErrorObject & {
+    referenceId: string;
+  })[] {
+    const missing = errors.find((e) => e.referenceId == null);
+    if (missing) {
+      throw new Error(
+        `Expected referenceId on all Kobo validation errors, but column '${missing.column}' had none`,
+      );
+    }
   }
 
   private assertKoboIntegrationExistsOrThrow<T extends Partial<KoboEntity>>(

--- a/services/121-service/src/kobo/services/kobo-submission.service.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.ts
@@ -3,10 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Equal, In, Repository } from 'typeorm';
 
 import { IS_DEVELOPMENT } from '@121-service/src/config';
-import {
-  ImportExistingSubmissionsResultDto,
-  SubmissionValidationError,
-} from '@121-service/src/kobo/dtos/import-existing-submissions-result.dto';
+import { ImportExistingSubmissionsResultDto } from '@121-service/src/kobo/dtos/import-existing-submissions-result.dto';
 import { KoboWebhookIncomingSubmission } from '@121-service/src/kobo/dtos/kobo-webhook-incoming-submission.dto';
 import { KoboEntity } from '@121-service/src/kobo/entities/kobo.entity';
 import { KoboRegistrationInput } from '@121-service/src/kobo/interfaces/kobo-registration-input.interface';
@@ -180,7 +177,6 @@ export class KoboSubmissionService {
         userId,
         typeOfInput: RegistrationValidationInputType.create,
         validationConfig: {
-          validateUniqueReferenceId: true,
           validateExistingReferenceId: true,
         },
       });
@@ -192,42 +188,25 @@ export class KoboSubmissionService {
         userId,
       });
 
-    const validationErrorsPerSubmission = this.groupErrorsBySubmissionId({
-      validationErrors,
-      registrationDataArray,
-    });
+    // The Kobo error DTO does not include validator-only fields such as index.
+    // Map the validator errors to only the fields returned in the response.
+    const validationErrorDtos = validationErrors.map((validationError) => ({
+      referenceId: validationError.referenceId ?? '',
+      column: validationError.column,
+      error: validationError.error,
+    }));
+
+    const failedReferenceIds = new Set(
+      validationErrorDtos.map((e) => e.referenceId),
+    );
 
     return {
       numberOfSubmissionsOnForm,
       numberOfSubmissionsImported: aggregateImportResult.countImported,
       numberOfSubmissionsSkipped,
-      numberOfSubmissionsFailed: Object.keys(validationErrorsPerSubmission)
-        .length,
-      validationErrorsPerSubmission,
+      numberOfSubmissionsFailed: failedReferenceIds.size,
+      validationErrors: validationErrorDtos,
     };
-  }
-
-  private groupErrorsBySubmissionId({
-    validationErrors,
-    registrationDataArray,
-  }: {
-    validationErrors: { index: number; column: string; error: string }[];
-    registrationDataArray: KoboRegistrationInput[];
-  }): Record<string, SubmissionValidationError[]> {
-    const resultingErrors: Record<string, SubmissionValidationError[]> = {};
-    for (const validationError of validationErrors) {
-      const { referenceId } = registrationDataArray[validationError.index];
-
-      // If there are no errors recorded for this referenceId yet, initialize an empty array
-      if (!resultingErrors[referenceId]) {
-        resultingErrors[referenceId] = [];
-      }
-      resultingErrors[referenceId].push({
-        column: validationError.column,
-        error: validationError.error,
-      });
-    }
-    return resultingErrors;
   }
 
   private async getExistingReferenceIds(

--- a/services/121-service/src/kobo/services/kobo-submission.service.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.ts
@@ -191,7 +191,7 @@ export class KoboSubmissionService {
     // The Kobo error DTO does not include validator-only fields such as index.
     // Map the validator errors to only the fields returned in the response.
     const validationErrorDtos = validationErrors.map((validationError) => ({
-      referenceId: validationError.referenceId ?? '',
+      referenceId: validationError.referenceId,
       column: validationError.column,
       error: validationError.error,
     }));

--- a/services/121-service/src/kobo/services/kobo-submission.service.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.ts
@@ -82,7 +82,7 @@ export class KoboSubmissionService {
     });
   }
 
-  public async importNewSubmissions({
+  public async importExistingSubmissions({
     programId,
     userId,
   }: {
@@ -108,6 +108,7 @@ export class KoboSubmissionService {
         token: koboIntegration.token,
         assetUid: koboIntegration.assetUid,
         baseUrl: koboIntegration.url,
+        limit: MAX_IMPORT_RECORDS,
       });
 
     if (count > MAX_IMPORT_RECORDS) {

--- a/services/121-service/src/registration/interfaces/validate-registration-error-object.interface.ts
+++ b/services/121-service/src/registration/interfaces/validate-registration-error-object.interface.ts
@@ -1,5 +1,6 @@
 export interface ValidateRegistrationErrorObject {
   readonly index: number;
+  readonly referenceId?: string;
   readonly column: string;
   readonly error: string;
   readonly value: string | number | undefined | boolean | null;

--- a/services/121-service/src/registration/registrations.module.ts
+++ b/services/121-service/src/registration/registrations.module.ts
@@ -102,6 +102,7 @@ import { createScopedRepositoryProvider } from '@121-service/src/utils/scope/cre
     RegistrationsCreationService,
     RegistrationScopedRepository,
     RegistrationViewScopedRepository,
+    RegistrationsInputValidator,
   ],
 })
 export class RegistrationsModule {}

--- a/services/121-service/src/registration/validators/registrations-input-validator.spec.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.spec.ts
@@ -321,6 +321,7 @@ describe('RegistrationsInputValidator', () => {
       expect.arrayContaining([
         {
           index: 0,
+          referenceId: undefined,
           column: GenericRegistrationAttributes.phoneNumber,
           value: undefined,
           error:

--- a/services/121-service/src/registration/validators/registrations-input-validator.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.ts
@@ -357,9 +357,12 @@ export class RegistrationsInputValidator {
         }),
       );
 
+      const referenceId =
+        typeof row.referenceId === 'string' ? row.referenceId : undefined;
+
       // Break the loop and stop processing if file has too many errors
       if (allErrors.length + rowErrors.length >= 5000) {
-        allErrors.push(...rowErrors);
+        allErrors.push(...rowErrors.map((e) => ({ ...e, referenceId })));
         return { validRegistrations, errors: allErrors };
       }
 
@@ -383,7 +386,7 @@ export class RegistrationsInputValidator {
       }
 
       if (rowErrors.length > 0) {
-        allErrors.push(...rowErrors);
+        allErrors.push(...rowErrors.map((e) => ({ ...e, referenceId })));
       } else {
         validRegistrations.push(validatedRegistrationInput);
       }

--- a/services/121-service/swagger.json
+++ b/services/121-service/swagger.json
@@ -1209,7 +1209,7 @@
     "params": [
       "programId"
     ],
-    "returnType": "ImportResult"
+    "returnType": "ImportExistingSubmissionsResultDto"
   },
   {
     "method": "post",

--- a/services/121-service/test/kobo/kobo-import-existing-submissions.test.ts
+++ b/services/121-service/test/kobo/kobo-import-existing-submissions.test.ts
@@ -111,7 +111,7 @@ describe('Import new Kobo submissions via PATCH endpoint', () => {
       numberOfSubmissionsImported: 1,
       numberOfSubmissionsSkipped: 0,
       numberOfSubmissionsFailed: 0,
-      validationErrorsPerSubmission: {},
+      validationErrors: [],
     });
 
     const searchResponse = await searchRegistrationByReferenceId(
@@ -144,7 +144,7 @@ describe('Import new Kobo submissions via PATCH endpoint', () => {
       numberOfSubmissionsImported: 1,
       numberOfSubmissionsSkipped: 0,
       numberOfSubmissionsFailed: 0,
-      validationErrorsPerSubmission: {},
+      validationErrors: [],
     });
 
     // Act: Import a second time — the same submission already exists
@@ -160,7 +160,7 @@ describe('Import new Kobo submissions via PATCH endpoint', () => {
       numberOfSubmissionsImported: 0,
       numberOfSubmissionsSkipped: 1,
       numberOfSubmissionsFailed: 0,
-      validationErrorsPerSubmission: {},
+      validationErrors: [],
     });
 
     const searchResponse = await searchRegistrationByReferenceId(
@@ -189,14 +189,19 @@ describe('Import new Kobo submissions via PATCH endpoint', () => {
       numberOfSubmissionsSkipped: 0,
       numberOfSubmissionsFailed: 1,
     });
-    const failureErrors =
-      response.body.validationErrorsPerSubmission[expectedFailureReferenceId];
+    const failureErrors = response.body.validationErrors.filter(
+      (e: { referenceId: string }) =>
+        e.referenceId === expectedFailureReferenceId,
+    );
     expect(failureErrors).toBeArrayOfSize(1);
     expect(failureErrors[0]).toMatchObject({
       column: 'programFspConfigurationName',
     });
-    expect(response.body.validationErrorsPerSubmission).not.toHaveProperty(
-      expectedSuccessReferenceId,
-    );
+    expect(
+      response.body.validationErrors.some(
+        (e: { referenceId: string }) =>
+          e.referenceId === expectedSuccessReferenceId,
+      ),
+    ).toBe(false);
   });
 });

--- a/services/121-service/test/kobo/kobo-import-existing-submissions.test.ts
+++ b/services/121-service/test/kobo/kobo-import-existing-submissions.test.ts
@@ -106,7 +106,13 @@ describe('Import new Kobo submissions via PATCH endpoint', () => {
 
     // Assert
     expect(response.status).toBe(HttpStatus.OK);
-    expect(response.body.aggregateImportResult.countImported).toBe(1);
+    expect(response.body).toMatchObject({
+      numberOfSubmissionsOnForm: 1,
+      numberOfSubmissionsImported: 1,
+      numberOfSubmissionsSkipped: 0,
+      numberOfSubmissionsFailed: 0,
+      validationErrorsPerSubmission: {},
+    });
 
     const searchResponse = await searchRegistrationByReferenceId(
       expectedReferenceId,
@@ -133,7 +139,13 @@ describe('Import new Kobo submissions via PATCH endpoint', () => {
       accessToken,
     });
     expect(firstResponse.status).toBe(HttpStatus.OK);
-    expect(firstResponse.body.aggregateImportResult.countImported).toBe(1);
+    expect(firstResponse.body).toMatchObject({
+      numberOfSubmissionsOnForm: 1,
+      numberOfSubmissionsImported: 1,
+      numberOfSubmissionsSkipped: 0,
+      numberOfSubmissionsFailed: 0,
+      validationErrorsPerSubmission: {},
+    });
 
     // Act: Import a second time — the same submission already exists
     const secondResponse = await patchKoboSubmissions({
@@ -143,7 +155,13 @@ describe('Import new Kobo submissions via PATCH endpoint', () => {
 
     // Assert
     expect(secondResponse.status).toBe(HttpStatus.OK);
-    expect(secondResponse.body.aggregateImportResult.countImported).toBe(0);
+    expect(secondResponse.body).toMatchObject({
+      numberOfSubmissionsOnForm: 1,
+      numberOfSubmissionsImported: 0,
+      numberOfSubmissionsSkipped: 1,
+      numberOfSubmissionsFailed: 0,
+      validationErrorsPerSubmission: {},
+    });
 
     const searchResponse = await searchRegistrationByReferenceId(
       expectedReferenceId,
@@ -151,5 +169,34 @@ describe('Import new Kobo submissions via PATCH endpoint', () => {
       accessToken,
     );
     expect(searchResponse.body.data).toBeArrayOfSize(1);
+  });
+
+  it('should report failed submissions with error messages when a submission fails validation', async () => {
+    // Arrange
+    const assetUid = 'import-with-failure';
+    const expectedSuccessReferenceId = `${KoboMockSubmissionUuids.success}-${assetUid}`;
+    const expectedFailureReferenceId = `${KoboMockSubmissionUuids.failure}-${assetUid}`;
+    const { programId } = await setup(assetUid);
+
+    // Act
+    const response = await patchKoboSubmissions({ programId, accessToken });
+
+    // Assert
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.body).toMatchObject({
+      numberOfSubmissionsOnForm: 2,
+      numberOfSubmissionsImported: 1,
+      numberOfSubmissionsSkipped: 0,
+      numberOfSubmissionsFailed: 1,
+    });
+    const failureErrors =
+      response.body.validationErrorsPerSubmission[expectedFailureReferenceId];
+    expect(failureErrors).toBeArrayOfSize(1);
+    expect(failureErrors[0]).toMatchObject({
+      column: 'programFspConfigurationName',
+    });
+    expect(response.body.validationErrorsPerSubmission).not.toHaveProperty(
+      expectedSuccessReferenceId,
+    );
   });
 });

--- a/services/121-service/test/registrations/__snapshots__/import-registration.test.ts.snap
+++ b/services/121-service/test/registrations/__snapshots__/import-registration.test.ts.snap
@@ -23,6 +23,7 @@ exports[`Import a registration should throw an error when a required fsp attribu
     "column": "whatsappPhoneNumber",
     "error": "Cannot update 'whatsappPhoneNumber' is required for the FSP: 'Intersolve-voucher-whatsapp'",
     "lineNumber": 1,
+    "referenceId": "westeros123456789",
   },
 ]
 `;
@@ -33,6 +34,7 @@ exports[`Import a registration should throw an error with a dropdown registratio
     "column": "house",
     "error": "Value 'null' is not in the allowed options: 'lannister, stark, greyjoy' for attribute 'house'",
     "lineNumber": 1,
+    "referenceId": "westeros123456789",
     "value": null,
   },
 ]
@@ -44,6 +46,7 @@ exports[`Import a registration should throw an error with a numeric registration
     "column": "addressHouseNumber",
     "error": "Cannot update/set addressHouseNumber with a nullable value as it is required for the FSP: Intersolve-visa",
     "lineNumber": 1,
+    "referenceId": "registration-visa-1",
     "value": null,
   },
 ]

--- a/services/mock-service/src/kobo/kobo.mock.service.ts
+++ b/services/mock-service/src/kobo/kobo.mock.service.ts
@@ -459,11 +459,11 @@ export class KoboMockService {
     results: Record<string, any>[];
   } {
     const asset = this.getAssetDeployment(uid_asset);
-    const submissionUuid = `${KoboMockSubmissionUuids.success}-${uid_asset}`;
-    const results = [
+    const successSubmissionUuid = `${KoboMockSubmissionUuids.success}-${uid_asset}`;
+    const results: Record<string, any>[] = [
       {
         _id: 1,
-        _uuid: submissionUuid,
+        _uuid: successSubmissionUuid,
         _xform_id_string: uid_asset,
         _submission_time: '2025-04-30T15:30:00.000Z',
         _status: 'submitted_via_web',
@@ -489,6 +489,27 @@ export class KoboMockService {
         __version__: asset.version_id,
       },
     ];
+
+    if (uid_asset.includes('with-failure')) {
+      const failureSubmissionUuid = `${KoboMockSubmissionUuids.failure}-${uid_asset}`;
+      results.push({
+        _id: 2,
+        _uuid: failureSubmissionUuid,
+        _xform_id_string: uid_asset,
+        _submission_time: '2025-04-30T16:00:00.000Z',
+        _status: 'submitted_via_web',
+        start: '2025-04-30T15:59:00.000Z',
+        end: '2025-04-30T16:00:00.000Z',
+        // This should trigger an error in our processing because the FSP is not a valid one
+        // In a real scenario this could have happended if submission were created with an older version of the form
+        fsp: 'Invalid-FSP',
+        'group_ad8jk55/fullName': 'Jane Doe',
+        nationalId: '987654321',
+        phoneNumber: '+31687654321',
+        __version__: asset.version_id,
+      });
+    }
+
     return { count: results.length, next: null, previous: null, results };
   }
 

--- a/services/mock-service/src/kobo/kobo.mock.service.ts
+++ b/services/mock-service/src/kobo/kobo.mock.service.ts
@@ -501,8 +501,7 @@ export class KoboMockService {
         start: '2025-04-30T15:59:00.000Z',
         end: '2025-04-30T16:00:00.000Z',
         // This should trigger an error in our processing because the FSP is not a valid one
-        // In a real scenario this could have happended if submission were created with an older version of the form
-        fsp: 'Invalid-FSP',
+        // In a real scenario, this could have happened if the submission was created with an older version of the form
         'group_ad8jk55/fullName': 'Jane Doe',
         nationalId: '987654321',
         phoneNumber: '+31687654321',

--- a/services/mock-service/src/kobo/kobo.mock.service.ts
+++ b/services/mock-service/src/kobo/kobo.mock.service.ts
@@ -500,7 +500,7 @@ export class KoboMockService {
         _status: 'submitted_via_web',
         start: '2025-04-30T15:59:00.000Z',
         end: '2025-04-30T16:00:00.000Z',
-        // This should trigger an error in our processing because the FSP is not a valid one
+        // This should trigger an error in our processing because the FSP is missing
         // In a real scenario, this could have happened if the submission was created with an older version of the form
         'group_ad8jk55/fullName': 'Jane Doe',
         nationalId: '987654321',


### PR DESCRIPTION
[AB#41604](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/41604) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes
Review https://github.com/global-121/121-platform/pull/8105 first

The `PATCH /programs/:programId/kobo/submissions` endpoint previously returned an `ImportResult` with only `aggregateImportResult.countImported`. This was insufficient for the new UI design (see attached screenshot), which needs to show users a detailed breakdown of what happened during import.



<img width="1102" height="643" alt="image" src="https://github.com/user-attachments/assets/0e15a8e5-736e-4a7e-8d07-28b4745ffd1f" />

This PR ensure that the controller now returns: 

```
export class ImportExistingSubmissionsResultDto {
  public numberOfSubmissionsOnForm: number;
  public numberOfSubmissionsImported: number;
  public numberOfSubmissionsSkipped: number;
  public numberOfSubmissionsFailed: number;
 	public validationErrors: SubmissionValidationError[];
}

```

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
