### PR TITLE
Session expired popup only on active session

### DIFF
--- a/e2e/portal/tests/LogOut/TokenExpiration.spec.ts
+++ b/e2e/portal/tests/LogOut/TokenExpiration.spec.ts
@@ -48,3 +48,60 @@ test('User is redirected to login when token expires', async ({ page }) => {
   await expect(sessionExpiredToast).toBeVisible();
   await expect(sessionExpiredToast).toContainText('Session expired');
 });
+
+test('User is silently redirected to login on fresh page load with already-expired token (no popup)', async ({
+  page,
+}) => {
+  const loginPage = new LoginPage(page);
+  await page.goto('/');
+  await loginPage.login();
+
+  // Verify we're logged in
+  await page.waitForURL((url) => url.pathname.startsWith('/en-GB/programs'));
+
+  // Simulate time passing while the browser was closed: backdate the stored
+  // token's `expires` field so it looks stale when the app next boots.
+  const localStorageKey = 'logged-in-user-portalicious';
+  /* eslint-disable n/no-unsupported-features/node-builtins -- page.evaluate runs in the browser, not Node */
+  await page.evaluate((key) => {
+    const user = JSON.parse(localStorage.getItem(key)!);
+    user.expires = new Date(Date.now() - 24 * 60 * 60 * 1_000).toISOString();
+    localStorage.setItem(key, JSON.stringify(user));
+  }, localStorageKey);
+  /* eslint-enable n/no-unsupported-features/node-builtins -- re-enable after browser-context block */
+
+  // Full page reload simulates reopening the browser to a bookmarked page.
+  // sessionWasActive resets to false (in-memory only), but the expired token
+  // is still in localStorage.
+  await page.goto('/en-GB/programs/2');
+
+  // Should be silently redirected to the login page
+  await page.waitForURL((url) => url.pathname.startsWith('/en-GB/login'));
+  await expect(page).toHaveURL(/.*\/en-GB\/login/);
+
+  // The "Session expired" dialog must NOT appear — this was Scenario B (fresh open)
+  const sessionExpiredDialog = page.getByText('Session expired');
+  await expect(sessionExpiredDialog).not.toBeVisible();
+});
+
+test('User with a valid (non-expired) token is not redirected to login on page reload', async ({
+  page,
+}) => {
+  const loginPage = new LoginPage(page);
+  await page.goto('/');
+  await loginPage.login();
+
+  // Verify we're logged in
+  await page.waitForURL((url) => url.pathname.startsWith('/en-GB/programs'));
+
+  // Reload the page to simulate returning to the app with a still-valid token
+  await page.reload();
+
+  // Should remain on the programs page, not redirected to login
+  await page.waitForURL((url) => url.pathname.startsWith('/en-GB/programs'));
+  await expect(page).toHaveURL(/.*\/en-GB\/programs/);
+
+  // The "Session expired" dialog must NOT appear
+  const sessionExpiredDialog = page.getByText('Session expired');
+  await expect(sessionExpiredDialog).not.toBeVisible();
+});

