### PR TITLE
chore: fix flaky payment-in-progress test

### DIFF
--- a/services/121-service/src/queues-registry/queues-registry.service.ts
+++ b/services/121-service/src/queues-registry/queues-registry.service.ts
@@ -157,15 +157,9 @@ export class QueuesRegistryService implements OnModuleInit {
   async emptyAllQueues(): Promise<void> {
     // Bull queues involve complex data structures and Bull maintains various metadata for job management.
     // Therefore the data of the Bull queue and the ioredis queue are deleted separately
-    const queues = Object.values(this.allQueues);
-
-    await Promise.all(queues.map((queue) => queue.pause(true)));
-    await Promise.all(queues.map((queue) => queue.whenCurrentJobsFinished()));
-
-    for (const queue of queues) {
+    for (const queue of Object.values(this.allQueues)) {
       await queue.empty();
     }
-    
     const redisClient = createRedisClient();
     // Prefix is needed here because .keys does not take into account the prefix of the redis client
     const keys = await redisClient.keys(`${env.REDIS_PREFIX}:*`);
@@ -176,8 +170,6 @@ export class QueuesRegistryService implements OnModuleInit {
       await this.batchDeleteKeys(redisClient, keysWithoutPrefix);
     }
     await redisClient.keys(`${env.REDIS_PREFIX}:*`);
-
-    await Promise.all(queues.map((queue) => queue.resume(true)));
   }
 
   // This is prevent this error when deleting large amount of keys: RangeError: Maximum call stack size exceeded

--- a/services/121-service/src/queues-registry/queues-registry.service.ts
+++ b/services/121-service/src/queues-registry/queues-registry.service.ts
@@ -157,9 +157,15 @@ export class QueuesRegistryService implements OnModuleInit {
   async emptyAllQueues(): Promise<void> {
     // Bull queues involve complex data structures and Bull maintains various metadata for job management.
     // Therefore the data of the Bull queue and the ioredis queue are deleted separately
-    for (const queue of Object.values(this.allQueues)) {
+    const queues = Object.values(this.allQueues);
+
+    await Promise.all(queues.map((queue) => queue.pause(true)));
+    await Promise.all(queues.map((queue) => queue.whenCurrentJobsFinished()));
+
+    for (const queue of queues) {
       await queue.empty();
     }
+    
     const redisClient = createRedisClient();
     // Prefix is needed here because .keys does not take into account the prefix of the redis client
     const keys = await redisClient.keys(`${env.REDIS_PREFIX}:*`);
@@ -170,6 +176,8 @@ export class QueuesRegistryService implements OnModuleInit {
       await this.batchDeleteKeys(redisClient, keysWithoutPrefix);
     }
     await redisClient.keys(`${env.REDIS_PREFIX}:*`);
+
+    await Promise.all(queues.map((queue) => queue.resume(true)));
   }
 
   // This is prevent this error when deleting large amount of keys: RangeError: Maximum call stack size exceeded

--- a/services/121-service/test/payment/payment-in-progress.test.ts
+++ b/services/121-service/test/payment/payment-in-progress.test.ts
@@ -382,9 +382,13 @@ describe('Payment in progress', () => {
       accessToken,
     });
 
-    const getProgramPaymentsPvResult = (
-      await getProgramPaymentsStatus(programIdPV, accessToken)
-    ).body;
+    const multiEndpointPaymentProgressPv =
+      await getPaymentProgressStatusForMultipleEndpoints({
+        programId: programIdPV,
+        accessToken,
+        paymentId: paymentIdPv,
+      });
+
     const getProgramPaymentsOcwResult = (
       await getProgramPaymentsStatus(programIdOCW, accessToken)
     ).body;
@@ -396,17 +400,8 @@ describe('Payment in progress', () => {
       accessToken,
     });
 
-    const multiEndpointPaymentProgressPv =
-      await getPaymentProgressStatusForMultipleEndpoints({
-        programId: programIdPV,
-        accessToken,
-        paymentId: paymentIdPv,
-      });
-
     // Assert
-    expect(getProgramPaymentsPvResult.inProgress).toBe(true);
     expect(getProgramPaymentsOcwResult.inProgress).toBe(false);
-
     expect(doPaymentOcwResultPaymentNext.status).toBe(HttpStatus.CREATED);
     expect(multiEndpointPaymentProgressPv).toMatchObject({
       paymentIsInProgress: true,


### PR DESCRIPTION
[AB#41742](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/41742) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Mainly affecting test shard 6/6 of which `payment-in-progress` was particularly flaky.

I reordered assertions in payment-in-progress.test.ts to check PV payment progress immediately after confirming it is in-progress, before unrelated API calls give the payment time to complete.

Note: the status of the PV payment in `payment-in-progress` is still being asserted by:
```
expect(multiEndpointPaymentProgressPv).toMatchObject({
      paymentIsInProgress: true,
      createPaymentBlocked: true,
      startPaymentBlocked: true,
      retryPaymentBlocked: true,
    });    
```

Shard 6/6 does not fail on `payment-in-progress` anymore, but does on `delete-deprecated-vouchers`. A fix for that test is in progress.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
