### PR TITLE
fix: update scoped registration queries to actually address the intended scoped registrations repository

### DIFF
--- a/services/121-service/src/registration/repositories/registration-scoped.repository.ts
+++ b/services/121-service/src/registration/repositories/registration-scoped.repository.ts
@@ -5,6 +5,7 @@ import {
   DeleteResult,
   Equal,
   FindOptionsWhere,
+  In,
   InsertResult,
   ObjectId,
   RemoveOptions,
@@ -159,13 +160,30 @@ export class RegistrationScopedRepository extends RegistrationScopedBaseReposito
     programId?: number;
     relations?: string[];
   }) {
-    return await this.repository.findOne({
+    return await this.findOne({
       where: {
         referenceId: Equal(referenceId),
         ...(programId != undefined ? { programId: Equal(programId) } : {}),
       },
       relations,
     });
+  }
+
+  public async getExistingReferenceIds({
+    programId,
+    referenceIds,
+  }: {
+    programId: number;
+    referenceIds: string[];
+  }): Promise<Set<string>> {
+    if (referenceIds.length === 0) {
+      return new Set();
+    }
+    const registrations = await this.find({
+      where: { programId: Equal(programId), referenceId: In(referenceIds) },
+      select: { referenceId: true },
+    });
+    return new Set(registrations.map((r) => r.referenceId));
   }
 
   public async getDuplicates({
@@ -309,7 +327,7 @@ export class RegistrationScopedRepository extends RegistrationScopedBaseReposito
   public async getDebitCardsDetailsForExport(
     programId: number,
   ): Promise<ExportVisaCardDetailsRawData[]> {
-    const wallets = await this.repository
+    const wallets = await this
       .createQueryBuilder('registration')
       .leftJoin('registration.intersolveVisaCustomer', 'customer')
       .leftJoin(
@@ -364,7 +382,7 @@ export class RegistrationScopedRepository extends RegistrationScopedBaseReposito
   }: {
     referenceId: string;
   }): Promise<boolean> {
-    const registrationToComplete = await this.repository
+    const registrationToComplete = await this
       .createQueryBuilder('registration')
       .andWhere('registration."paymentCount" >= registration."maxPayments"')
       .andWhere('registration."registrationStatus" != :completedStatus', {

--- a/services/121-service/src/registration/repositories/registration-scoped.repository.ts
+++ b/services/121-service/src/registration/repositories/registration-scoped.repository.ts
@@ -5,7 +5,6 @@ import {
   DeleteResult,
   Equal,
   FindOptionsWhere,
-  In,
   InsertResult,
   ObjectId,
   RemoveOptions,
@@ -167,23 +166,6 @@ export class RegistrationScopedRepository extends RegistrationScopedBaseReposito
       },
       relations,
     });
-  }
-
-  public async getExistingReferenceIds({
-    programId,
-    referenceIds,
-  }: {
-    programId: number;
-    referenceIds: string[];
-  }): Promise<Set<string>> {
-    if (referenceIds.length === 0) {
-      return new Set();
-    }
-    const registrations = await this.find({
-      where: { programId: Equal(programId), referenceId: In(referenceIds) },
-      select: { referenceId: true },
-    });
-    return new Set(registrations.map((r) => r.referenceId));
   }
 
   public async getDuplicates({


### PR DESCRIPTION
[AB#41899](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/41899) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

`RegistrationScopedRepository` was using `this.repository` in methods where scoped data should be fetched. `this.repository` uses plain TypeORM CRUD methods, so the data returned in these methods were not scoped. Updated relevant queries to use `this` which refs to the intended scoped repository.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [ ] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