--- a/e2e/portal/tests/LogOut/TokenExpiration.spec.ts
+++ b/e2e/portal/tests/LogOut/TokenExpiration.spec.ts
@@ -64,8 +64,10 @@ test('User is silently redirected to login on fresh page load with already-expir
   const localStorageKey = 'logged-in-user-portalicious';
   /* eslint-disable n/no-unsupported-features/node-builtins -- page.evaluate runs in the browser, not Node */
   await page.evaluate((key) => {
+    const expiredTimeStamp = `1970-01-01T00:00:00.000Z`;
+
     const user = JSON.parse(localStorage.getItem(key)!);
-    user.expires = new Date(Date.now() - 24 * 60 * 60 * 1_000).toISOString();
+    user.expires = expiredTimeStamp;
     localStorage.setItem(key, JSON.stringify(user));
   }, localStorageKey);
   /* eslint-enable n/no-unsupported-features/node-builtins -- re-enable after browser-context block */
@@ -73,15 +75,16 @@ test('User is silently redirected to login on fresh page load with already-expir
   // Full page reload simulates reopening the browser to a bookmarked page.
   // sessionWasActive resets to false (in-memory only), but the expired token
   // is still in localStorage.
-  await page.goto('/en-GB/programs/2');
+  await page.goto('/en-GB/program/2/registrations');
 
-  // Should be silently redirected to the login page
-  await page.waitForURL((url) => url.pathname.startsWith('/en-GB/login'));
-  await expect(page).toHaveURL(/.*\/en-GB\/login/);
-
-  // The "Session expired" dialog must NOT appear — this was Scenario B (fresh open)
+  // The "Session expired" dialog must NOT appear
   const sessionExpiredDialog = page.getByText('Session expired');
   await expect(sessionExpiredDialog).not.toBeVisible();
+  // After logging back in, the user should land on the originally requested URL.
+  await loginPage.login(undefined, undefined, true);
+  await page.waitForURL((url) =>
+    url.pathname.endsWith('/program/2/registrations'),
+  );
 });
 
 test('User with a valid (non-expired) token is not redirected to login on page reload', async ({

--- a/interfaces/portal/src/app/services/auth.service.ts
+++ b/interfaces/portal/src/app/services/auth.service.ts
@@ -57,7 +57,8 @@ export class AuthService {
    * Tracks whether the session was active at any point during the current browser session.
    * Intentionally NOT stored in localStorage/sessionStorage so it resets on page refresh/new tab.
    * Set to `true` immediately on login and by the token expiration monitor
-   * whenever it detects a valid token (e.g. after a page refresh with a still-valid token).
+   * whenever the token has not yet expired (timeUntilExpiry > 0), including
+   * when the token is inside the force-logout window.
    * Used in `handleTokenExpiration` to distinguish between:
    * - Token expired mid-use (sessionWasActive=true) → show "Session expired" popup
    * - Token was already expired on app start (sessionWasActive=false) → silent redirect to login

--- a/interfaces/portal/src/app/services/auth.service.ts
+++ b/interfaces/portal/src/app/services/auth.service.ts
@@ -56,7 +56,8 @@ export class AuthService {
   /**
    * Tracks whether the session was active at any point during the current browser session.
    * Intentionally NOT stored in localStorage/sessionStorage so it resets on page refresh/new tab.
-   * Set to `true` by the token expiration monitor whenever it detects a valid token.
+   * Set to `true` immediately on login and by the token expiration monitor
+   * whenever it detects a valid token (e.g. after a page refresh with a still-valid token).
    * Used in `handleTokenExpiration` to distinguish between:
    * - Token expired mid-use (sessionWasActive=true) → show "Session expired" popup
    * - Token was already expired on app start (sessionWasActive=false) → silent redirect to login
@@ -93,11 +94,10 @@ export class AuthService {
     });
   }
 
-  // Called by the token expiration monitor on each tick where the token is still valid.
-  // This is the mechanism that sets sessionWasActive to true: after login()
-  // stores the user, or when a page refresh/tab reopen finds a still-valid token,
-  // the next monitor tick detects it and marks the session as active so that a
-  // later expiration correctly shows the "Session expired" dialog.
+  // Called by login() and by the token expiration monitor on each tick where
+  // the token is still valid. login() calls it immediately so there is no gap
+  // between a successful login and the first monitor tick. The monitor still
+  // calls it to cover page refreshes where a still-valid token is found.
   private markSessionActive(): void {
     this.sessionWasActive = true;
   }
@@ -183,6 +183,7 @@ export class AuthService {
     const user = await this.authStrategy.login(credentials);
     if (user) {
       setUserInLocalStorage(user);
+      this.markSessionActive();
     }
     return this.router.navigate(['/', AppRoutes.authCallback]);
   }

--- a/interfaces/portal/src/app/services/auth.service.ts
+++ b/interfaces/portal/src/app/services/auth.service.ts
@@ -119,18 +119,27 @@ export class AuthService {
     }
 
     if (!this.sessionWasActive) {
-      // Token was already expired when the app started — skip the popup and
-      // redirect silently so the user is not confused by a stale "session expired" message.
-      await this.clearSession();
-      await this.router.navigate(['/', AppRoutes.login]);
-      return;
+      await this.redirectToLoginSilently();
+    } else {
+      await this.expireSessionWithDialog();
     }
+  }
 
-    const currentUrl = this.router.url;
+  // Token was already expired when the app started — skip the popup and
+  // redirect silently so the user is not confused by a stale "session expired" message.
+  private async redirectToLoginSilently(): Promise<void> {
+    const returnUrl = this.router.url;
+    await this.clearSession();
+    await this.router.navigate(['/', AppRoutes.login], {
+      queryParams: { returnUrl },
+    });
+  }
 
+  private async expireSessionWithDialog(): Promise<void> {
+    const returnUrl = this.router.url;
     this.showSessionExpiredDialog.set(true);
     await this.clearSession();
-    this.sessionExpiredReturnUrl.set(currentUrl);
+    this.sessionExpiredReturnUrl.set(returnUrl);
   }
 
   public get isLoggedIn(): boolean {

--- a/interfaces/portal/src/app/services/auth.service.ts
+++ b/interfaces/portal/src/app/services/auth.service.ts
@@ -53,6 +53,16 @@ export class AuthService {
   private readonly CHECK_INTERVAL_MS = 3_000; // Check every 3 seconds
   private readonly FORCE_LOGOUT_WHEN_EXP_IN_MS = 5_000; // Logout 5 seconds before expiry
 
+  /**
+   * Tracks whether the session was active at any point during the current browser session.
+   * Intentionally NOT stored in localStorage/sessionStorage so it resets on page refresh/new tab.
+   * Set to `true` by the token expiration monitor whenever it detects a valid token.
+   * Used in `handleTokenExpiration` to distinguish between:
+   * - Token expired mid-use (sessionWasActive=true) → show "Session expired" popup
+   * - Token was already expired on app start (sessionWasActive=false) → silent redirect to login
+   */
+  private sessionWasActive = false;
+
   public readonly showSessionExpiredDialog = signal(false);
   public readonly sessionExpiredReturnUrl = signal<string | undefined>(
     undefined,
@@ -77,12 +87,28 @@ export class AuthService {
       forceLogoutMs: this.FORCE_LOGOUT_WHEN_EXP_IN_MS,
       getTimeUntilExpiration: () => this.authStrategy.getTimeUntilExpiration(),
       onExpired: () => void this.handleTokenExpiration(),
+      onValid: () => {
+        this.markSessionActive();
+      },
     });
+  }
+
+  // Called by the token expiration monitor on each tick where the token is still valid.
+  // This is the mechanism that sets sessionWasActive to true: after login()
+  // stores the user, or when a page refresh/tab reopen finds a still-valid token,
+  // the next monitor tick detects it and marks the session as active so that a
+  // later expiration correctly shows the "Session expired" dialog.
+  private markSessionActive(): void {
+    this.sessionWasActive = true;
   }
 
   /**
    * Handles token expiration by logging out and preserving the current URL
    * for redirect after re-authentication.
+   *
+   * Shows the "Session expired" dialog only when the session was active during
+   * the current browser session (i.e. the token transitioned from valid → expired).
+   * When the token was already expired on app start, redirects silently to login.
    *
    * @private
    */
@@ -90,6 +116,15 @@ export class AuthService {
     if (this.showSessionExpiredDialog()) {
       return;
     }
+
+    if (!this.sessionWasActive) {
+      // Token was already expired when the app started — skip the popup and
+      // redirect silently so the user is not confused by a stale "session expired" message.
+      await this.clearSession();
+      await this.router.navigate(['/', AppRoutes.login]);
+      return;
+    }
+
     const currentUrl = this.router.url;
 
     this.showSessionExpiredDialog.set(true);

--- a/interfaces/portal/src/app/services/auth/token-expiration-monitor.spec.ts
+++ b/interfaces/portal/src/app/services/auth/token-expiration-monitor.spec.ts
@@ -9,11 +9,13 @@ describe('startTokenExpirationMonitor', () => {
 
   let subscription: Subscription;
   let onExpired: ReturnType<typeof vi.fn<() => void>>;
+  let onValid: ReturnType<typeof vi.fn<() => void>>;
   let getTimeUntilExpiration: ReturnType<typeof vi.fn<() => number>>;
 
   beforeEach(() => {
     vi.useFakeTimers();
     onExpired = vi.fn<() => void>();
+    onValid = vi.fn<() => void>();
     getTimeUntilExpiration = vi.fn<() => number>().mockReturnValue(Infinity);
   });
 
@@ -28,6 +30,7 @@ describe('startTokenExpirationMonitor', () => {
       forceLogoutMs: FORCE_LOGOUT_MS,
       getTimeUntilExpiration,
       onExpired,
+      onValid,
     });
 
     vi.advanceTimersByTime(CHECK_INTERVAL_MS * 5);
@@ -43,6 +46,7 @@ describe('startTokenExpirationMonitor', () => {
       forceLogoutMs: FORCE_LOGOUT_MS,
       getTimeUntilExpiration,
       onExpired,
+      onValid,
     });
 
     vi.advanceTimersByTime(CHECK_INTERVAL_MS * 5);
@@ -58,6 +62,7 @@ describe('startTokenExpirationMonitor', () => {
       forceLogoutMs: FORCE_LOGOUT_MS,
       getTimeUntilExpiration,
       onExpired,
+      onValid,
     });
 
     vi.advanceTimersByTime(CHECK_INTERVAL_MS);
@@ -73,6 +78,7 @@ describe('startTokenExpirationMonitor', () => {
       forceLogoutMs: FORCE_LOGOUT_MS,
       getTimeUntilExpiration,
       onExpired,
+      onValid,
     });
 
     vi.advanceTimersByTime(CHECK_INTERVAL_MS);
@@ -88,6 +94,7 @@ describe('startTokenExpirationMonitor', () => {
       forceLogoutMs: FORCE_LOGOUT_MS,
       getTimeUntilExpiration,
       onExpired,
+      onValid,
     });
 
     vi.advanceTimersByTime(CHECK_INTERVAL_MS * 3);
@@ -103,6 +110,7 @@ describe('startTokenExpirationMonitor', () => {
       forceLogoutMs: FORCE_LOGOUT_MS,
       getTimeUntilExpiration,
       onExpired,
+      onValid,
     });
 
     vi.advanceTimersByTime(CHECK_INTERVAL_MS);
@@ -123,6 +131,7 @@ describe('startTokenExpirationMonitor', () => {
       forceLogoutMs: FORCE_LOGOUT_MS,
       getTimeUntilExpiration,
       onExpired,
+      onValid,
     });
 
     vi.advanceTimersByTime(CHECK_INTERVAL_MS);
@@ -132,5 +141,22 @@ describe('startTokenExpirationMonitor', () => {
     vi.advanceTimersByTime(CHECK_INTERVAL_MS * 5);
 
     expect(onExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onValid when time remaining is above the threshold', () => {
+    getTimeUntilExpiration.mockReturnValue(FORCE_LOGOUT_MS + 1);
+
+    subscription = startTokenExpirationMonitor({
+      checkIntervalMs: CHECK_INTERVAL_MS,
+      forceLogoutMs: FORCE_LOGOUT_MS,
+      getTimeUntilExpiration,
+      onExpired,
+      onValid,
+    });
+
+    vi.advanceTimersByTime(CHECK_INTERVAL_MS * 3);
+
+    expect(onValid).toHaveBeenCalledTimes(3);
+    expect(onExpired).not.toHaveBeenCalled();
   });
 });

--- a/interfaces/portal/src/app/services/auth/token-expiration-monitor.spec.ts
+++ b/interfaces/portal/src/app/services/auth/token-expiration-monitor.spec.ts
@@ -86,6 +86,23 @@ describe('startTokenExpirationMonitor', () => {
     expect(onExpired).toHaveBeenCalledTimes(1);
   });
 
+  it('should not call onValid when token is already expired', () => {
+    getTimeUntilExpiration.mockReturnValue(0);
+
+    subscription = startTokenExpirationMonitor({
+      checkIntervalMs: CHECK_INTERVAL_MS,
+      forceLogoutMs: FORCE_LOGOUT_MS,
+      getTimeUntilExpiration,
+      onExpired,
+      onValid,
+    });
+
+    vi.advanceTimersByTime(CHECK_INTERVAL_MS);
+
+    expect(onValid).not.toHaveBeenCalled();
+    expect(onExpired).toHaveBeenCalledTimes(1);
+  });
+
   it('should call onExpired on every tick while time remaining stays below the threshold', () => {
     getTimeUntilExpiration.mockReturnValue(FORCE_LOGOUT_MS - 1);
 
@@ -100,6 +117,8 @@ describe('startTokenExpirationMonitor', () => {
     vi.advanceTimersByTime(CHECK_INTERVAL_MS * 3);
 
     expect(onExpired).toHaveBeenCalledTimes(3);
+    // onValid also fires because token is still technically valid (> 0)
+    expect(onValid).toHaveBeenCalledTimes(3);
   });
 
   it('should stop calling onExpired after getTimeUntilExpiration returns Infinity (e.g. after session cleared)', () => {

--- a/interfaces/portal/src/app/services/auth/token-expiration-monitor.ts
+++ b/interfaces/portal/src/app/services/auth/token-expiration-monitor.ts
@@ -39,9 +39,15 @@ export const startTokenExpirationMonitor = ({
       return;
     }
 
+    // Mark the session as valid whenever the token hasn't actually expired yet.
+    // This covers the edge case where the app boots with a token inside the
+    // force-logout window (0 < timeUntilExpiry <= forceLogoutMs): the token is
+    // still valid, so the session should be considered active before forcing logout.
+    if (timeUntilExpiry > 0) {
+      onValid();
+    }
+
     if (timeUntilExpiry <= forceLogoutMs) {
       onExpired();
-    } else {
-      onValid();
     }
   });

--- a/interfaces/portal/src/app/services/auth/token-expiration-monitor.ts
+++ b/interfaces/portal/src/app/services/auth/token-expiration-monitor.ts
@@ -23,11 +23,13 @@ export const startTokenExpirationMonitor = ({
   forceLogoutMs,
   getTimeUntilExpiration,
   onExpired,
+  onValid,
 }: {
   checkIntervalMs: number;
   forceLogoutMs: number;
   getTimeUntilExpiration: () => number;
   onExpired: () => void;
+  onValid: () => void;
 }): Subscription =>
   interval(checkIntervalMs).subscribe(() => {
     const timeUntilExpiry = getTimeUntilExpiration();
@@ -39,5 +41,7 @@ export const startTokenExpirationMonitor = ({
 
     if (timeUntilExpiry <= forceLogoutMs) {
       onExpired();
+    } else {
+      onValid();
     }
   });


### PR DESCRIPTION
[AB#41775](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/41746) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Adjusts session-expiration UX so the “Session expired” dialog is only shown when an in-app session actually became active, avoiding confusing popups when the app starts with an already-expired token.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8158.westeurope.3.azurestaticapps.net
