### PR TITLE
chore: upgrade swagger to update vulnerable dependency of lodash

### DIFF
--- a/services/121-service/package-lock.json
+++ b/services/121-service/package-lock.json
@@ -15,7 +15,7 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.1.18",
         "@nestjs/schedule": "^6.1.1",
-        "@nestjs/swagger": "^11.2.6",
+        "@nestjs/swagger": "^11.2.7",
         "@nestjs/terminus": "^11.1.1",
         "@nestjs/testing": "^11.1.18",
         "@nestjs/throttler": "^6.5.0",
@@ -3452,25 +3452,15 @@
         }
       }
     },
-    "node_modules/@nestjs/core/node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/@nestjs/mapped-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
-      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
       "license": "MIT",
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "class-transformer": "^0.4.0 || ^0.5.0",
-        "class-validator": "^0.13.0 || ^0.14.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
         "reflect-metadata": "^0.1.12 || ^0.2.0"
       },
       "peerDependenciesMeta": {
@@ -3511,16 +3501,6 @@
       "peerDependencies": {
         "@nestjs/common": "^11.0.0",
         "@nestjs/core": "^11.0.0"
-      }
-    },
-    "node_modules/@nestjs/platform-express/node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@nestjs/schedule": {
@@ -3611,17 +3591,17 @@
       }
     },
     "node_modules/@nestjs/swagger": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.6.tgz",
-      "integrity": "sha512-oiXOxMQqDFyv1AKAqFzSo6JPvMEs4uA36Eyz/s2aloZLxUjcLfUMELSLSNQunr61xCPTpwEOShfmO7NIufKXdA==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.7.tgz",
+      "integrity": "sha512-+e1KWSyZMAQeyZ8nbQSvm3fhzqdxxBNQENvpjO2dVyD7KJmLTTQyXpRb1nM5O04oFdDTUtG3SHMl4+e+zgCK2A==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "0.16.0",
-        "@nestjs/mapped-types": "2.1.0",
+        "@nestjs/mapped-types": "2.1.1",
         "js-yaml": "4.1.1",
