### PR TITLE
Refactor submission service to 2 services too make it more testable

### DIFF
--- a/services/121-service/src/kobo/kobo.module.ts
+++ b/services/121-service/src/kobo/kobo.module.ts
@@ -8,6 +8,7 @@ import { KoboController } from '@121-service/src/kobo/kobo.controller';
 import { KoboService } from '@121-service/src/kobo/services/kobo.service';
 import { KoboValidationService } from '@121-service/src/kobo/services/kobo.validation.service';
 import { KoboApiService } from '@121-service/src/kobo/services/kobo-api.service';
+import { KoboSubmissionHelperService } from '@121-service/src/kobo/services/kobo-submission.helper.service';
 import { KoboSubmissionService } from '@121-service/src/kobo/services/kobo-submission.service';
 import { KoboSurveyProcessorService } from '@121-service/src/kobo/services/kobo-survey-processor.service';
 import { ProgramFspConfigurationsModule } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.module';
@@ -31,6 +32,7 @@ import { CustomHttpService } from '@121-service/src/shared/services/custom-http.
     CustomHttpService,
     KoboSurveyProcessorService,
     KoboSubmissionService,
+    KoboSubmissionHelperService,
     KoboWebhookBasicAuthGuard,
   ],
   controllers: [KoboController],

--- a/services/121-service/src/kobo/services/kobo-submission.helper.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.helper.service.spec.ts
@@ -1,0 +1,460 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { KoboEntity } from '@121-service/src/kobo/entities/kobo.entity';
+import { KoboFormDefinition } from '@121-service/src/kobo/interfaces/kobo-form-definition.interface';
+import { KoboRegistrationInput } from '@121-service/src/kobo/interfaces/kobo-registration-input.interface';
+import { KoboService } from '@121-service/src/kobo/services/kobo.service';
+import { KoboSubmissionHelperService } from '@121-service/src/kobo/services/kobo-submission.helper.service';
+import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
+import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
+import { RegistrationsCreationService } from '@121-service/src/registration/services/registrations-creation.service';
+import { RegistrationsInputValidator } from '@121-service/src/registration/validators/registrations-input-validator';
+
+describe('KoboSubmissionHelperService', () => {
+  let service: KoboSubmissionHelperService;
+  let koboService: jest.Mocked<KoboService>;
+  let koboRepository: jest.Mocked<Repository<KoboEntity>>;
+  let registrationRepository: jest.Mocked<Repository<RegistrationEntity>>;
+  let registrationsInputValidator: jest.Mocked<RegistrationsInputValidator>;
+  let registrationsCreationService: jest.Mocked<RegistrationsCreationService>;
+
+  const mockProgram = {
+    id: 1,
+    titlePortal: { en: 'Test Program' },
+  } as ProgramEntity;
+
+  const userId = 42;
+
+  const registrationDataArray: KoboRegistrationInput[] = [
+    {
+      referenceId: 'uuid-1',
+      programFspConfigurationName: 'Safaricom',
+      fullName: 'John Doe',
+      phoneNumber: '+31612345678',
+    },
+    {
+      referenceId: 'uuid-2',
+      programFspConfigurationName: 'Safaricom',
+      fullName: 'Jane Doe',
+      phoneNumber: '+31698765432',
+    },
+  ];
+
+  function buildMockFormDefinition(
+    overrides: Partial<KoboFormDefinition>,
+  ): KoboFormDefinition {
+    return {
+      name: 'Test Form',
+      survey: [],
+      languages: ['English (en)'],
+      dateDeployed: new Date('2025-06-01'),
+      versionId: 'mock-version-id',
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        KoboSubmissionHelperService,
+        {
+          provide: KoboService,
+          useValue: {
+            getFormDefinitionOrThrow: jest.fn(),
+            validateFormAndUpdateProgram: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(KoboEntity),
+          useValue: {
+            update: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(RegistrationEntity),
+          useValue: {
+            find: jest.fn(),
+          },
+        },
+        {
+          provide: RegistrationsInputValidator,
+          useValue: {
+            validateAndCleanInput: jest.fn(),
+          },
+        },
+        {
+          provide: RegistrationsCreationService,
+          useValue: {
+            importValidatedRegistrations: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<KoboSubmissionHelperService>(
+      KoboSubmissionHelperService,
+    );
+    koboService = module.get(KoboService);
+    koboRepository = module.get(getRepositoryToken(KoboEntity));
+    registrationRepository = module.get(getRepositoryToken(RegistrationEntity));
+    registrationsInputValidator = module.get(RegistrationsInputValidator);
+    registrationsCreationService = module.get(RegistrationsCreationService);
+  });
+
+  describe('updateProgramToNewVersionIfApplicable', () => {
+    const baseVersionParams = {
+      currentVersion: 'v1',
+      currentVersionDateDeployed: new Date('2024-01-01'),
+      formVersionFromIncomingSubmission: 'v2',
+      assetUid: 'test-asset-uid',
+      token: 'mock-token',
+      url: 'https://kobo.example.com',
+      programId: 1,
+    };
+
+    it('should update program when incoming version is newer', async () => {
+      // Arrange
+      const newerDateDeployed = new Date('2025-06-01');
+      koboService.getFormDefinitionOrThrow.mockResolvedValue(
+        buildMockFormDefinition({
+          dateDeployed: newerDateDeployed,
+          versionId: 'v2',
+        }),
+      );
+      koboService.validateFormAndUpdateProgram.mockResolvedValue(undefined);
+
+      // Act
+      await service.updateProgramToNewVersionIfApplicable(baseVersionParams);
+
+      // Assert
+      expect(koboService.validateFormAndUpdateProgram).toHaveBeenCalledWith({
+        formDefinition: expect.objectContaining({ versionId: 'v2' }),
+        programId: 1,
+      });
+      expect(koboRepository.update).toHaveBeenCalledWith(
+        { versionId: 'v1', programId: 1 },
+        { versionId: 'v2', dateDeployed: newerDateDeployed },
+      );
+    });
+
+    it('should skip update when versions match', async () => {
+      // Act
+      await service.updateProgramToNewVersionIfApplicable({
+        ...baseVersionParams,
+        formVersionFromIncomingSubmission: 'v1',
+      });
+
+      // Assert
+      expect(koboService.getFormDefinitionOrThrow).not.toHaveBeenCalled();
+    });
+
+    it('should skip update when incoming version is older', async () => {
+      // Arrange
+      koboService.getFormDefinitionOrThrow.mockResolvedValue(
+        buildMockFormDefinition({
+          dateDeployed: new Date('2023-01-01'), // Older than current
+        }),
+      );
+
+      // Act
+      await service.updateProgramToNewVersionIfApplicable(baseVersionParams);
+
+      // Assert
+      expect(koboService.validateFormAndUpdateProgram).not.toHaveBeenCalled();
+    });
+
+    it('should throw when form validation fails', async () => {
+      // Arrange
+      const validationError = new HttpException(
+        'Kobo form definition validation failed',
+        HttpStatus.BAD_REQUEST,
+      );
+      koboService.getFormDefinitionOrThrow.mockResolvedValue(
+        buildMockFormDefinition({ versionId: 'v2' }),
+      );
+      koboService.validateFormAndUpdateProgram.mockRejectedValue(
+        validationError,
+      );
+
+      // Act & Assert
+      await expect(
+        service.updateProgramToNewVersionIfApplicable(baseVersionParams),
+      ).rejects.toThrow(validationError);
+    });
+  });
+
+  describe('getExistingReferenceIds', () => {
+    it('should return set of existing reference IDs', async () => {
+      // Arrange
+      registrationRepository.find.mockResolvedValue([
+        { referenceId: 'uuid-1' } as RegistrationEntity,
+        { referenceId: 'uuid-3' } as RegistrationEntity,
+      ]);
+
+      // Act
+      const result = await service.getExistingReferenceIds([
+        'uuid-1',
+        'uuid-2',
+        'uuid-3',
+      ]);
+
+      // Assert
+      expect(result).toEqual(new Set(['uuid-1', 'uuid-3']));
+    });
+
+    it('should return empty set for empty input', async () => {
+      // Act
+      const result = await service.getExistingReferenceIds([]);
+
+      // Assert
+      expect(result).toEqual(new Set());
+      expect(registrationRepository.find).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validateAndImportAsRegistrations', () => {
+    it('should return correct counts when all submissions import successfully', async () => {
+      // Arrange
+      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
+        validRegistrations: registrationDataArray.map((r) => ({
+          ...r,
+          data: {},
+        })),
+        errors: [],
+      });
+      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
+        { aggregateImportResult: { countImported: 2 } },
+      );
+
+      // Act
+      const result = await service.validateAndImportAsRegistrations({
+        registrationDataArray,
+        program: mockProgram,
+        userId,
+        numberOfSubmissionsOnForm: 5,
+        numberOfSubmissionsSkipped: 3,
+      });
+
+      // Assert
+      expect(result).toEqual({
+        numberOfSubmissionsOnForm: 5,
+        numberOfSubmissionsImported: 2,
+        numberOfSubmissionsSkipped: 3,
+        numberOfSubmissionsFailed: 0,
+        validationErrors: [],
+      });
+    });
+
+    it('should return flat validation errors with referenceId', async () => {
+      // Arrange
+      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
+        validRegistrations: [],
+        errors: [
+          {
+            index: 0,
+            referenceId: 'uuid-1',
+            column: 'phoneNumber',
+            error: 'Value is not valid',
+            value: 'invalid',
+          },
+          {
+            index: 0,
+            referenceId: 'uuid-1',
+            column: 'fullName',
+            error: 'Value is required',
+            value: '',
+          },
+          {
+            index: 1,
+            referenceId: 'uuid-2',
+            column: 'programFspConfigurationName',
+            error: 'FSP not found',
+            value: 'InvalidFsp',
+          },
+        ],
+      });
+      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
+        { aggregateImportResult: { countImported: 0 } },
+      );
+
+      // Act
+      const result = await service.validateAndImportAsRegistrations({
+        registrationDataArray,
+        program: mockProgram,
+        userId,
+        numberOfSubmissionsOnForm: 2,
+        numberOfSubmissionsSkipped: 0,
+      });
+
+      // Assert
+      expect(result.validationErrors).toEqual([
+        {
+          referenceId: 'uuid-1',
+          column: 'phoneNumber',
+          error: 'Value is not valid',
+        },
+        {
+          referenceId: 'uuid-1',
+          column: 'fullName',
+          error: 'Value is required',
+        },
+        {
+          referenceId: 'uuid-2',
+          column: 'programFspConfigurationName',
+          error: 'FSP not found',
+        },
+      ]);
+      expect(result.numberOfSubmissionsFailed).toBe(2);
+    });
+
+    it('should handle partial success with some valid and some invalid submissions', async () => {
+      // Arrange
+      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
+        validRegistrations: [{ ...registrationDataArray[0], data: {} }],
+        errors: [
+          {
+            index: 1,
+            referenceId: 'uuid-2',
+            column: 'phoneNumber',
+            error: 'Value is not valid',
+            value: 'bad-phone',
+          },
+        ],
+      });
+      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
+        { aggregateImportResult: { countImported: 1 } },
+      );
+
+      // Act
+      const result = await service.validateAndImportAsRegistrations({
+        registrationDataArray,
+        program: mockProgram,
+        userId,
+        numberOfSubmissionsOnForm: 5,
+        numberOfSubmissionsSkipped: 3,
+      });
+
+      // Assert
+      expect(result).toEqual({
+        numberOfSubmissionsOnForm: 5,
+        numberOfSubmissionsImported: 1,
+        numberOfSubmissionsSkipped: 3,
+        numberOfSubmissionsFailed: 1,
+        validationErrors: [
+          {
+            referenceId: 'uuid-2',
+            column: 'phoneNumber',
+            error: 'Value is not valid',
+          },
+        ],
+      });
+    });
+
+    it('should handle empty registration data array', async () => {
+      // Arrange
+      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
+        validRegistrations: [],
+        errors: [],
+      });
+      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
+        { aggregateImportResult: { countImported: 0 } },
+      );
+
+      // Act
+      const result = await service.validateAndImportAsRegistrations({
+        registrationDataArray: [],
+        program: mockProgram,
+        userId,
+        numberOfSubmissionsOnForm: 3,
+        numberOfSubmissionsSkipped: 3,
+      });
+
+      // Assert
+      expect(result).toEqual({
+        numberOfSubmissionsOnForm: 3,
+        numberOfSubmissionsImported: 0,
+        numberOfSubmissionsSkipped: 3,
+        numberOfSubmissionsFailed: 0,
+        validationErrors: [],
+      });
+    });
+
+    it('should pass correct parameters to validator and import service', async () => {
+      // Arrange
+      const validatedRegistrations = registrationDataArray.map((r) => ({
+        ...r,
+        data: {},
+      }));
+      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
+        validRegistrations: validatedRegistrations,
+        errors: [],
+      });
+      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
+        { aggregateImportResult: { countImported: 2 } },
+      );
+
+      // Act
+      await service.validateAndImportAsRegistrations({
+        registrationDataArray,
+        program: mockProgram,
+        userId,
+        numberOfSubmissionsOnForm: 2,
+        numberOfSubmissionsSkipped: 0,
+      });
+
+      // Assert
+      expect(
+        registrationsInputValidator.validateAndCleanInput,
+      ).toHaveBeenCalledWith({
+        registrationInputArray: registrationDataArray,
+        programId: mockProgram.id,
+        userId,
+        typeOfInput: 'create',
+        validationConfig: {
+          validateExistingReferenceId: true,
+        },
+      });
+      expect(
+        registrationsCreationService.importValidatedRegistrations,
+      ).toHaveBeenCalledWith({
+        validatedImportRecords: validatedRegistrations,
+        program: mockProgram,
+        userId,
+      });
+    });
+  });
+
+  describe('assertErrorsHaveReferenceId (via validateAndImportAsRegistrations)', () => {
+    it('should throw when a validation error has no referenceId', async () => {
+      // Arrange
+      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
+        validRegistrations: [],
+        errors: [
+          {
+            index: 0,
+            referenceId: undefined,
+            column: 'phoneNumber',
+            error: 'Value is not valid',
+            value: 'invalid',
+          },
+        ],
+      });
+
+      // Act & Assert
+      await expect(
+        service.validateAndImportAsRegistrations({
+          registrationDataArray: [],
+          program: mockProgram,
+          userId,
+          numberOfSubmissionsOnForm: 1,
+          numberOfSubmissionsSkipped: 0,
+        }),
+      ).rejects.toThrow(
+        "Expected referenceId on all Kobo validation errors, but column 'phoneNumber' had none",
+      );
+    });
+  });
+});

