### PR TITLE
chore(deps): Pin GitHub Actions to specific commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     schedule:
       interval: monthly
       day: tuesday
+    cooldown:
+      default-days: 8
 
   - directory: '/'
     commit-message:

--- a/.github/workflows/deploy_test_portal.yml
+++ b/.github/workflows/deploy_test_portal.yml
@@ -116,7 +116,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Add Deployment URL to PR Description
-        uses: nefrob/pr-description@v1.2.0
+        uses: nefrob/pr-description@4dcc9f3ad5ec06b2a197c5f8f93db5e69d2fdca7
         with:
           content: ${{ needs.test.outputs.preview_url }}
           regex: '<!-- start deployment url -->.*?<!-- end deployment url -->'

--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Docker logs
         if: always()
-        uses: jwalton/gh-docker-logs@v2
+        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e
 
   # This job is here to make the above jobs "required" in GitHub.
   # This is a workaround for this issue: https://github.com/orgs/community/discussions/44490

--- a/.github/workflows/test_interface_portal.yml
+++ b/.github/workflows/test_interface_portal.yml
@@ -73,7 +73,8 @@ jobs:
         working-directory: ${{ env.interfacePath }}
         run: 'npm run test:coverage'
 
-      - uses: qltysh/qlty-action/coverage@v2
+      - name: 'Upload coverage report to QLTY'
+        uses: qltysh/qlty-action/coverage@3bb7beb615879bb26aa12c9540889f9ef6cb1c85
         with:
           oidc: true
           add-prefix: ${{ env.interfacePath }}

--- a/.github/workflows/test_jest_performance_cronjob.yml
+++ b/.github/workflows/test_jest_performance_cronjob.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Docker logs
         if: always()
-        uses: jwalton/gh-docker-logs@v2
+        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e
 
   performance-test-shard-resolution:
     runs-on: ubuntu-latest
@@ -120,7 +120,7 @@ jobs:
 
       - name: Microsoft Teams Notification
         if: always()
-        uses: tlolkema/simple-teams-message@main
+        uses: tlolkema/simple-teams-message@18ffc37b4253de8243ff28318ac51abccdacd024
         env:
           JOB_STATUS_WITH_NICE_EMOJI: ${{ job.status == 'success' && '✅ Success' || '❌ Failed' }}
         with:

--- a/.github/workflows/test_service_api.yml
+++ b/.github/workflows/test_service_api.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Docker logs
         if: always()
-        uses: jwalton/gh-docker-logs@v2
+        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e
 
   test:
     runs-on: ubuntu-latest
@@ -167,7 +167,7 @@ jobs:
       # Coverage reports will be merged automatically by QLTY
       # See: https://docs.qlty.sh/coverage/merging#client-side-merging
       - name: Upload all coverage reports to QLTY
-        uses: qltysh/qlty-action/coverage@v2
+        uses: qltysh/qlty-action/coverage@3bb7beb615879bb26aa12c9540889f9ef6cb1c85
         with:
           command: publish
           oidc: true

--- a/.github/workflows/test_service_api.yml
+++ b/.github/workflows/test_service_api.yml
@@ -87,7 +87,9 @@ jobs:
       - name: Generate Coverage-report from 121-service
         working-directory: ${{ env.workingDirectory }}
         run: |
-          curl --data '{"secret":"${{ env.RESET_SECRET }}"}' --header "Content-Type: application/json" --request POST '${{ env.EXTERNAL_121_SERVICE_URL }}/api/test/kill-service' || true
+          curl --data "{\"secret\":\"$RESET_SECRET\"}" \
+               --header "Content-Type: application/json" \
+               --request POST "$EXTERNAL_121_SERVICE_URL/api/test/kill-service" || true
           docker compose exec 121-service npm run coverage:report:integration
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/test_service_check_migrations.yml
+++ b/.github/workflows/test_service_check_migrations.yml
@@ -54,4 +54,4 @@ jobs:
 
       - name: Docker logs
         if: always()
-        uses: jwalton/gh-docker-logs@v2
+        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e

--- a/.github/workflows/test_service_only_restart.yml
+++ b/.github/workflows/test_service_only_restart.yml
@@ -67,4 +67,4 @@ jobs:
 
       - name: Docker logs
         if: always()
-        uses: jwalton/gh-docker-logs@v2
+        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e

--- a/.github/workflows/test_workflows.yml
+++ b/.github/workflows/test_workflows.yml
@@ -28,7 +28,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Lint GitHub Action workflows
-        uses: raven-actions/actionlint@v2
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8
         with:
           group-result: false
           shellcheck: true
@@ -36,7 +36,7 @@ jobs:
           flags: '-ignore SC2086'
 
       - name: Lint .env files
-        uses: dotenv-linter/action-dotenv-linter@v3
+        uses: dotenv-linter/action-dotenv-linter@afde61cfda2ecffe7bea35837b6f20b956c88689
         with:
           reporter: github-code-suggestions
           dotenv_linter_flags: --ignore-checks UnorderedKey


### PR DESCRIPTION
See [AB#41651](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/41651)

Only "external party" GitHub Actions are being pinned to specific `sha` hashes.

As we think the GitHub/Azure-supported/provided ones are less of a risk and would cause too much 'churn' in new updates and checking of changes.

--

Also: fix some syntax that warned/complained about potentially undefined ENV-variables in the workflow-environment.


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8144.westeurope.3.azurestaticapps.net