-        "lodash": "4.17.23",
-        "path-to-regexp": "8.3.0",
-        "swagger-ui-dist": "5.31.0"
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.2"
       },
       "peerDependencies": {
         "@fastify/static": "^8.0.0 || ^9.0.0",
@@ -3642,12 +3622,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@nestjs/swagger/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
     },
     "node_modules/@nestjs/terminus": {
       "version": "11.1.1",
@@ -14837,9 +14811,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -16916,9 +16890,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
-      "integrity": "sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==",
+      "version": "5.32.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.2.tgz",
+      "integrity": "sha512-t6Ns52nS8LU2hqi0+rezMjFO1ZrCsCrnommXrU7Nfrg2va2dWahdvM6TuSwzdHpG29v6BHJyU1c/UWFhgVZzVQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"

--- a/services/121-service/package.json
+++ b/services/121-service/package.json
@@ -65,7 +65,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.18",
     "@nestjs/schedule": "^6.1.1",
-    "@nestjs/swagger": "^11.2.6",
+    "@nestjs/swagger": "^11.2.7",
     "@nestjs/terminus": "^11.1.1",
     "@nestjs/testing": "^11.1.18",
     "@nestjs/throttler": "^6.5.0",

--- a/services/121-service/test/payment/payment-in-progress.test.ts
+++ b/services/121-service/test/payment/payment-in-progress.test.ts
@@ -42,19 +42,6 @@ import {
 
 const transferValue = 25;
 
-// Use file-local reference IDs to avoid conflicts with parallel test files
-// that seed the same registrations from the shared fixture.
-const registrationsPV = [
-  {
-    ...registrationNotScopedPv,
-    referenceId: 'payment-in-progress-not-scoped-pv',
-  },
-  {
-    ...registrationScopedTurkanaNorthPv,
-    referenceId: 'payment-in-progress-scoped-turkana-north-pv',
-  },
-];
-
 // const function to validate whether payement are in progress for multiple endpoints
 const getPaymentProgressStatusForMultipleEndpoints = async ({
   programId,
@@ -100,6 +87,11 @@ const getPaymentProgressStatusForMultipleEndpoints = async ({
     retryPaymentBlocked: is4xxStatus(retryPaymentResponse.status),
   };
 };
+
+const registrationsPV = [
+  registrationNotScopedPv,
+  registrationScopedTurkanaNorthPv,
+];
 
 describe('Payment in progress', () => {
   let accessToken: string;
@@ -397,22 +389,19 @@ describe('Payment in progress', () => {
       await getProgramPaymentsStatus(programIdOCW, accessToken)
     ).body;
 
-    // Check blocked endpoints while the payment is still in progress,
-    // before doing the OCW payment (which takes multiple async calls and
-    // would give the PV payment time to complete).
-    const multiEndpointPaymentProgressPv =
-      await getPaymentProgressStatusForMultipleEndpoints({
-        programId: programIdPV,
-        accessToken,
-        paymentId: paymentIdPv,
-      });
-
     const doPaymentOcwResultPaymentNext = await doPayment({
       programId: programIdOCW,
       transferValue,
       referenceIds: [],
       accessToken,
     });
+
+    const multiEndpointPaymentProgressPv =
+      await getPaymentProgressStatusForMultipleEndpoints({
+        programId: programIdPV,
+        accessToken,
+        paymentId: paymentIdPv,
+      });
 
     // Assert
     expect(getProgramPaymentsPvResult.inProgress).toBe(true);

--- a/services/121-service/test/payment/payment-in-progress.test.ts
+++ b/services/121-service/test/payment/payment-in-progress.test.ts
@@ -42,6 +42,19 @@ import {
 
 const transferValue = 25;
 
+// Use file-local reference IDs to avoid conflicts with parallel test files
+// that seed the same registrations from the shared fixture.
+const registrationsPV = [
+  {
+    ...registrationNotScopedPv,
+    referenceId: 'payment-in-progress-not-scoped-pv',
+  },
+  {
+    ...registrationScopedTurkanaNorthPv,
+    referenceId: 'payment-in-progress-scoped-turkana-north-pv',
+  },
+];
+
 // const function to validate whether payement are in progress for multiple endpoints
 const getPaymentProgressStatusForMultipleEndpoints = async ({
   programId,
@@ -87,11 +100,6 @@ const getPaymentProgressStatusForMultipleEndpoints = async ({
     retryPaymentBlocked: is4xxStatus(retryPaymentResponse.status),
   };
 };
-
-const registrationsPV = [
-  registrationNotScopedPv,
-  registrationScopedTurkanaNorthPv,
-];
 
 describe('Payment in progress', () => {
   let accessToken: string;
@@ -389,19 +397,22 @@ describe('Payment in progress', () => {
       await getProgramPaymentsStatus(programIdOCW, accessToken)
     ).body;
 
-    const doPaymentOcwResultPaymentNext = await doPayment({
-      programId: programIdOCW,
-      transferValue,
-      referenceIds: [],
-      accessToken,
-    });
-
+    // Check blocked endpoints while the payment is still in progress,
+    // before doing the OCW payment (which takes multiple async calls and
+    // would give the PV payment time to complete).
     const multiEndpointPaymentProgressPv =
       await getPaymentProgressStatusForMultipleEndpoints({
         programId: programIdPV,
         accessToken,
         paymentId: paymentIdPv,
       });
+
+    const doPaymentOcwResultPaymentNext = await doPayment({
+      programId: programIdOCW,
+      transferValue,
+      referenceIds: [],
+      accessToken,
+    });
 
     // Assert
     expect(getProgramPaymentsPvResult.inProgress).toBe(true);

--- a/services/mock-service/package-lock.json
+++ b/services/mock-service/package-lock.json
@@ -11,7 +11,7 @@
         "@nestjs/common": "^11.1.18",
         "@nestjs/core": "^11.1.18",
         "@nestjs/platform-express": "^11.1.18",
-        "@nestjs/swagger": "^11.2.6",
+        "@nestjs/swagger": "^11.2.7",
         "@nestjs/testing": "^11.1.18",
         "@t3-oss/env-core": "^0.13.11",
         "class-transformer": "^0.5.1",
@@ -1065,14 +1065,24 @@
         }
       }
     },
-    "node_modules/@nestjs/core/node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
       "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/platform-express": {
@@ -1094,16 +1104,6 @@
       "peerDependencies": {
         "@nestjs/common": "^11.0.0",
         "@nestjs/core": "^11.0.0"
-      }
-    },
-    "node_modules/@nestjs/platform-express/node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@nestjs/schematics": {
@@ -1171,17 +1171,17 @@
       }
     },
     "node_modules/@nestjs/swagger": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.6.tgz",
-      "integrity": "sha512-oiXOxMQqDFyv1AKAqFzSo6JPvMEs4uA36Eyz/s2aloZLxUjcLfUMELSLSNQunr61xCPTpwEOShfmO7NIufKXdA==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.7.tgz",
+      "integrity": "sha512-+e1KWSyZMAQeyZ8nbQSvm3fhzqdxxBNQENvpjO2dVyD7KJmLTTQyXpRb1nM5O04oFdDTUtG3SHMl4+e+zgCK2A==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "0.16.0",
-        "@nestjs/mapped-types": "2.1.0",
+        "@nestjs/mapped-types": "2.1.1",
         "js-yaml": "4.1.1",
-        "lodash": "4.17.23",
-        "path-to-regexp": "8.3.0",
-        "swagger-ui-dist": "5.31.0"
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.2"
       },
       "peerDependencies": {
         "@fastify/static": "^8.0.0 || ^9.0.0",
@@ -1195,26 +1195,6 @@
         "@fastify/static": {
           "optional": true
         },
-        "class-transformer": {
-          "optional": true
-        },
-        "class-validator": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nestjs/swagger/node_modules/@nestjs/mapped-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
-      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@nestjs/common": "^10.0.0 || ^11.0.0",
-        "class-transformer": "^0.4.0 || ^0.5.0",
-        "class-validator": "^0.13.0 || ^0.14.0",
-        "reflect-metadata": "^0.1.12 || ^0.2.0"
-      },
-      "peerDependenciesMeta": {
         "class-transformer": {
           "optional": true
         },
@@ -5499,9 +5479,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -6097,9 +6077,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -6972,9 +6952,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
-      "integrity": "sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==",
+      "version": "5.32.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.2.tgz",
+      "integrity": "sha512-t6Ns52nS8LU2hqi0+rezMjFO1ZrCsCrnommXrU7Nfrg2va2dWahdvM6TuSwzdHpG29v6BHJyU1c/UWFhgVZzVQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"

--- a/services/mock-service/package.json
+++ b/services/mock-service/package.json
@@ -31,7 +31,7 @@
     "@nestjs/common": "^11.1.18",
     "@nestjs/core": "^11.1.18",
     "@nestjs/platform-express": "^11.1.18",
-    "@nestjs/swagger": "^11.2.6",
+    "@nestjs/swagger": "^11.2.7",
     "@nestjs/testing": "^11.1.18",
     "@t3-oss/env-core": "^0.13.11",
     "class-transformer": "^0.5.1",


### PR DESCRIPTION
[AB#41327](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/41327) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes
upgraded swagger to update vulnerable dependency of lodash:

in 4.17 lodash had a function called _.template() that compiles a template string into a function using JavaScript's Function() constructor — essentially eval(). The bug: if an attacker can control the key names passed in options.imports, they can inject arbitrary code that runs when the template is compiled.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
