### PR TITLE
fix: Skip hostname-check on CBE-connections (to accept new certificate)

### DIFF
--- a/services/121-service/src/fsp-integrations/integrations/commercial-bank-ethiopia/services/commercial-bank-ethiopia-api-client.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/integrations/commercial-bank-ethiopia/services/commercial-bank-ethiopia-api-client.service.spec.ts
@@ -75,9 +75,21 @@ describe('CommercialBankEthiopiaApiClientService', () => {
       new CommercialBankEthiopiaApiClientService(httpService);
 
       // Assert
+      // Unfortunately we can't directly check the creation of the default https.Agent since it's private and
+      // we therefore have to test the internal working of this method to see if createHttpsAgentWithWeakSelfSignedCertificateOnly is called or not
       expect(
         httpService.createHttpsAgentWithWeakSelfSignedCertificateOnly,
-      ).toHaveBeenCalledWith(certificatePath, { keepAlive: true }); // Unfortunately we can't directly check the creation of the default https.Agent since it's private and we therefore have to test the internal working of this method to see if createHttpsAgentWithWeakSelfSignedCertificateOnly is called or not
+      ).toHaveBeenCalledWith(certificatePath, {
+        keepAlive: true,
+        checkServerIdentity: expect.any(Function),
+      });
+
+      const [, options] = (
+        httpService.createHttpsAgentWithWeakSelfSignedCertificateOnly as jest.Mock
+      ).mock.calls[0];
+      expect(
+        options.checkServerIdentity('any-host.example.test', {} as unknown),
+      ).toBeUndefined();
     });
 
     it('should create a default HTTPS agent when mode is external but certificate path is not provided', () => {

--- a/services/121-service/src/fsp-integrations/integrations/commercial-bank-ethiopia/services/commercial-bank-ethiopia-api-client.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/commercial-bank-ethiopia/services/commercial-bank-ethiopia-api-client.service.ts
@@ -46,7 +46,13 @@ export class CommercialBankEthiopiaApiClientService implements OnModuleDestroy {
     ) {
       return this.httpService.createHttpsAgentWithWeakSelfSignedCertificateOnly(
         env.COMMERCIAL_BANK_ETHIOPIA_CERTIFICATE_PATH,
-        cbeConnectionConfig,
+        {
+          ...cbeConnectionConfig,
+          //
+          // NOTE: By NEVER returning _any_ error, we 'skip' hostname verification. As its certificate's name does not match its API's hostname.
+          // This is (unfortunately) required. However, since we are ALSO using a VPN-tunnel directly with CBE, this risk is acceptable.
+          checkServerIdentity: () => undefined,
+        },
       );
     }
     // Use a 'default' https agent for Mock mode and for CBE Acceptance environment, without certificate


### PR DESCRIPTION
[AB#41682](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/41682)

## Describe your changes

We verify the (self-signed) certificate, but we make the "hostname identity-check" always pass.


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] I have updated tests for my changes
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