--- a/services/121-service/src/kobo/services/kobo-submission.helper.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.helper.service.spec.ts
@@ -186,7 +186,7 @@ describe('KoboSubmissionHelperService', () => {
     });
   });
 
-  describe('getExistingReferenceIds', () => {
+  describe('filter submissions ids already existing', () => {
     it('should return set of existing reference IDs', async () => {
       // Arrange
       registrationRepository.find.mockResolvedValue([
@@ -195,7 +195,7 @@ describe('KoboSubmissionHelperService', () => {
       ]);
 
       // Act
-      const result = await service.getExistingReferenceIds([
+      const result = await service.filterAlreadyExistingSubmissionUuids([
         'uuid-1',
         'uuid-2',
         'uuid-3',
@@ -207,7 +207,7 @@ describe('KoboSubmissionHelperService', () => {
 
     it('should return empty set for empty input', async () => {
       // Act
-      const result = await service.getExistingReferenceIds([]);
+      const result = await service.filterAlreadyExistingSubmissionUuids([]);
 
       // Assert
       expect(result).toEqual(new Set());

--- a/services/121-service/src/kobo/services/kobo-submission.helper.service.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.helper.service.ts
@@ -89,14 +89,14 @@ export class KoboSubmissionHelperService {
     );
   }
 
-  public async getExistingReferenceIds(
-    referenceIds: string[],
+  public async filterAlreadyExistingSubmissionUuids(
+    submissionUuids: string[],
   ): Promise<Set<string>> {
-    if (referenceIds.length === 0) {
+    if (submissionUuids.length === 0) {
       return new Set();
     }
     const registrations = await this.registrationRepository.find({
-      where: { referenceId: In(referenceIds) },
+      where: { referenceId: In(submissionUuids) },
       select: { referenceId: true },
     });
     return new Set(registrations.map((r) => r.referenceId));

--- a/services/121-service/src/kobo/services/kobo-submission.helper.service.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.helper.service.ts
@@ -1,0 +1,176 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+
+import { IS_DEVELOPMENT } from '@121-service/src/config';
+import { ImportExistingSubmissionsResultDto } from '@121-service/src/kobo/dtos/import-existing-submissions-result.dto';
+import { KoboEntity } from '@121-service/src/kobo/entities/kobo.entity';
+import { KoboRegistrationInput } from '@121-service/src/kobo/interfaces/kobo-registration-input.interface';
+import { KoboService } from '@121-service/src/kobo/services/kobo.service';
+import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
+import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
+import { RegistrationValidationInputType } from '@121-service/src/registration/enum/registration-validation-input-type.enum';
+import { ValidateRegistrationErrorObject } from '@121-service/src/registration/interfaces/validate-registration-error-object.interface';
+import { RegistrationsCreationService } from '@121-service/src/registration/services/registrations-creation.service';
+import { RegistrationsInputValidator } from '@121-service/src/registration/validators/registrations-input-validator';
+
+@Injectable()
+export class KoboSubmissionHelperService {
+  @InjectRepository(KoboEntity)
+  private readonly koboRepository: Repository<KoboEntity>;
+  @InjectRepository(RegistrationEntity)
+  private readonly registrationRepository: Repository<RegistrationEntity>;
+
+  constructor(
+    private readonly koboService: KoboService,
+    private readonly registrationsCreationService: RegistrationsCreationService,
+    private readonly registrationsInputValidator: RegistrationsInputValidator,
+  ) {}
+
+  public async updateProgramToNewVersionIfApplicable({
+    currentVersion,
+    currentVersionDateDeployed,
+    formVersionFromIncomingSubmission,
+    assetUid,
+    token,
+    url,
+    programId,
+  }: {
+    currentVersion: string;
+    currentVersionDateDeployed: Date;
+    formVersionFromIncomingSubmission: string;
+    assetUid: string;
+    token: string;
+    url: string;
+    programId: number;
+  }): Promise<void> {
+    if (currentVersion === formVersionFromIncomingSubmission) {
+      return;
+    }
+
+    if (IS_DEVELOPMENT) {
+      // The mock service is stateless and cannot serve multiple real Kobo form versions.
+      // Integration tests encode the target mock asset UID in __version__ so this service
+      // fetches the correct mock asset instead of the original one.
+      if (formVersionFromIncomingSubmission.includes('asset-')) {
+        assetUid = `asset-${formVersionFromIncomingSubmission.split('asset-')[1]}`;
+      }
+    }
+
+    const formDefinition = await this.koboService.getFormDefinitionOrThrow({
+      assetUid,
+      token,
+      url,
+    });
+
+    // We expect that, most of the time, the incoming submission will be for the same version as the current one or for a newer version.
+    // However, if we receive a submission for an older version (for example, because Kobo is retrying a submission that previously failed),
+    // we do not update the program to that older version, to avoid removing program languages that were added later.
+    // We still allow the submission to proceed as normal. If there are required attributes in the older version that are not in the program,
+    // an error will be thrown during registration creation, will show up in the Kobo REST API service, and will need to be resolved by a human.
+    const formDeployedDateOfIncomingSubmission = new Date(
+      formDefinition.dateDeployed,
+    );
+    if (formDeployedDateOfIncomingSubmission < currentVersionDateDeployed) {
+      return;
+    }
+
+    await this.koboService.validateFormAndUpdateProgram({
+      formDefinition,
+      programId,
+    });
+
+    await this.koboRepository.update(
+      { versionId: currentVersion, programId },
+      {
+        versionId: formVersionFromIncomingSubmission,
+        dateDeployed: formDeployedDateOfIncomingSubmission,
+      },
+    );
+  }
+
+  public async getExistingReferenceIds(
+    referenceIds: string[],
+  ): Promise<Set<string>> {
+    if (referenceIds.length === 0) {
+      return new Set();
+    }
+    const registrations = await this.registrationRepository.find({
+      where: { referenceId: In(referenceIds) },
+      select: { referenceId: true },
+    });
+    return new Set(registrations.map((r) => r.referenceId));
+  }
+
+  public async validateAndImportAsRegistrations({
+    registrationDataArray,
+    program,
+    userId,
+    numberOfSubmissionsOnForm,
+    numberOfSubmissionsSkipped,
+  }: {
+    registrationDataArray: KoboRegistrationInput[];
+    program: ProgramEntity;
+    userId: number;
+    numberOfSubmissionsOnForm: number;
+    numberOfSubmissionsSkipped: number;
+  }): Promise<ImportExistingSubmissionsResultDto> {
+    const { validRegistrations, errors: validationErrors } =
+      await this.registrationsInputValidator.validateAndCleanInput({
+        registrationInputArray: registrationDataArray,
+        programId: program.id,
+        userId,
+        typeOfInput: RegistrationValidationInputType.create,
+        validationConfig: {
+          validateExistingReferenceId: true,
+        },
+      });
+
+    // Kobo submissions always have a referenceId (derived from the Kobo _uuid).
+    // The shared validator types it as optional because other callers (e.g. CSV
+    // import) may not provide one. This assertion narrows the type so downstream
+    // code can rely on referenceId being present.
+    this.assertErrorsHaveReferenceId(validationErrors);
+
+    const { aggregateImportResult } =
+      await this.registrationsCreationService.importValidatedRegistrations({
+        validatedImportRecords: validRegistrations,
+        program,
+        userId,
+      });
+
+    // The validator error object may include `index` (row number) and `value`,
+    // but those fields are intentionally omitted from
+    // ImportExistingSubmissionsResultDto.validationErrors.
+    const validationErrorDtos = validationErrors.map((validationError) => ({
+      referenceId: validationError.referenceId,
+      column: validationError.column,
+      error: validationError.error,
+    }));
+
+    const failedReferenceIds = new Set(
+      validationErrorDtos.map((e) => e.referenceId),
+    );
+
+    return {
+      numberOfSubmissionsOnForm,
+      numberOfSubmissionsImported: aggregateImportResult.countImported,
+      numberOfSubmissionsSkipped,
+      numberOfSubmissionsFailed: failedReferenceIds.size,
+      validationErrors: validationErrorDtos,
+    };
+  }
+
+  private assertErrorsHaveReferenceId(
+    errors: ValidateRegistrationErrorObject[],
+  ): asserts errors is (ValidateRegistrationErrorObject & {
+    referenceId: string;
+  })[] {
+    const missing = errors.find((e) => e.referenceId == null);
+    if (missing) {
+      throw new Error(
+        `Expected referenceId on all Kobo validation errors, but column '${missing.column}' had none`,
+      );
+    }
+  }
+}

--- a/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
@@ -246,7 +246,7 @@ describe('KoboSubmissionService', () => {
         count: 2,
         submissions: [mockSubmission, mockSubmission2],
       });
-      koboSubmissionHelperService.getExistingReferenceIds.mockResolvedValue(
+      koboSubmissionHelperService.filterAlreadyExistingSubmissionUuids.mockResolvedValue(
         new Set([successSubmissionUuid]),
       );
       koboSubmissionHelperService.validateAndImportAsRegistrations.mockResolvedValue(
@@ -327,7 +327,7 @@ describe('KoboSubmissionService', () => {
         count: 1,
         submissions: [{ ...mockSubmission, __version__: newerVersionId }],
       });
-      koboSubmissionHelperService.getExistingReferenceIds.mockResolvedValue(
+      koboSubmissionHelperService.filterAlreadyExistingSubmissionUuids.mockResolvedValue(
         new Set(),
       );
       koboSubmissionHelperService.validateAndImportAsRegistrations.mockResolvedValue(
@@ -364,7 +364,7 @@ describe('KoboSubmissionService', () => {
         count: 1,
         submissions: [mockSubmission], // __version__: 'v1' matches stored versionId: 'v1'
       });
-      koboSubmissionHelperService.getExistingReferenceIds.mockResolvedValue(
+      koboSubmissionHelperService.filterAlreadyExistingSubmissionUuids.mockResolvedValue(
         new Set(),
       );
       koboSubmissionHelperService.validateAndImportAsRegistrations.mockResolvedValue(
@@ -394,7 +394,7 @@ describe('KoboSubmissionService', () => {
         submissions: [mockSubmission, mockSubmission2],
       });
       // Both submissions already exist
-      koboSubmissionHelperService.getExistingReferenceIds.mockResolvedValue(
+      koboSubmissionHelperService.filterAlreadyExistingSubmissionUuids.mockResolvedValue(
         new Set([successSubmissionUuid, 'new-submission-uuid']),
       );
       koboSubmissionHelperService.validateAndImportAsRegistrations.mockResolvedValue(
@@ -442,7 +442,7 @@ describe('KoboSubmissionService', () => {
         count: 1,
         submissions: [mockSubmission],
       });
-      koboSubmissionHelperService.getExistingReferenceIds.mockResolvedValue(
+      koboSubmissionHelperService.filterAlreadyExistingSubmissionUuids.mockResolvedValue(
         new Set(),
       );
       koboSubmissionHelperService.validateAndImportAsRegistrations.mockResolvedValue(
@@ -466,7 +466,7 @@ describe('KoboSubmissionService', () => {
         count: 2,
         submissions: [mockSubmission, mockSubmission2],
       });
-      koboSubmissionHelperService.getExistingReferenceIds.mockResolvedValue(
+      koboSubmissionHelperService.filterAlreadyExistingSubmissionUuids.mockResolvedValue(
         new Set([successSubmissionUuid]),
       );
       koboSubmissionHelperService.validateAndImportAsRegistrations.mockResolvedValue(

--- a/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
@@ -5,14 +5,11 @@ import { Repository } from 'typeorm';
 
 import { KoboWebhookIncomingSubmission } from '@121-service/src/kobo/dtos/kobo-webhook-incoming-submission.dto';
 import { KoboEntity } from '@121-service/src/kobo/entities/kobo.entity';
-import { KoboFormDefinition } from '@121-service/src/kobo/interfaces/kobo-form-definition.interface';
-import { KoboService } from '@121-service/src/kobo/services/kobo.service';
 import { KoboApiService } from '@121-service/src/kobo/services/kobo-api.service';
+import { KoboSubmissionHelperService } from '@121-service/src/kobo/services/kobo-submission.helper.service';
 import { KoboSubmissionService } from '@121-service/src/kobo/services/kobo-submission.service';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
-import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { RegistrationsCreationService } from '@121-service/src/registration/services/registrations-creation.service';
-import { RegistrationsInputValidator } from '@121-service/src/registration/validators/registrations-input-validator';
 
 import '@121-service/src/utils/test-helpers/matchers/httpExceptionMatcher';
 
@@ -20,10 +17,8 @@ describe('KoboSubmissionService', () => {
   let service: KoboSubmissionService;
   let koboRepository: jest.Mocked<Repository<KoboEntity>>;
   let koboApiService: jest.Mocked<KoboApiService>;
-  let koboService: jest.Mocked<KoboService>;
   let registrationsCreationService: jest.Mocked<RegistrationsCreationService>;
-  let registrationsInputValidator: jest.Mocked<RegistrationsInputValidator>;
-  let registrationRepository: jest.Mocked<Repository<RegistrationEntity>>;
+  let koboSubmissionHelperService: jest.Mocked<KoboSubmissionHelperService>;
 
   const successSubmissionUuid = 'success-submission-uuid';
   const assetUid = 'test-asset-uid';
@@ -74,6 +69,21 @@ describe('KoboSubmissionService', () => {
     ],
   };
 
+  const mockSubmission2 = {
+    ...mockSubmission,
+    _id: 2,
+    _uuid: 'new-submission-uuid',
+    fullName: 'Jane Doe',
+    nationalId: '987654321',
+    phoneNumber: '+31698765432',
+  };
+
+  const incomingWebhook: KoboWebhookIncomingSubmission = {
+    _uuid: successSubmissionUuid,
+    _xform_id_string: assetUid,
+    __version__: mockKoboEntity.versionId!, // Same version → skips program update
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -93,29 +103,17 @@ describe('KoboSubmissionService', () => {
           },
         },
         {
-          provide: KoboService,
-          useValue: {
-            getFormDefinitionOrThrow: jest.fn(),
-            validateFormAndUpdateProgram: jest.fn(),
-          },
-        },
-        {
           provide: RegistrationsCreationService,
           useValue: {
             importRegistrations: jest.fn(),
-            importValidatedRegistrations: jest.fn(),
           },
         },
         {
-          provide: RegistrationsInputValidator,
+          provide: KoboSubmissionHelperService,
           useValue: {
-            validateAndCleanInput: jest.fn(),
-          },
-        },
-        {
-          provide: getRepositoryToken(RegistrationEntity),
-          useValue: {
-            find: jest.fn(),
+            updateProgramToNewVersionIfApplicable: jest.fn(),
+            getExistingReferenceIds: jest.fn(),
+            validateAndImportAsRegistrations: jest.fn(),
           },
         },
       ],
@@ -124,19 +122,11 @@ describe('KoboSubmissionService', () => {
     service = module.get<KoboSubmissionService>(KoboSubmissionService);
     koboRepository = module.get(getRepositoryToken(KoboEntity));
     koboApiService = module.get(KoboApiService);
-    koboService = module.get(KoboService);
     registrationsCreationService = module.get(RegistrationsCreationService);
-    registrationsInputValidator = module.get(RegistrationsInputValidator);
-    registrationRepository = module.get(getRepositoryToken(RegistrationEntity));
+    koboSubmissionHelperService = module.get(KoboSubmissionHelperService);
   });
 
-  describe('processKoboWebhookCall', () => {
-    const incomingWebhook: KoboWebhookIncomingSubmission = {
-      _uuid: successSubmissionUuid,
-      _xform_id_string: assetUid,
-      __version__: mockKoboEntity.versionId!, // Same version → skips program update
-    };
-
+  describe('when processing a Kobo webhook call', () => {
     it('should successfully process a Kobo webhook and import registration (happy flow)', async () => {
       // Arrange
       koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
@@ -190,19 +180,6 @@ describe('KoboSubmissionService', () => {
   });
 
   describe('handle form version in incoming submission', () => {
-    function buildMockFormDefinition(
-      overrides: Partial<KoboFormDefinition>,
-    ): KoboFormDefinition {
-      return {
-        name: 'Test Form',
-        survey: [],
-        languages: ['English (en)'],
-        dateDeployed: new Date('2025-06-01'),
-        versionId: 'mock-version-id',
-        ...overrides,
-      };
-    }
-
     beforeEach(() => {
       koboApiService.getSubmission.mockResolvedValue(mockSubmission);
       registrationsCreationService.importRegistrations.mockResolvedValue({
@@ -210,23 +187,10 @@ describe('KoboSubmissionService', () => {
       });
     });
 
-    it('should update program when incoming submission has a newer form version', async () => {
+    it('should call helper to update program version', async () => {
       // Arrange
       const newerVersionId = 'mock-id-newer-version';
-      const newerDateDeployed = new Date('2025-06-01');
-      const koboEntityWithOlderVersion = {
-        ...mockKoboEntity,
-        dateDeployed: new Date('2024-01-01'),
-      } as KoboEntity;
-
-      koboRepository.findOne.mockResolvedValue(koboEntityWithOlderVersion);
-      koboService.getFormDefinitionOrThrow.mockResolvedValue(
-        buildMockFormDefinition({
-          dateDeployed: newerDateDeployed,
-          versionId: newerVersionId,
-        }),
-      );
-      koboService.validateFormAndUpdateProgram.mockResolvedValue(undefined);
+      koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
 
       // Act
       await service.processKoboWebhookCall({
@@ -236,60 +200,27 @@ describe('KoboSubmissionService', () => {
       });
 
       // Assert
-      expect(koboService.validateFormAndUpdateProgram).toHaveBeenCalledWith({
-        formDefinition: expect.objectContaining({ versionId: newerVersionId }),
+      expect(
+        koboSubmissionHelperService.updateProgramToNewVersionIfApplicable,
+      ).toHaveBeenCalledWith({
+        currentVersion: mockKoboEntity.versionId,
+        currentVersionDateDeployed: mockKoboEntity.dateDeployed,
+        formVersionFromIncomingSubmission: newerVersionId,
+        assetUid: mockKoboEntity.assetUid,
+        token: mockKoboEntity.token,
+        url: mockKoboEntity.url,
         programId: mockProgram.id,
       });
-      expect(koboRepository.update).toHaveBeenCalledWith(
-        { versionId: mockKoboEntity.versionId },
-        {
-          versionId: newerVersionId,
-          dateDeployed: newerDateDeployed,
-        },
-      );
     });
 
-    it('should not update program when incoming submission has an older form version', async () => {
+    it('should throw and not import when version update fails', async () => {
       // Arrange
-      const olderVersionId = 'mock-id-older-version';
-      koboRepository.findOne.mockResolvedValue({
-        ...mockKoboEntity,
-        dateDeployed: new Date('2025-06-01'), // Current version is newer
-      } as KoboEntity);
-      koboService.getFormDefinitionOrThrow.mockResolvedValue(
-        buildMockFormDefinition({
-          dateDeployed: new Date('2024-01-01'), // Older than current
-          versionId: olderVersionId,
-        }),
-      );
-
-      // Act
-      await service.processKoboWebhookCall({
-        _uuid: successSubmissionUuid,
-        _xform_id_string: assetUid,
-        __version__: olderVersionId,
-      });
-
-      // Assert
-      expect(koboService.validateFormAndUpdateProgram).not.toHaveBeenCalled();
-    });
-
-    it('should throw and not update program when form validation fails', async () => {
-      // Arrange
-      const newerVersionId = 'mock-id-newer-version';
       const validationError = new HttpException(
-        'Kobo form definition validation failed:\n- phoneNumber is missing a label for language English (en)',
+        'Kobo form definition validation failed',
         HttpStatus.BAD_REQUEST,
       );
-
-      koboRepository.findOne.mockResolvedValue({
-        ...mockKoboEntity,
-        dateDeployed: new Date('2024-01-01'),
-      } as KoboEntity);
-      koboService.getFormDefinitionOrThrow.mockResolvedValue(
-        buildMockFormDefinition({ versionId: newerVersionId }),
-      );
-      koboService.validateFormAndUpdateProgram.mockRejectedValue(
+      koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
+      koboSubmissionHelperService.updateProgramToNewVersionIfApplicable.mockRejectedValue(
         validationError,
       );
 
@@ -298,23 +229,16 @@ describe('KoboSubmissionService', () => {
         service.processKoboWebhookCall({
           _uuid: successSubmissionUuid,
           _xform_id_string: assetUid,
-          __version__: newerVersionId,
+          __version__: 'newer-version',
         }),
       ).rejects.toThrow(validationError);
-      expect(koboService.validateFormAndUpdateProgram).toHaveBeenCalled();
+      expect(
+        registrationsCreationService.importRegistrations,
+      ).not.toHaveBeenCalled();
     });
   });
 
-  describe('import existing submissions', () => {
-    const mockSubmission2 = {
-      ...mockSubmission,
-      _id: 2,
-      _uuid: 'new-submission-uuid',
-      fullName: 'Jane Doe',
-      nationalId: '987654321',
-      phoneNumber: '+31698765432',
-    };
-
+  describe('when importing existing submissions', () => {
     it('should successfully import new submissions (happy flow)', async () => {
       // Arrange
       koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
@@ -322,16 +246,16 @@ describe('KoboSubmissionService', () => {
         count: 2,
         submissions: [mockSubmission, mockSubmission2],
       });
-      registrationRepository.find.mockResolvedValue([
-        { referenceId: successSubmissionUuid } as RegistrationEntity,
-      ]);
-      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
-        validRegistrations: [],
-        errors: [],
-      });
-      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
+      koboSubmissionHelperService.getExistingReferenceIds.mockResolvedValue(
+        new Set([successSubmissionUuid]),
+      );
+      koboSubmissionHelperService.validateAndImportAsRegistrations.mockResolvedValue(
         {
-          aggregateImportResult: { countImported: 1 },
+          numberOfSubmissionsOnForm: 2,
+          numberOfSubmissionsImported: 1,
+          numberOfSubmissionsSkipped: 1,
+          numberOfSubmissionsFailed: 0,
+          validationErrors: [],
         },
       );
 
@@ -379,7 +303,6 @@ describe('KoboSubmissionService', () => {
         count: 1001,
         submissions: [],
       });
-      registrationRepository.find.mockResolvedValue([]);
 
       // Act
       let error: any;
@@ -399,28 +322,21 @@ describe('KoboSubmissionService', () => {
     it('should update program when submissions contain a new form version', async () => {
       // Arrange
       const newerVersionId = 'v2';
-      const newerDateDeployed = new Date('2025-06-01');
       koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
       koboApiService.getSubmissionsUpToLimit.mockResolvedValue({
         count: 1,
         submissions: [{ ...mockSubmission, __version__: newerVersionId }],
       });
-      registrationRepository.find.mockResolvedValue([]);
-      koboService.getFormDefinitionOrThrow.mockResolvedValue({
-        name: 'Test Form',
-        survey: [],
-        languages: ['English (en)'],
-        dateDeployed: newerDateDeployed,
-        versionId: newerVersionId,
-      });
-      koboService.validateFormAndUpdateProgram.mockResolvedValue(undefined);
-      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
-        validRegistrations: [],
-        errors: [],
-      });
-      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
+      koboSubmissionHelperService.getExistingReferenceIds.mockResolvedValue(
+        new Set(),
+      );
+      koboSubmissionHelperService.validateAndImportAsRegistrations.mockResolvedValue(
         {
-          aggregateImportResult: { countImported: 1 },
+          numberOfSubmissionsOnForm: 1,
+          numberOfSubmissionsImported: 1,
+          numberOfSubmissionsSkipped: 0,
+          numberOfSubmissionsFailed: 0,
+          validationErrors: [],
         },
       );
 
@@ -428,14 +344,17 @@ describe('KoboSubmissionService', () => {
       await service.importExistingSubmissions({ programId: 1, userId: 42 });
 
       // Assert
-      expect(koboService.validateFormAndUpdateProgram).toHaveBeenCalledWith({
-        formDefinition: expect.objectContaining({ versionId: newerVersionId }),
+      expect(
+        koboSubmissionHelperService.updateProgramToNewVersionIfApplicable,
+      ).toHaveBeenCalledWith({
+        currentVersion: mockKoboEntity.versionId,
+        currentVersionDateDeployed: mockKoboEntity.dateDeployed,
+        formVersionFromIncomingSubmission: newerVersionId,
+        assetUid: mockKoboEntity.assetUid,
+        token: mockKoboEntity.token,
+        url: mockKoboEntity.url,
         programId: mockProgram.id,
       });
-      expect(koboRepository.update).toHaveBeenCalledWith(
-        { versionId: mockKoboEntity.versionId },
-        { versionId: newerVersionId, dateDeployed: newerDateDeployed },
-      );
     });
 
     it('should not update program when all submissions have the current form version', async () => {
@@ -445,14 +364,16 @@ describe('KoboSubmissionService', () => {
         count: 1,
         submissions: [mockSubmission], // __version__: 'v1' matches stored versionId: 'v1'
       });
-      registrationRepository.find.mockResolvedValue([]);
-      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
-        validRegistrations: [],
-        errors: [],
-      });
-      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
+      koboSubmissionHelperService.getExistingReferenceIds.mockResolvedValue(
+        new Set(),
+      );
+      koboSubmissionHelperService.validateAndImportAsRegistrations.mockResolvedValue(
         {
-          aggregateImportResult: { countImported: 0 },
+          numberOfSubmissionsOnForm: 1,
+          numberOfSubmissionsImported: 0,
+          numberOfSubmissionsSkipped: 0,
+          numberOfSubmissionsFailed: 0,
+          validationErrors: [],
         },
       );
 
@@ -460,8 +381,9 @@ describe('KoboSubmissionService', () => {
       await service.importExistingSubmissions({ programId: 1, userId: 42 });
 
       // Assert
-      expect(koboService.getFormDefinitionOrThrow).not.toHaveBeenCalled();
-      expect(koboService.validateFormAndUpdateProgram).not.toHaveBeenCalled();
+      expect(
+        koboSubmissionHelperService.updateProgramToNewVersionIfApplicable,
+      ).not.toHaveBeenCalled();
     });
 
     it('should filter out already existing registrations', async () => {
@@ -472,17 +394,16 @@ describe('KoboSubmissionService', () => {
         submissions: [mockSubmission, mockSubmission2],
       });
       // Both submissions already exist
-      registrationRepository.find.mockResolvedValue([
-        { referenceId: successSubmissionUuid } as RegistrationEntity,
-        { referenceId: 'new-submission-uuid' } as RegistrationEntity,
-      ]);
-      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
-        validRegistrations: [],
-        errors: [],
-      });
-      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
+      koboSubmissionHelperService.getExistingReferenceIds.mockResolvedValue(
+        new Set([successSubmissionUuid, 'new-submission-uuid']),
+      );
+      koboSubmissionHelperService.validateAndImportAsRegistrations.mockResolvedValue(
         {
-          aggregateImportResult: { countImported: 0 },
+          numberOfSubmissionsOnForm: 2,
+          numberOfSubmissionsImported: 0,
+          numberOfSubmissionsSkipped: 2,
+          numberOfSubmissionsFailed: 0,
+          validationErrors: [],
         },
       );
 
@@ -491,40 +412,41 @@ describe('KoboSubmissionService', () => {
 
       // Assert
       expect(
-        registrationsInputValidator.validateAndCleanInput,
+        koboSubmissionHelperService.validateAndImportAsRegistrations,
       ).toHaveBeenCalledWith({
-        registrationInputArray: [],
-        programId: mockProgram.id,
+        registrationDataArray: [],
+        program: mockProgram,
         userId: 42,
-        typeOfInput: 'create',
-        validationConfig: {
-          validateExistingReferenceId: true,
-        },
+        numberOfSubmissionsOnForm: 2,
+        numberOfSubmissionsSkipped: 2,
       });
     });
 
-    it('should populate validationErrors when a submission fails validation', async () => {
+    it('should return result from import service with validation errors', async () => {
       // Arrange
+      const expectedResult = {
+        numberOfSubmissionsOnForm: 1,
+        numberOfSubmissionsImported: 0,
+        numberOfSubmissionsSkipped: 0,
+        numberOfSubmissionsFailed: 1,
+        validationErrors: [
+          {
+            referenceId: successSubmissionUuid,
+            column: 'programFspConfigurationName',
+            error: 'FspConfigurationName Invalid-FSP not found in program.',
+          },
+        ],
+      };
       koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
       koboApiService.getSubmissionsUpToLimit.mockResolvedValue({
         count: 1,
         submissions: [mockSubmission],
       });
-      registrationRepository.find.mockResolvedValue([]);
-      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
-        validRegistrations: [],
-        errors: [
-          {
-            index: 0,
-            referenceId: successSubmissionUuid,
-            column: 'programFspConfigurationName',
-            error: 'FspConfigurationName Invalid-FSP not found in program.',
-            value: 'Invalid-FSP',
-          },
-        ],
-      });
-      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
-        { aggregateImportResult: { countImported: 0 } },
+      koboSubmissionHelperService.getExistingReferenceIds.mockResolvedValue(
+        new Set(),
+      );
+      koboSubmissionHelperService.validateAndImportAsRegistrations.mockResolvedValue(
+        expectedResult,
       );
 
       // Act
@@ -534,78 +456,51 @@ describe('KoboSubmissionService', () => {
       });
 
       // Assert
-      expect(result.validationErrors).toEqual([
-        {
-          referenceId: successSubmissionUuid,
-          column: 'programFspConfigurationName',
-          error: 'FspConfigurationName Invalid-FSP not found in program.',
-        },
-      ]);
+      expect(result).toEqual(expectedResult);
     });
 
-    it('should exclude failed submissions from numberOfSubmissionsImported and count them in numberOfSubmissionsFailed', async () => {
+    it('should pass mapped registration data and counts to import service', async () => {
       // Arrange
       koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
       koboApiService.getSubmissionsUpToLimit.mockResolvedValue({
         count: 2,
         submissions: [mockSubmission, mockSubmission2],
       });
-      registrationRepository.find.mockResolvedValue([]);
-      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
-        validRegistrations: [],
-        errors: [
-          {
-            index: 0,
-            referenceId: successSubmissionUuid,
-            column: 'programFspConfigurationName',
-            error: 'FspConfigurationName Invalid-FSP not found in program.',
-            value: 'Invalid-FSP',
-          },
-        ],
-      });
-      registrationsCreationService.importValidatedRegistrations.mockResolvedValue(
-        { aggregateImportResult: { countImported: 1 } },
+      koboSubmissionHelperService.getExistingReferenceIds.mockResolvedValue(
+        new Set([successSubmissionUuid]),
+      );
+      koboSubmissionHelperService.validateAndImportAsRegistrations.mockResolvedValue(
+        {
+          numberOfSubmissionsOnForm: 2,
+          numberOfSubmissionsImported: 1,
+          numberOfSubmissionsSkipped: 1,
+          numberOfSubmissionsFailed: 0,
+          validationErrors: [],
+        },
       );
 
       // Act
-      const result = await service.importExistingSubmissions({
-        programId: 1,
-        userId: 42,
-      });
+      await service.importExistingSubmissions({ programId: 1, userId: 42 });
 
       // Assert
-      expect(result.numberOfSubmissionsImported).toBe(1);
-      expect(result.numberOfSubmissionsFailed).toBe(1);
-      expect(result.numberOfSubmissionsOnForm).toBe(2);
-    });
-
-    it('should throw when a validation error has no referenceId', async () => {
-      // Arrange
-      koboRepository.findOne.mockResolvedValue(mockKoboEntity as KoboEntity);
-      koboApiService.getSubmissionsUpToLimit.mockResolvedValue({
-        count: 1,
-        submissions: [mockSubmission],
-      });
-      registrationRepository.find.mockResolvedValue([]);
-      registrationsInputValidator.validateAndCleanInput.mockResolvedValue({
-        validRegistrations: [],
-        errors: [
+      expect(
+        koboSubmissionHelperService.validateAndImportAsRegistrations,
+      ).toHaveBeenCalledWith({
+        registrationDataArray: [
           {
-            index: 0,
-            referenceId: undefined,
-            column: 'phoneNumber',
-            error: 'Value is not valid',
-            value: 'invalid',
+            referenceId: 'new-submission-uuid',
+            programFspConfigurationName: fspName,
+            fullName: 'Jane Doe',
+            nationalId: '987654321',
+            phoneNumber: '+31698765432',
+            photo: photoDownloadUrl,
           },
         ],
+        program: mockProgram,
+        userId: 42,
+        numberOfSubmissionsOnForm: 2,
+        numberOfSubmissionsSkipped: 1,
       });
-
-      // Act & Assert
-      await expect(
-        service.importExistingSubmissions({ programId: 1, userId: 42 }),
-      ).rejects.toThrow(
-        "Expected referenceId on all Kobo validation errors, but column 'phoneNumber' had none",
-      );
     });
   });
 });

--- a/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
@@ -112,7 +112,7 @@ describe('KoboSubmissionService', () => {
           provide: KoboSubmissionHelperService,
           useValue: {
             updateProgramToNewVersionIfApplicable: jest.fn(),
-            getExistingReferenceIds: jest.fn(),
+            filterAlreadyExistingSubmissionUuids: jest.fn(),
             validateAndImportAsRegistrations: jest.fn(),
           },
         },

--- a/services/121-service/src/kobo/services/kobo-submission.service.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.ts
@@ -1,37 +1,27 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Equal, In, Repository } from 'typeorm';
+import { Equal, Repository } from 'typeorm';
 
-import { IS_DEVELOPMENT } from '@121-service/src/config';
 import { ImportExistingSubmissionsResultDto } from '@121-service/src/kobo/dtos/import-existing-submissions-result.dto';
 import { KoboWebhookIncomingSubmission } from '@121-service/src/kobo/dtos/kobo-webhook-incoming-submission.dto';
 import { KoboEntity } from '@121-service/src/kobo/entities/kobo.entity';
-import { KoboRegistrationInput } from '@121-service/src/kobo/interfaces/kobo-registration-input.interface';
 import { KoboSubmissionMapper } from '@121-service/src/kobo/mappers/kobo-submission.mapper';
-import { KoboService } from '@121-service/src/kobo/services/kobo.service';
 import { KoboApiService } from '@121-service/src/kobo/services/kobo-api.service';
-import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
-import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
-import { RegistrationValidationInputType } from '@121-service/src/registration/enum/registration-validation-input-type.enum';
-import { ValidateRegistrationErrorObject } from '@121-service/src/registration/interfaces/validate-registration-error-object.interface';
+import { KoboSubmissionHelperService } from '@121-service/src/kobo/services/kobo-submission.helper.service';
 import {
   MAX_IMPORT_RECORDS,
   RegistrationsCreationService,
 } from '@121-service/src/registration/services/registrations-creation.service';
-import { RegistrationsInputValidator } from '@121-service/src/registration/validators/registrations-input-validator';
 
 @Injectable()
 export class KoboSubmissionService {
   @InjectRepository(KoboEntity)
   private readonly koboRepository: Repository<KoboEntity>;
-  @InjectRepository(RegistrationEntity)
-  private readonly registrationRepository: Repository<RegistrationEntity>;
 
   constructor(
     private readonly koboApiService: KoboApiService,
-    private readonly koboService: KoboService,
     private readonly registrationsCreationService: RegistrationsCreationService,
-    private readonly registrationsInputValidator: RegistrationsInputValidator,
+    private readonly koboSubmissionHelperService: KoboSubmissionHelperService,
   ) {}
 
   public async processKoboWebhookCall(
@@ -53,16 +43,18 @@ export class KoboSubmissionService {
     });
     this.assertKoboIntegrationExistsOrThrow(koboIntegration);
 
-    await this.updateProgramToNewVersionIfApplicable({
-      currentVersion: koboIntegration.versionId,
-      currentVersionDateDeployed: koboIntegration.dateDeployed,
-      formVersionFromIncomingSubmission:
-        koboWebhookIncomingSubmission.__version__,
-      assetUid: koboIntegration.assetUid,
-      token: koboIntegration.token,
-      url: koboIntegration.url,
-      programId: koboIntegration.program.id,
-    });
+    await this.koboSubmissionHelperService.updateProgramToNewVersionIfApplicable(
+      {
+        currentVersion: koboIntegration.versionId,
+        currentVersionDateDeployed: koboIntegration.dateDeployed,
+        formVersionFromIncomingSubmission:
+          koboWebhookIncomingSubmission.__version__,
+        assetUid: koboIntegration.assetUid,
+        token: koboIntegration.token,
+        url: koboIntegration.url,
+        programId: koboIntegration.program.id,
+      },
+    );
 
     const submission = await this.koboApiService.getSubmission({
       token: koboIntegration.token,
@@ -123,22 +115,26 @@ export class KoboSubmissionService {
     );
 
     if (submissionWithDifferentVersion) {
-      await this.updateProgramToNewVersionIfApplicable({
-        currentVersion: koboIntegration.versionId,
-        currentVersionDateDeployed: koboIntegration.dateDeployed,
-        formVersionFromIncomingSubmission:
-          submissionWithDifferentVersion.__version__,
-        assetUid: koboIntegration.assetUid,
-        token: koboIntegration.token,
-        url: koboIntegration.url,
-        programId: koboIntegration.program.id,
-      });
+      await this.koboSubmissionHelperService.updateProgramToNewVersionIfApplicable(
+        {
+          currentVersion: koboIntegration.versionId,
+          currentVersionDateDeployed: koboIntegration.dateDeployed,
+          formVersionFromIncomingSubmission:
+            submissionWithDifferentVersion.__version__,
+          assetUid: koboIntegration.assetUid,
+          token: koboIntegration.token,
+          url: koboIntegration.url,
+          programId: koboIntegration.program.id,
+        },
+      );
     }
 
     const submissionUuids = submissions.map((s) => s._uuid);
 
     const existingReferenceIds =
-      await this.getExistingReferenceIds(submissionUuids);
+      await this.koboSubmissionHelperService.getExistingReferenceIds(
+        submissionUuids,
+      );
 
     const newSubmissions = submissions.filter(
       (submission) => !existingReferenceIds.has(submission._uuid),
@@ -150,95 +146,13 @@ export class KoboSubmissionService {
       }),
     );
 
-    return this.validateImportAndBuildResult({
+    return this.koboSubmissionHelperService.validateAndImportAsRegistrations({
       registrationDataArray,
       program: koboIntegration.program,
       userId,
       numberOfSubmissionsOnForm: count,
       numberOfSubmissionsSkipped: existingReferenceIds.size,
     });
-  }
-
-  private async validateImportAndBuildResult({
-    registrationDataArray,
-    program,
-    userId,
-    numberOfSubmissionsOnForm,
-    numberOfSubmissionsSkipped,
-  }: {
-    registrationDataArray: KoboRegistrationInput[];
-    program: ProgramEntity;
-    userId: number;
-    numberOfSubmissionsOnForm: number;
-    numberOfSubmissionsSkipped: number;
-  }): Promise<ImportExistingSubmissionsResultDto> {
-    const { validRegistrations, errors: validationErrors } =
-      await this.registrationsInputValidator.validateAndCleanInput({
-        registrationInputArray: registrationDataArray,
-        programId: program.id,
-        userId,
-        typeOfInput: RegistrationValidationInputType.create,
-        validationConfig: {
-          validateExistingReferenceId: true,
-        },
-      });
-
-    // Kobo submissions always have a referenceId (derived from the Kobo _uuid).
-    // The shared validator types it as optional because other callers (e.g. CSV
-    // import) may not provide one. This assertion narrows the type so downstream
-    // code can rely on referenceId being present.
-    this.assertErrorsHaveReferenceId(validationErrors);
-
-    const { aggregateImportResult } =
-      await this.registrationsCreationService.importValidatedRegistrations({
-        validatedImportRecords: validRegistrations,
-        program,
-        userId,
-      });
-
-    const validationErrorDtos = validationErrors.map((validationError) => ({
-      referenceId: validationError.referenceId,
-      column: validationError.column,
-      error: validationError.error,
-    }));
-
-    const failedReferenceIds = new Set(
-      validationErrorDtos.map((e) => e.referenceId),
-    );
-
-    return {
-      numberOfSubmissionsOnForm,
-      numberOfSubmissionsImported: aggregateImportResult.countImported,
-      numberOfSubmissionsSkipped,
-      numberOfSubmissionsFailed: failedReferenceIds.size,
-      validationErrors: validationErrorDtos,
-    };
-  }
-
-  private async getExistingReferenceIds(
-    referenceIds: string[],
-  ): Promise<Set<string>> {
-    if (referenceIds.length === 0) {
-      return new Set();
-    }
-    const registrations = await this.registrationRepository.find({
-      where: { referenceId: In(referenceIds) },
-      select: { referenceId: true },
-    });
-    return new Set(registrations.map((r) => r.referenceId));
-  }
-
-  private assertErrorsHaveReferenceId(
-    errors: ValidateRegistrationErrorObject[],
-  ): asserts errors is (ValidateRegistrationErrorObject & {
-    referenceId: string;
-  })[] {
-    const missing = errors.find((e) => e.referenceId == null);
-    if (missing) {
-      throw new Error(
-        `Expected referenceId on all Kobo validation errors, but column '${missing.column}' had none`,
-      );
-    }
   }
 
   private assertKoboIntegrationExistsOrThrow<T extends Partial<KoboEntity>>(
@@ -250,67 +164,5 @@ export class KoboSubmissionService {
         HttpStatus.NOT_FOUND,
       );
     }
-  }
-
-  private async updateProgramToNewVersionIfApplicable({
-    currentVersion,
-    currentVersionDateDeployed,
-    formVersionFromIncomingSubmission,
-    assetUid,
-    token,
-    url,
-    programId,
-  }: {
-    currentVersion: string;
-    currentVersionDateDeployed: Date;
-    formVersionFromIncomingSubmission: string;
-    assetUid: string;
-    token: string;
-    url: string;
-    programId: number;
-  }): Promise<void> {
-    if (currentVersion === formVersionFromIncomingSubmission) {
-      return;
-    }
-
-    if (IS_DEVELOPMENT) {
-      // The mock service is stateless and cannot serve multiple real Kobo form versions.
-      // Integration tests encode the target mock asset UID in __version__ so this service
-      // fetches the correct mock asset instead of the original one.
-      if (formVersionFromIncomingSubmission.includes('asset-')) {
-        assetUid = `asset-${formVersionFromIncomingSubmission.split('asset-')[1]}`;
-      }
-    }
-
-    const formDefinition = await this.koboService.getFormDefinitionOrThrow({
-      assetUid,
-      token,
-      url,
-    });
-
-    // We would expect that most of the time, the incoming submission will be for the same version as the current one, or for a newer version.
-    // But in case we receive a submission for an older version (e.g. because Kobo is retrying to send us a submission that previously failed),
-    // We do not update the program to the older version to prevent for example removing the program languages that were added
-    // We allow the submission to proceed as normal, in case there any required attributes in the older version that are not in the program
-    // an error will be thrown during the registration creation which show up in the kobo rest api service and it has to be resolved by a human
-    const formDeployedDateOfIncomingSubmission = new Date(
-      formDefinition.dateDeployed,
-    );
-    if (formDeployedDateOfIncomingSubmission < currentVersionDateDeployed) {
-      return;
-    }
-
-    await this.koboService.validateFormAndUpdateProgram({
-      formDefinition,
-      programId,
-    });
-
-    await this.koboRepository.update(
-      { versionId: currentVersion },
-      {
-        versionId: formVersionFromIncomingSubmission,
-        dateDeployed: formDeployedDateOfIncomingSubmission,
-      },
-    );
   }
 }

--- a/services/121-service/src/kobo/services/kobo-submission.service.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.ts
@@ -132,7 +132,7 @@ export class KoboSubmissionService {
     const submissionUuids = submissions.map((s) => s._uuid);
 
     const existingReferenceIds =
-      await this.koboSubmissionHelperService.getExistingReferenceIds(
+      await this.koboSubmissionHelperService.filterAlreadyExistingSubmissionUuids(
         submissionUuids,
       );
 

--- a/services/121-service/src/registration/repositories/registration-scoped.repository.ts
+++ b/services/121-service/src/registration/repositories/registration-scoped.repository.ts
@@ -5,7 +5,6 @@ import {
   DeleteResult,
   Equal,
   FindOptionsWhere,
-  In,
   InsertResult,
   ObjectId,
   RemoveOptions,
@@ -167,23 +166,6 @@ export class RegistrationScopedRepository extends RegistrationScopedBaseReposito
       },
       relations,
     });
-  }
-
-  public async getExistingReferenceIds({
-    programId,
-    referenceIds,
-  }: {
-    programId: number;
-    referenceIds: string[];
-  }): Promise<Set<string>> {
-    if (referenceIds.length === 0) {
-      return new Set();
-    }
-    const registrations = await this.repository.find({
-      where: { programId: Equal(programId), referenceId: In(referenceIds) },
-      select: { referenceId: true },
-    });
-    return new Set(registrations.map((r) => r.referenceId));
   }
 
   public async getDuplicates({


### PR DESCRIPTION
[AB#41617](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/41617) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Split `KoboSubmissionService` into two services to improve testability and separation of concerns:

- **`KoboSubmissionService`** — retains the high-level orchestration: fetching the Kobo integration, calling the API, mapping submissions, and delegating import.
- **`KoboSubmissionHelperService`** (new) — extracted logic for program version updates, checking existing reference IDs, and the validate-and-import flow for existing submissions. This service owns the `RegistrationsInputValidator` and `RegistrationsCreationService` dependencies, making each service easier to mock and test in isolation.

Updated and split the unit tests accordingly, adding dedicated specs for the helper service.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
