### PR TITLE
feature: import existing kobo registration UI

### DIFF
--- a/e2e/portal/pages/RegistrationDataPage.ts
+++ b/e2e/portal/pages/RegistrationDataPage.ts
@@ -13,6 +13,7 @@ class RegistrationDataPage extends BasePage {
 
   constructor(page: Page) {
     super(page);
+    this.koboCard = this.page.getByTestId('kobo-integration-card');
     this.addKoboToolboxButton = this.page
       .getByTestId('card-with-link')
       .getByTitle('KoboToolbox');
@@ -29,7 +30,7 @@ class RegistrationDataPage extends BasePage {
     });
   }
 
-  async addKoboIntergration(koboIntegrationDetails: {
+  async addKoboIntegration(koboIntegrationDetails: {
     url: string;
     apiKey: string;
   }) {
@@ -93,7 +94,7 @@ class RegistrationDataPage extends BasePage {
   }
 
   async openImportExistingKoboRegistrationsDialog() {
-    const ellipsisMenuButton = await this.page.getByTestId(
+    const ellipsisMenuButton = this.koboCard.getByTestId(
       'ellipsis-menu-button',
     );
 

--- a/e2e/portal/pages/RegistrationDataPage.ts
+++ b/e2e/portal/pages/RegistrationDataPage.ts
@@ -5,6 +5,11 @@ import BasePage from './BasePage';
 class RegistrationDataPage extends BasePage {
   readonly addKoboToolboxButton: Locator;
   readonly continueButton: Locator;
+  readonly koboCardEllipsisMenu: Locator;
+  readonly koboCard: Locator;
+  readonly initiateImportButton: Locator;
+  readonly importDialog: Locator;
+  readonly closeImportDialog: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -12,6 +17,37 @@ class RegistrationDataPage extends BasePage {
       .getByTestId('card-with-link')
       .getByTitle('KoboToolbox');
     this.continueButton = this.page.getByRole('button', { name: 'Continue' });
+    this.importDialog = this.page.getByTestId(
+      'import-existing-kobo-registrations-dialog',
+    );
+    this.initiateImportButton = this.page.getByRole('button', {
+      name: 'Import registrations',
+    });
+
+    this.closeImportDialog = this.page.getByRole('button', {
+      name: 'Close',
+    });
+  }
+
+  async addKoboIntergration(koboIntegrationDetails: {
+    url: string;
+    apiKey: string;
+  }) {
+    await this.clickRegistrationDataSection();
+    await this.addKoboToolboxIntegration({
+      url: koboIntegrationDetails.url,
+      apiKey: koboIntegrationDetails.apiKey,
+    });
+    // Validate success message after adding Kobo integration with correct details
+    await this.validateKoboIntegration({
+      koboFormName: '25042025 Prototype Sprint',
+    });
+    // Click continue button to exit the form
+    await this.clickContinueButton();
+    // Validate toast message after exiting the form
+    await this.validateToastMessageAndClose(
+      'Kobo form successfully integrated.',
+    );
   }
 
   async clickRegistrationDataSection() {
@@ -54,6 +90,15 @@ class RegistrationDataPage extends BasePage {
     if (koboFormName) {
       await this.page.getByText(koboFormName).waitFor();
     }
+  }
+
+  async openImportExistingKoboRegistrationsDialog() {
+    const ellipsisMenuButton = await this.page.getByTestId(
+      'ellipsis-menu-button',
+    );
+
+    await ellipsisMenuButton.click();
+    await this.page.getByText('Import existing reg.').click();
   }
 }
 

--- a/e2e/portal/tests/ProgramSettings/RegistrationData/AddKoboIntegrationSuccessfully.spec.ts
+++ b/e2e/portal/tests/ProgramSettings/RegistrationData/AddKoboIntegrationSuccessfully.spec.ts
@@ -19,20 +19,19 @@ const koboIntegrationFormColumns = [
   'How are you today (select one)?',
 ];
 
-test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
+test('Add Kobo integration successfully', async ({
+  resetDBAndSeedRegistrations,
+  registrationDataPage,
+  registrationsPage,
+  tableComponent,
+}) => {
   await resetDBAndSeedRegistrations({
     seedScript: SeedScript.safaricomProgram,
     registrations: registrationsSafaricom,
     programId: programIdSafaricom,
     navigateToPage: `/program/${programIdSafaricom}/registrations`,
   });
-});
 
-test('Add Kobo integration successfully', async ({
-  registrationDataPage,
-  registrationsPage,
-  tableComponent,
-}) => {
   await test.step('Validate column availability from Registrations page', async () => {
     for (const column of koboIntegrationFormColumns) {
       await registrationsPage.checkColumnAvailability({
@@ -47,21 +46,7 @@ test('Add Kobo integration successfully', async ({
   });
 
   await test.step('Add Kobo integration', async () => {
-    await registrationDataPage.clickRegistrationDataSection();
-    await registrationDataPage.addKoboToolboxIntegration({
-      url: koboIntegrationDetails.url,
-      apiKey: koboIntegrationDetails.apiKey,
-    });
-    // Validate success message after adding Kobo integration with correct details
-    await registrationDataPage.validateKoboIntegration({
-      koboFormName: '25042025 Prototype Sprint',
-    });
-    // Click continue button to exit the form
-    await registrationDataPage.clickContinueButton();
-    // Validate toast message after exiting the form
-    await registrationDataPage.validateToastMessageAndClose(
-      'Kobo form successfully integrated.',
-    );
+    await registrationDataPage.addKoboIntergration(koboIntegrationDetails);
   });
 
   await test.step('Validate Kobo integration details on Registrations page', async () => {

--- a/e2e/portal/tests/ProgramSettings/RegistrationData/AddKoboIntegrationSuccessfully.spec.ts
+++ b/e2e/portal/tests/ProgramSettings/RegistrationData/AddKoboIntegrationSuccessfully.spec.ts
@@ -46,7 +46,7 @@ test('Add Kobo integration successfully', async ({
   });
 
   await test.step('Add Kobo integration', async () => {
-    await registrationDataPage.addKoboIntergration(koboIntegrationDetails);
+    await registrationDataPage.addKoboIntegration(koboIntegrationDetails);
   });
 
   await test.step('Validate Kobo integration details on Registrations page', async () => {

--- a/e2e/portal/tests/ProgramSettings/RegistrationData/ImportExistingKoboRegistrations.spec.ts
+++ b/e2e/portal/tests/ProgramSettings/RegistrationData/ImportExistingKoboRegistrations.spec.ts
@@ -1,3 +1,5 @@
+import { expect } from '@playwright/test';
+
 import { env } from '@121-service/src/env';
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import {
@@ -25,7 +27,7 @@ test('Import existing Kobo registrations', async ({
   });
 
   await test.step('Add Kobo integration', async () => {
-    await registrationDataPage.addKoboIntergration(koboIntegrationDetails);
+    await registrationDataPage.addKoboIntegration(koboIntegrationDetails);
   });
 
   await test.step('Import existing Kobo registrations', async () => {
@@ -34,10 +36,12 @@ test('Import existing Kobo registrations', async ({
   });
 
   await test.step('Validate success message after importing existing Kobo registrations', async () => {
-    await registrationDataPage.importDialog.getByText('1 total submission(s)');
-    await registrationDataPage.importDialog.getByText(
-      'Imported successfully: 1',
-    );
+    await expect(
+      registrationDataPage.importDialog.getByText('1 total submission(s)'),
+    ).toBeVisible();
+    await expect(
+      registrationDataPage.importDialog.getByText('Imported successfully: 1'),
+    ).toBeVisible();
   });
 
   await test.step('Skip importing existing Kobo registrations when there are no new registrations to import', async () => {
@@ -45,7 +49,12 @@ test('Import existing Kobo registrations', async ({
     await registrationDataPage.openImportExistingKoboRegistrationsDialog();
     await registrationDataPage.initiateImportButton.click();
 
-    await registrationDataPage.importDialog.getByText('1 total submission(s)');
-    await registrationDataPage.importDialog.getByText('Submissions skipped: 1');
+    await expect(
+      registrationDataPage.importDialog.getByText('1 total submission(s)'),
+    ).toBeVisible();
+
+    await expect(
+      registrationDataPage.importDialog.getByText('Submissions skipped: 1'),
+    ).toBeVisible();
   });
 });

--- a/e2e/portal/tests/ProgramSettings/RegistrationData/ImportExistingKoboRegistrations.spec.ts
+++ b/e2e/portal/tests/ProgramSettings/RegistrationData/ImportExistingKoboRegistrations.spec.ts
@@ -1,0 +1,51 @@
+import { env } from '@121-service/src/env';
+import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
+import {
+  programIdSafaricom,
+  registrationsSafaricom,
+} from '@121-service/test/registrations/pagination/pagination-data';
+
+import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
+
+// KOBO INTEGRATION DETAILS
+const koboIntegrationDetails = {
+  url: `${env.MOCK_SERVICE_URL}/api/kobo/#/forms/success-asset/summary`,
+  apiKey: 'mock-token',
+};
+
+test('Import existing Kobo registrations', async ({
+  resetDBAndSeedRegistrations,
+  registrationDataPage,
+}) => {
+  await resetDBAndSeedRegistrations({
+    seedScript: SeedScript.safaricomProgram,
+    registrations: registrationsSafaricom,
+    programId: programIdSafaricom,
+    navigateToPage: `/program/${programIdSafaricom}/settings/registration-data`,
+  });
+
+  await test.step('Add Kobo integration', async () => {
+    await registrationDataPage.addKoboIntergration(koboIntegrationDetails);
+  });
+
+  await test.step('Import existing Kobo registrations', async () => {
+    await registrationDataPage.openImportExistingKoboRegistrationsDialog();
+    await registrationDataPage.initiateImportButton.click();
+  });
+
+  await test.step('Validate success message after importing existing Kobo registrations', async () => {
+    await registrationDataPage.importDialog.getByText('1 total submission(s)');
+    await registrationDataPage.importDialog.getByText(
+      'Imported successfully: 1',
+    );
+  });
+
+  await test.step('Skip importing existing Kobo registrations when there are no new registrations to import', async () => {
+    await registrationDataPage.closeImportDialog.click();
+    await registrationDataPage.openImportExistingKoboRegistrationsDialog();
+    await registrationDataPage.initiateImportButton.click();
+
+    await registrationDataPage.importDialog.getByText('1 total submission(s)');
+    await registrationDataPage.importDialog.getByText('Submissions skipped: 1');
+  });
+});

--- a/interfaces/portal/src/app/components/colored-chip/colored-chip.helper.ts
+++ b/interfaces/portal/src/app/components/colored-chip/colored-chip.helper.ts
@@ -5,7 +5,10 @@ import { RegistrationStatusEnum } from '@121-service/src/registration/enum/regis
 
 import { ChipVariant } from '~/components/colored-chip/colored-chip.component';
 import { VISA_CARD_STATUS_LABELS } from '~/domains/fsp-account-management/intersolve-visa.helper';
-import { SUBMISSION_RESULT_LABELS } from '~/domains/kobo/kobo.helpers';
+import {
+  ImportExistingSubmissionsResultKey,
+  SUBMISSION_RESULT_LABELS,
+} from '~/domains/kobo/kobo.helpers';
 import {
   convertTwilioMessageStatusToMessageStatus,
   MESSAGE_STATUS_LABELS,
@@ -16,7 +19,6 @@ import {
   REGISTRATION_STATUS_LABELS,
 } from '~/domains/registration/registration.helper';
 import { TRANSACTION_STATUS_LABELS } from '~/domains/transaction/transaction.helper';
-import { SubmissionKey } from '~/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component';
 
 export interface ChipData {
   chipLabel: string;
@@ -121,14 +123,14 @@ export const getChipDataByDuplicateStatus = (
   });
 
 export const getChipDataBySubmissionsKey = (
-  status?: null | SubmissionKey,
+  status?: ImportExistingSubmissionsResultKey | null,
 ): ChipData =>
   mapValueToChipData({
     value: status,
     labels: SUBMISSION_RESULT_LABELS,
     chipVariants: {
-      [SubmissionKey.Failed]: 'red',
-      [SubmissionKey.Imported]: 'green',
-      [SubmissionKey.Skipped]: 'orange',
+      [ImportExistingSubmissionsResultKey.numberOfSubmissionsFailed]: 'red',
+      [ImportExistingSubmissionsResultKey.numberOfSubmissionsImported]: 'green',
+      [ImportExistingSubmissionsResultKey.numberOfSubmissionsSkipped]: 'orange',
     },
   });

--- a/interfaces/portal/src/app/components/colored-chip/colored-chip.helper.ts
+++ b/interfaces/portal/src/app/components/colored-chip/colored-chip.helper.ts
@@ -5,6 +5,7 @@ import { RegistrationStatusEnum } from '@121-service/src/registration/enum/regis
 
 import { ChipVariant } from '~/components/colored-chip/colored-chip.component';
 import { VISA_CARD_STATUS_LABELS } from '~/domains/fsp-account-management/intersolve-visa.helper';
+import { SUBMISSION_RESULT_LABELS } from '~/domains/kobo/kobo.helpers';
 import {
   convertTwilioMessageStatusToMessageStatus,
   MESSAGE_STATUS_LABELS,
@@ -15,10 +16,7 @@ import {
   REGISTRATION_STATUS_LABELS,
 } from '~/domains/registration/registration.helper';
 import { TRANSACTION_STATUS_LABELS } from '~/domains/transaction/transaction.helper';
-import {
-  SUBMISSION_RESULT_LABELS,
-  SubmissionKey,
-} from '~/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component';
+import { SubmissionKey } from '~/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component';
 
 export interface ChipData {
   chipLabel: string;

--- a/interfaces/portal/src/app/components/colored-chip/colored-chip.helper.ts
+++ b/interfaces/portal/src/app/components/colored-chip/colored-chip.helper.ts
@@ -15,6 +15,10 @@ import {
   REGISTRATION_STATUS_LABELS,
 } from '~/domains/registration/registration.helper';
 import { TRANSACTION_STATUS_LABELS } from '~/domains/transaction/transaction.helper';
+import {
+  SUBMISSION_RESULT_LABELS,
+  SubmissionKey,
+} from '~/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component';
 
 export interface ChipData {
   chipLabel: string;
@@ -115,5 +119,18 @@ export const getChipDataByDuplicateStatus = (
     chipVariants: {
       [DuplicateStatus.unique]: 'green',
       [DuplicateStatus.duplicate]: 'red',
+    },
+  });
+
+export const getChipDataBySubmissionsKey = (
+  status?: null | SubmissionKey,
+): ChipData =>
+  mapValueToChipData({
+    value: status,
+    labels: SUBMISSION_RESULT_LABELS,
+    chipVariants: {
+      [SubmissionKey.Failed]: 'red',
+      [SubmissionKey.Imported]: 'green',
+      [SubmissionKey.Skipped]: 'orange',
     },
   });

--- a/interfaces/portal/src/app/domains/kobo/kobo-api.service.ts
+++ b/interfaces/portal/src/app/domains/kobo/kobo-api.service.ts
@@ -2,6 +2,7 @@ import { HttpStatusCode } from '@angular/common/http';
 import { Injectable, Signal } from '@angular/core';
 
 import { CreateKoboDto } from '@121-service/src/kobo/dtos/create-kobo.dto';
+import { ImportExistingSubmissionsResultDto } from '@121-service/src/kobo/dtos/import-existing-submissions-result.dto';
 import { KoboIntegrationResultDto } from '@121-service/src/kobo/dtos/kobo-integration-result.dto';
 import { KoboResponseDto } from '@121-service/src/kobo/dtos/kobo-response.dto';
 
@@ -53,6 +54,18 @@ export class KoboApiService extends DomainApiService {
       httpParams: {
         dryRun,
       },
+    });
+  }
+
+  importExistingSubmissions(programId: Signal<number | string>) {
+    return this.httpWrapperService.perform121ServiceRequest<
+      Dto<ImportExistingSubmissionsResultDto>
+    >({
+      method: 'PATCH',
+      endpoint: this.pathToQueryKey([
+        ...BASE_ENDPOINT(programId),
+        'submissions',
+      ]).join('/'),
     });
   }
 }

--- a/interfaces/portal/src/app/domains/kobo/kobo.helpers.ts
+++ b/interfaces/portal/src/app/domains/kobo/kobo.helpers.ts
@@ -3,8 +3,6 @@ import { withoutTrailingSlash } from 'ufo';
 
 import { KoboResponseDto } from '@121-service/src/kobo/dtos/kobo-response.dto';
 
-import { SubmissionKey } from '~/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component';
-
 const KOBO_URL_FORMS_PREFIX = 'forms';
 
 export const isKoboIntegrated = (
@@ -56,8 +54,17 @@ export const extractServerAndAssetIdFromUrl = (
   return {};
 };
 
-export const SUBMISSION_RESULT_LABELS: Record<SubmissionKey, string> = {
-  [SubmissionKey.Failed]: $localize`:@@submission-result-failed:Submissions failed`,
-  [SubmissionKey.Imported]: $localize`:@@submission-result-imported:Imported successfully`,
-  [SubmissionKey.Skipped]: $localize`:@@submission-result-skipped:Submissions skipped`,
+export enum ImportExistingSubmissionsResultKey {
+  numberOfSubmissionsFailed = 'numberOfSubmissionsFailed',
+  numberOfSubmissionsImported = 'numberOfSubmissionsImported',
+  numberOfSubmissionsSkipped = 'numberOfSubmissionsSkipped',
+}
+
+export const SUBMISSION_RESULT_LABELS: Record<
+  ImportExistingSubmissionsResultKey,
+  string
+> = {
+  [ImportExistingSubmissionsResultKey.numberOfSubmissionsFailed]: $localize`:@@submission-result-failed:Submissions failed`,
+  [ImportExistingSubmissionsResultKey.numberOfSubmissionsImported]: $localize`:@@submission-result-imported:Imported successfully`,
+  [ImportExistingSubmissionsResultKey.numberOfSubmissionsSkipped]: $localize`:@@submission-result-skipped:Submissions skipped`,
 };

--- a/interfaces/portal/src/app/domains/kobo/kobo.helpers.ts
+++ b/interfaces/portal/src/app/domains/kobo/kobo.helpers.ts
@@ -3,6 +3,8 @@ import { withoutTrailingSlash } from 'ufo';
 
 import { KoboResponseDto } from '@121-service/src/kobo/dtos/kobo-response.dto';
 
+import { SubmissionKey } from '~/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component';
+
 const KOBO_URL_FORMS_PREFIX = 'forms';
 
 export const isKoboIntegrated = (
@@ -52,4 +54,10 @@ export const extractServerAndAssetIdFromUrl = (
   }
 
   return {};
+};
+
+export const SUBMISSION_RESULT_LABELS: Record<SubmissionKey, string> = {
+  [SubmissionKey.Failed]: $localize`:@@submission-result-failed:Submissions failed`,
+  [SubmissionKey.Imported]: $localize`:@@submission-result-imported:Imported successfully`,
+  [SubmissionKey.Skipped]: $localize`:@@submission-result-skipped:Submissions skipped`,
 };

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/KoboImportExistingRegistrationsDialogState.enum.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/KoboImportExistingRegistrationsDialogState.enum.ts
@@ -1,0 +1,6 @@
+export enum DialogState {
+  ImportedWithErrors = 'importedWithErrors',
+  ImportedWithoutErrors = 'importedWithoutErrors',
+  ImportedWithoutSubmissions = 'importedWithoutSubmissions',
+  NotInitiated = 'notInitiated',
+}

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
@@ -1,0 +1,81 @@
+<p-dialog
+  #confirmDialog
+  [modal]="true"
+  [(visible)]="responseDialogVisible"
+  [style]="{ width: dialogWidth() }"
+  (onHide)="closeDialogAndResetDialogState()"
+  appendTo="body"
+>
+  <ng-template pTemplate="header">
+    <div class="flex items-center gap-2">
+      <h3>
+        <i [class]="headerIcon()"></i>
+        {{ dialogTitle() }}
+      </h3>
+    </div>
+  </ng-template>
+
+  @if (this.importState() === 'NotInitiated') {
+    <div>
+      <p i18n>Import existing registrations from your Kobo form.</p>
+      <p i18n>
+        The system will create registrations with the status
+        <app-colored-chip
+          [label]="'New'"
+          [variant]="'blue'"
+        />
+      </p>
+      <p i18n>The import takes about 1 minute per 100 records.</p>
+    </div>
+
+    <div class="mt-5 flex justify-end gap-4">
+      <p-button
+        label="Cancel"
+        i18n-label
+        severity="secondary"
+        (click)="responseDialogVisible.set(false)"
+      />
+      <p-button
+        label="Import registrations"
+        i18n-label
+        (click)="importExistingSubmissions.mutate()"
+        [loading]="importExistingSubmissions.isPending()"
+      />
+    </div>
+  }
+
+  @if (this.importState() === 'ImportedWithoutErrors') {
+    <div>
+      <p i18n>
+        Successfully imported submissions from Kobo form ”{{
+          koboIntegration.data()?.name
+        }}”
+      </p>
+
+      <p
+        i18n
+        class="font-bold"
+      >
+        {{ importExistingSubmissions.data()?.numberOfSubmissionsImported }}
+        total submissions
+      </p>
+
+      <app-colored-chip
+        [label]="`imported succesfully ${importExistingSubmissions.data()?.numberOfSubmissionsImported}`"
+        [variant]="'green'"
+      />
+    </div>
+
+    <div class="mt-5 flex justify-end gap-4">
+      <p-button
+        label="Close"
+        i18n-label
+        (click)="responseDialogVisible.set(false)"
+      />
+    </div>
+  }
+
+  @if (this.importState() === 'ImportedWithErrors') {
+    <div i18n>All is wrong</div>
+  }
+</p-dialog>

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
@@ -85,8 +85,12 @@
           ) {
             <div class="flex items-center gap-1">
               <app-colored-chip
-                [label]="`${getChipLabelBySubmissionKey(SubmissionKey.Skipped)}: ${importExistingSubmissions.data()?.numberOfSubmissionsSkipped ?? 0}`"
-                [variant]="getChipVariantBySubmissionKey(SubmissionKey.Skipped)"
+                [label]="`${getChipLabelBySubmissionKey(importExistingSubmissionsResultKey.numberOfSubmissionsSkipped)}: ${importExistingSubmissions.data()?.numberOfSubmissionsSkipped ?? 0}`"
+                [variant]="
+                  getChipVariantBySubmissionKey(
+                    importExistingSubmissionsResultKey.numberOfSubmissionsSkipped
+                  )
+                "
                 [icon]="'pi pi-fast-forward'"
                 class="block"
                 i18n-icon
@@ -104,8 +108,12 @@
               ?.numberOfSubmissionsImported !== 0
           ) {
             <app-colored-chip
-              [label]="`${getChipLabelBySubmissionKey(SubmissionKey.Imported)}: ${importExistingSubmissions.data()?.numberOfSubmissionsImported ?? 0}`"
-              [variant]="getChipVariantBySubmissionKey(SubmissionKey.Imported)"
+              [label]="`${getChipLabelBySubmissionKey(importExistingSubmissionsResultKey.numberOfSubmissionsImported)}: ${importExistingSubmissions.data()?.numberOfSubmissionsImported ?? 0}`"
+              [variant]="
+                getChipVariantBySubmissionKey(
+                  importExistingSubmissionsResultKey.numberOfSubmissionsImported
+                )
+              "
               [icon]="'pi pi-check'"
               class="block"
               i18n-icon
@@ -130,8 +138,12 @@
       <div>
         <div class="mt-4 space-y-2">
           <app-colored-chip
-            [label]="`${getChipLabelBySubmissionKey(SubmissionKey.Failed)}: ${importExistingSubmissions.data()?.numberOfSubmissionsFailed ?? 0}`"
-            [variant]="getChipVariantBySubmissionKey(SubmissionKey.Failed)"
+            [label]="`${getChipLabelBySubmissionKey(importExistingSubmissionsResultKey.numberOfSubmissionsFailed)}: ${importExistingSubmissions.data()?.numberOfSubmissionsFailed ?? 0}`"
+            [variant]="
+              getChipVariantBySubmissionKey(
+                importExistingSubmissionsResultKey.numberOfSubmissionsFailed
+              )
+            "
             [icon]="'pi pi-exclamation-triangle'"
             class="block"
           />

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
@@ -15,7 +15,7 @@
     </div>
   </ng-template>
 
-  @if (this.importState() === 'NotInitiated') {
+  @if (this.importState() === ImportStates.NotInitiated) {
     <div>
       <p i18n>Import existing registrations from your Kobo form.</p>
       <p i18n>
@@ -44,7 +44,7 @@
     </div>
   }
 
-  @if (this.importState() === 'ImportedWithoutErrors') {
+  @if (this.importState() === ImportStates.ImportedWithoutErrors) {
     <div>
       <p i18n>
         Successfully imported submissions from Kobo form ”{{
@@ -52,18 +52,21 @@
         }}”
       </p>
 
-      <p
-        i18n
-        class="font-bold"
-      >
-        {{ importExistingSubmissions.data()?.numberOfSubmissionsImported }}
-        total submissions
-      </p>
+      <div class="mt-4 space-y-2">
+        <p
+          i18n
+          class="font-bold"
+        >
+          {{ importExistingSubmissions.data()?.numberOfSubmissionsImported }}
+          total submissions
+        </p>
 
-      <app-colored-chip
-        [label]="`imported succesfully ${importExistingSubmissions.data()?.numberOfSubmissionsImported}`"
-        [variant]="'green'"
-      />
+        <app-colored-chip
+          [label]="`imported succesfully ${importExistingSubmissions.data()?.numberOfSubmissionsImported}`"
+          [variant]="'green'"
+          class="block"
+        />
+      </div>
     </div>
 
     <div class="mt-5 flex justify-end gap-4">
@@ -75,7 +78,16 @@
     </div>
   }
 
-  @if (this.importState() === 'ImportedWithErrors') {
-    <div i18n>All is wrong</div>
+  @if (this.importState() === ImportStates.ImportedWithErrors) {
+    <div>
+      <div i18n>All is wrong</div>
+      <div class="mt-5 flex justify-end gap-4">
+        <p-button
+          label="Try again"
+          i18n-label
+          (click)="this.importState.set(ImportStates.NotInitiated)"
+        />
+      </div>
+    </div>
   }
 </p-dialog>

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
@@ -47,6 +47,23 @@
     </div>
   }
 
+  @if (importState() === ImportStates.ImportedWithoutSubmissions) {
+    <p i18n>
+      Kobo form ”25042025 Prototype Sprint” does not have existing
+      registrations. New registrations will be synced to the program
+      automatically.
+    </p>
+
+    <div class="mt-5 flex justify-end gap-4">
+      <p-button
+        label="Close"
+        i18n-label
+        (click)="closeDialog()"
+        [rounded]="true"
+      />
+    </div>
+  }
+
   @if (
     importState() === ImportStates.ImportedWithoutErrors ||
     importState() === ImportStates.ImportedWithErrors
@@ -58,23 +75,39 @@
       </p>
 
       <div class="mt-4 space-y-2">
-        <p
-          i18n
-          class="font-bold"
-        >
-          {{ importExistingSubmissions.data()?.numberOfSubmissionsImported }}
-          total submissions
+        <p class="font-bold">
+          {{ submissionCountTranslations().totalSubmissions }}
         </p>
 
-        <app-colored-chip
-          [label]="
-            submissionCountTranslations().numberOfSubmissionsImportedChipLabel
-          "
-          [variant]="'green'"
-          [icon]="'pi pi-check'"
-          class="block"
-          i18n-icon
-        />
+        @if (
+          this.importExistingSubmissions.data()?.numberOfSubmissionsSkipped !==
+          0
+        ) {
+          <app-colored-chip
+            [label]="
+              submissionCountTranslations().numberOfSubmissionsSkippedChipLabel
+            "
+            [variant]="'grey'"
+            [icon]="'pi pi-check'"
+            class="block"
+            i18n-icon
+          />
+        }
+
+        @if (
+          this.importExistingSubmissions.data()?.numberOfSubmissionsImported !==
+          0
+        ) {
+          <app-colored-chip
+            [label]="
+              submissionCountTranslations().numberOfSubmissionsImportedChipLabel
+            "
+            [variant]="'green'"
+            [icon]="'pi pi-check'"
+            class="block"
+            i18n-icon
+          />
+        }
       </div>
     </div>
   }
@@ -83,7 +116,7 @@
     <div class="mt-5 flex justify-end gap-4">
       <p-button
         label="Close"
-        i18n-label="@@generic-close"
+        i18n-label
         (click)="closeDialog()"
         [rounded]="true"
       />
@@ -110,16 +143,21 @@
       <app-query-table
         [items]="detailedImportErrors() ?? []"
         [columns]="detailedErrorsColumns()"
-        [initialSortField]="'id'"
+        [initialSortField]="'referenceId'"
         [isPending]="false"
+        [dataTestId]="'kobo-import-existing-registration-dialog-errors-table'"
+        [paginatorDropdownAppendTo]="'body'"
+        [scrollHeight]="'400px'"
+        [scrollable]="true"
       >
       </app-query-table>
+
       <div class="mt-5 flex justify-end gap-4">
         <p-button
           (click)="importState.set(ImportStates.NotInitiated)"
           label="Try again"
-          i18n-label
           [rounded]="true"
+          i18n-label
         />
       </div>
     </div>

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
@@ -1,8 +1,7 @@
 <p-dialog
-  [(visible)]="responseDialogVisible"
+  [(visible)]="dialogVisible"
   [style]="{ width: dialogWidth() }"
   (onHide)="resetDialogState()"
-  [attr.data-testid]="'import-existing-kobo-registrations-dialog'"
   [draggable]="false"
   appendTo="body"
   #confirmDialog
@@ -17,154 +16,157 @@
     </div>
   </ng-template>
 
-  @if (importState() === DialogState.NotInitiated) {
-    <div>
-      <p i18n>Import existing registrations from your Kobo form.</p>
-      <p i18n>
-        The system will create registrations with the status
-        <app-colored-chip
-          [variant]="chipsColors.new"
-          [label]="'New'"
-        />
-      </p>
-      <p i18n>The import takes about 1 minute per 100 records.</p>
-    </div>
-
-    <div class="mt-5 flex justify-end gap-4">
-      <p-button
-        (click)="responseDialogVisible.set(false)"
-        severity="secondary"
-        [rounded]="true"
-        label="Cancel"
-        i18n-label
-      />
-      <p-button
-        [loading]="importExistingSubmissions.isPending()"
-        (click)="importExistingSubmissions.mutate()"
-        label="Import registrations"
-        [rounded]="true"
-        i18n-label
-      />
-    </div>
-  }
-
-  @if (importState() === DialogState.ImportedWithoutSubmissions) {
-    <p>{{ noExistingSubmissionsTranslation() }}</p>
-
-    <div class="mt-5 flex justify-end gap-4">
-      <p-button
-        (click)="closeDialog()"
-        [rounded]="true"
-        label="Close"
-        i18n-label
-      />
-    </div>
-  }
-
-  @if (
-    importState() === DialogState.ImportedWithoutErrors ||
-    importState() === DialogState.ImportedWithErrors
-  ) {
-    <div>
-      <p>
-        <span i18n> Successfully imported submissions from Kobo form </span>
-        <span>”{{ koboIntegration.data()?.name }}”</span>
-      </p>
-
-      <div class="mt-4 space-y-2">
-        <p class="font-bold">
-          {{ submissionCountTranslations().totalSubmissions }}
-        </p>
-
-        @if (
-          this.importExistingSubmissions.data()?.numberOfSubmissionsSkipped !==
-          0
-        ) {
-          <div class="flex items-center gap-1">
-            <app-colored-chip
-              [label]="
-                submissionCountTranslations()
-                  .numberOfSubmissionsSkippedChipLabel
-              "
-              [variant]="chipsColors.numberOfSubmissionsSkipped"
-              [icon]="'pi pi-fast-forward'"
-              class="block"
-              i18n-icon
-            />
-            <app-info-tooltip
-              i18n-tooltip
-              message="Submissions that have been added to the program already are skipped to avoid duplications."
-              i18n-message
-            />
-          </div>
-        }
-
-        @if (
-          this.importExistingSubmissions.data()?.numberOfSubmissionsImported !==
-          0
-        ) {
+  <section data-testid="import-existing-kobo-registrations-dialog">
+    @if (importState() === DialogState.NotInitiated) {
+      <div>
+        <p i18n>Import existing registrations from your Kobo form.</p>
+        <p i18n>
+          The system will create registrations with the status
           <app-colored-chip
-            [label]="
-              submissionCountTranslations().numberOfSubmissionsImportedChipLabel
-            "
-            [variant]="chipsColors.numberOfSubmissionsImported"
-            [icon]="'pi pi-check'"
-            class="block"
-            i18n-icon
+            [variant]="chipsColors.new"
+            [label]="'New'"
           />
-        }
+        </p>
+        <p i18n>The import takes about 1 minute per 100 records.</p>
       </div>
-    </div>
-  }
-
-  @if (importState() === DialogState.ImportedWithoutErrors) {
-    <div class="mt-5 flex justify-end gap-4">
-      <p-button
-        label="Close"
-        i18n-label
-        (click)="closeDialog()"
-        [rounded]="true"
-      />
-    </div>
-  }
-
-  @if (importState() === DialogState.ImportedWithErrors) {
-    <div>
-      <div class="mt-4 space-y-2">
-        <app-colored-chip
-          [label]="
-            submissionCountTranslations().numberOfSubmissionsFailedChipLabel
-          "
-          [variant]="chipsColors.numberOfSubmissionsFailed"
-          [icon]="'pi pi-exclamation-triangle'"
-          class="block"
-        />
-
-        <app-form-error
-          [error]="'Below are the errors corresponding to the failed submissions. Correct the submissions in the kobo form and try again.'"
-        />
-      </div>
-
-      <app-query-table
-        [items]="detailedImportErrors() ?? []"
-        [columns]="detailedErrorsColumns()"
-        [initialSortField]="'referenceId'"
-        [isPending]="false"
-        [dataTestId]="'kobo-import-existing-registration-dialog-errors-table'"
-        [paginatorDropdownAppendTo]="'body'"
-        [scrollHeight]="'400px'"
-        [scrollable]="true"
-      >
-      </app-query-table>
 
       <div class="mt-5 flex justify-end gap-4">
         <p-button
-          (click)="importState.set(DialogState.NotInitiated)"
-          label="Try again"
+          (click)="dialogVisible.set(false)"
+          severity="secondary"
+          [rounded]="true"
+          label="Cancel"
+          i18n-label
+        />
+        <p-button
+          [loading]="importExistingSubmissions.isPending()"
+          (click)="importExistingSubmissions.mutate()"
+          label="Import registrations"
           [rounded]="true"
           i18n-label
         />
       </div>
-    </div>
-  }
+    }
+
+    @if (importState() === DialogState.ImportedWithoutSubmissions) {
+      <p>{{ noExistingSubmissionsTranslation() }}</p>
+
+      <div class="mt-5 flex justify-end gap-4">
+        <p-button
+          (click)="closeDialog()"
+          [rounded]="true"
+          label="Close"
+          i18n-label
+        />
+      </div>
+    }
+
+    @if (
+      importState() === DialogState.ImportedWithoutErrors ||
+      importState() === DialogState.ImportedWithErrors
+    ) {
+      <div>
+        <p>
+          <span i18n> Successfully imported submissions from Kobo form </span>
+          <span>”{{ koboIntegration.data()?.name }}”</span>
+        </p>
+
+        <div class="mt-4 space-y-2">
+          <p class="font-bold">
+            {{ submissionCountTranslations().totalSubmissions }}
+          </p>
+
+          @if (
+            this.importExistingSubmissions.data()
+              ?.numberOfSubmissionsSkipped !== 0
+          ) {
+            <div class="flex items-center gap-1">
+              <app-colored-chip
+                [label]="
+                  submissionCountTranslations()
+                    .numberOfSubmissionsSkippedChipLabel
+                "
+                [variant]="chipsColors.numberOfSubmissionsSkipped"
+                [icon]="'pi pi-fast-forward'"
+                class="block"
+                i18n-icon
+              />
+              <app-info-tooltip
+                i18n-tooltip
+                message="Submissions that have been added to the program already are skipped to avoid duplications."
+                i18n-message
+              />
+            </div>
+          }
+
+          @if (
+            this.importExistingSubmissions.data()
+              ?.numberOfSubmissionsImported !== 0
+          ) {
+            <app-colored-chip
+              [label]="
+                submissionCountTranslations()
+                  .numberOfSubmissionsImportedChipLabel
+              "
+              [variant]="chipsColors.numberOfSubmissionsImported"
+              [icon]="'pi pi-check'"
+              class="block"
+              i18n-icon
+            />
+          }
+        </div>
+      </div>
+    }
+
+    @if (importState() === DialogState.ImportedWithoutErrors) {
+      <div class="mt-5 flex justify-end gap-4">
+        <p-button
+          label="Close"
+          i18n-label
+          (click)="closeDialog()"
+          [rounded]="true"
+        />
+      </div>
+    }
+
+    @if (importState() === DialogState.ImportedWithErrors) {
+      <div>
+        <div class="mt-4 space-y-2">
+          <app-colored-chip
+            [label]="
+              submissionCountTranslations().numberOfSubmissionsFailedChipLabel
+            "
+            [variant]="chipsColors.numberOfSubmissionsFailed"
+            [icon]="'pi pi-exclamation-triangle'"
+            class="block"
+          />
+
+          <app-form-error
+            [error]="'Below are the errors corresponding to the failed submissions. Correct the submissions in the kobo form and try again.'"
+          />
+        </div>
+
+        <app-query-table
+          [items]="detailedImportErrors() ?? []"
+          [columns]="detailedErrorsColumns()"
+          [initialSortField]="'referenceId'"
+          [isPending]="false"
+          [dataTestId]="'kobo-import-existing-registration-dialog-errors-table'"
+          [paginatorDropdownAppendTo]="'body'"
+          [scrollHeight]="'400px'"
+          [scrollable]="true"
+        >
+        </app-query-table>
+
+        <div class="mt-5 flex justify-end gap-4">
+          <p-button
+            (click)="resetDialogState()"
+            label="Try again"
+            [rounded]="true"
+            i18n-label
+          />
+        </div>
+      </div>
+    }
+  </section>
 </p-dialog>

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
@@ -2,6 +2,7 @@
   [(visible)]="responseDialogVisible"
   [style]="{ width: dialogWidth() }"
   (onHide)="resetDialogState()"
+  [attr.data-testid]="'import-existing-kobo-registrations-dialog'"
   [draggable]="false"
   appendTo="body"
   #confirmDialog
@@ -33,8 +34,8 @@
       <p-button
         (click)="responseDialogVisible.set(false)"
         severity="secondary"
-        label="Cancel"
         [rounded]="true"
+        label="Cancel"
         i18n-label
       />
       <p-button

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
@@ -1,10 +1,11 @@
 <p-dialog
-  #confirmDialog
-  [modal]="true"
   [(visible)]="responseDialogVisible"
   [style]="{ width: dialogWidth() }"
   (onHide)="resetDialogState()"
+  [draggable]="false"
   appendTo="body"
+  #confirmDialog
+  [modal]="true"
 >
   <ng-template pTemplate="header">
     <div class="flex items-center gap-2">
@@ -21,8 +22,8 @@
       <p i18n>
         The system will create registrations with the status
         <app-colored-chip
-          [label]="'New'"
           [variant]="'blue'"
+          [label]="'New'"
         />
       </p>
       <p i18n>The import takes about 1 minute per 100 records.</p>
@@ -30,26 +31,28 @@
 
     <div class="mt-5 flex justify-end gap-4">
       <p-button
+        (click)="responseDialogVisible.set(false)"
+        severity="secondary"
         label="Cancel"
         i18n-label
-        severity="secondary"
-        (click)="responseDialogVisible.set(false)"
       />
       <p-button
+        [loading]="importExistingSubmissions.isPending()"
+        (click)="importExistingSubmissions.mutate()"
         label="Import registrations"
         i18n-label
-        (click)="importExistingSubmissions.mutate()"
-        [loading]="importExistingSubmissions.isPending()"
       />
     </div>
   }
 
-  @if (this.importState() === ImportStates.ImportedWithoutErrors) {
+  @if (
+    this.importState() === ImportStates.ImportedWithoutErrors ||
+    this.importState() === ImportStates.ImportedWithErrors
+  ) {
     <div>
-      <p i18n>
-        Successfully imported submissions from Kobo form ”{{
-          koboIntegration.data()?.name
-        }}”
+      <p>
+        <span i18n> Successfully imported submissions from Kobo form </span>
+        <span>”{{ koboIntegration.data()?.name }}”</span>
       </p>
 
       <div class="mt-4 space-y-2">
@@ -62,13 +65,19 @@
         </p>
 
         <app-colored-chip
-          [label]="`imported successfully ${importExistingSubmissions.data()?.numberOfSubmissionsImported}`"
+          [label]="
+            submissionCountTranslations().numberOfSubmissionsImportedChipLabel
+          "
           [variant]="'green'"
+          [icon]="'pi pi-check'"
           class="block"
+          i18n-icon
         />
       </div>
     </div>
+  }
 
+  @if (this.importState() === ImportStates.ImportedWithoutErrors) {
     <div class="mt-5 flex justify-end gap-4">
       <p-button
         label="Close"
@@ -80,7 +89,28 @@
 
   @if (this.importState() === ImportStates.ImportedWithErrors) {
     <div>
-      <div i18n>All is wrong</div>
+      <div class="mt-4 space-y-2">
+        <app-colored-chip
+          [label]="
+            submissionCountTranslations().numberOfSubmissionsFailedChipLabel
+          "
+          [variant]="'red'"
+          [icon]="'pi pi-exclamation-triangle'"
+          class="block"
+        />
+
+        <app-form-error
+          [error]="'Below are the errors corresponding to the failed submissions. Correct the submissions in the kobo form and try again.'"
+        />
+      </div>
+
+      <app-query-table
+        [items]="detailedImportErrors() ?? []"
+        [columns]="detailedErrorsColumns()"
+        [initialSortField]="'id'"
+        [isPending]="false"
+      >
+      </app-query-table>
       <div class="mt-5 flex justify-end gap-4">
         <p-button
           label="Try again"

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
@@ -22,9 +22,11 @@
         <p i18n>Import existing registrations from your Kobo form.</p>
         <p i18n>
           The system will create registrations with the status
+          <!-- This is a one off label for this view -->
           <app-colored-chip
-            [variant]="chipsColors.new"
-            [label]="'New'"
+            [variant]="'blue'"
+            label="'New'"
+            i18n-label
           />
         </p>
         <p i18n>The import takes about 1 minute per 100 records.</p>
@@ -67,13 +69,14 @@
     ) {
       <div>
         <p>
-          <span i18n> Successfully imported submissions from Kobo form </span>
+          <span i18n>Successfully imported submissions from Kobo form</span
+          >&nbsp;
           <span>”{{ koboIntegration.data()?.name }}”</span>
         </p>
 
         <div class="mt-4 space-y-2">
           <p class="font-bold">
-            {{ submissionCountTranslations().totalSubmissions }}
+            {{ totalSubmissionsTranslation() }}
           </p>
 
           @if (
@@ -82,11 +85,8 @@
           ) {
             <div class="flex items-center gap-1">
               <app-colored-chip
-                [label]="
-                  submissionCountTranslations()
-                    .numberOfSubmissionsSkippedChipLabel
-                "
-                [variant]="chipsColors.numberOfSubmissionsSkipped"
+                [label]="`${getChipLabelBySubmissionKey(SubmissionKey.Skipped)}: ${importExistingSubmissions.data()?.numberOfSubmissionsSkipped ?? 0}`"
+                [variant]="getChipVariantBySubmissionKey(SubmissionKey.Skipped)"
                 [icon]="'pi pi-fast-forward'"
                 class="block"
                 i18n-icon
@@ -104,11 +104,8 @@
               ?.numberOfSubmissionsImported !== 0
           ) {
             <app-colored-chip
-              [label]="
-                submissionCountTranslations()
-                  .numberOfSubmissionsImportedChipLabel
-              "
-              [variant]="chipsColors.numberOfSubmissionsImported"
+              [label]="`${getChipLabelBySubmissionKey(SubmissionKey.Imported)}: ${importExistingSubmissions.data()?.numberOfSubmissionsImported ?? 0}`"
+              [variant]="getChipVariantBySubmissionKey(SubmissionKey.Imported)"
               [icon]="'pi pi-check'"
               class="block"
               i18n-icon
@@ -133,10 +130,8 @@
       <div>
         <div class="mt-4 space-y-2">
           <app-colored-chip
-            [label]="
-              submissionCountTranslations().numberOfSubmissionsFailedChipLabel
-            "
-            [variant]="chipsColors.numberOfSubmissionsFailed"
+            [label]="`${getChipLabelBySubmissionKey(SubmissionKey.Failed)}: ${importExistingSubmissions.data()?.numberOfSubmissionsFailed ?? 0}`"
+            [variant]="getChipVariantBySubmissionKey(SubmissionKey.Failed)"
             [icon]="'pi pi-exclamation-triangle'"
             class="block"
           />

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
@@ -17,13 +17,13 @@
     </div>
   </ng-template>
 
-  @if (importState() === ImportStates.NotInitiated) {
+  @if (importState() === DialogState.NotInitiated) {
     <div>
       <p i18n>Import existing registrations from your Kobo form.</p>
       <p i18n>
         The system will create registrations with the status
         <app-colored-chip
-          [variant]="'blue'"
+          [variant]="chipsColors.new"
           [label]="'New'"
         />
       </p>
@@ -48,26 +48,22 @@
     </div>
   }
 
-  @if (importState() === ImportStates.ImportedWithoutSubmissions) {
-    <p i18n>
-      Kobo form ”25042025 Prototype Sprint” does not have existing
-      registrations. New registrations will be synced to the program
-      automatically.
-    </p>
+  @if (importState() === DialogState.ImportedWithoutSubmissions) {
+    <p>{{ noExistingSubmissionsTranslation() }}</p>
 
     <div class="mt-5 flex justify-end gap-4">
       <p-button
-        label="Close"
-        i18n-label
         (click)="closeDialog()"
         [rounded]="true"
+        label="Close"
+        i18n-label
       />
     </div>
   }
 
   @if (
-    importState() === ImportStates.ImportedWithoutErrors ||
-    importState() === ImportStates.ImportedWithErrors
+    importState() === DialogState.ImportedWithoutErrors ||
+    importState() === DialogState.ImportedWithErrors
   ) {
     <div>
       <p>
@@ -84,15 +80,23 @@
           this.importExistingSubmissions.data()?.numberOfSubmissionsSkipped !==
           0
         ) {
-          <app-colored-chip
-            [label]="
-              submissionCountTranslations().numberOfSubmissionsSkippedChipLabel
-            "
-            [variant]="'grey'"
-            [icon]="'pi pi-check'"
-            class="block"
-            i18n-icon
-          />
+          <div class="flex items-center gap-1">
+            <app-colored-chip
+              [label]="
+                submissionCountTranslations()
+                  .numberOfSubmissionsSkippedChipLabel
+              "
+              [variant]="chipsColors.numberOfSubmissionsSkipped"
+              [icon]="'pi pi-fast-forward'"
+              class="block"
+              i18n-icon
+            />
+            <app-info-tooltip
+              i18n-tooltip
+              message="Submissions that have been added to the program already are skipped to avoid duplications."
+              i18n-message
+            />
+          </div>
         }
 
         @if (
@@ -103,7 +107,7 @@
             [label]="
               submissionCountTranslations().numberOfSubmissionsImportedChipLabel
             "
-            [variant]="'green'"
+            [variant]="chipsColors.numberOfSubmissionsImported"
             [icon]="'pi pi-check'"
             class="block"
             i18n-icon
@@ -113,7 +117,7 @@
     </div>
   }
 
-  @if (importState() === ImportStates.ImportedWithoutErrors) {
+  @if (importState() === DialogState.ImportedWithoutErrors) {
     <div class="mt-5 flex justify-end gap-4">
       <p-button
         label="Close"
@@ -124,14 +128,14 @@
     </div>
   }
 
-  @if (importState() === ImportStates.ImportedWithErrors) {
+  @if (importState() === DialogState.ImportedWithErrors) {
     <div>
       <div class="mt-4 space-y-2">
         <app-colored-chip
           [label]="
             submissionCountTranslations().numberOfSubmissionsFailedChipLabel
           "
-          [variant]="'red'"
+          [variant]="chipsColors.numberOfSubmissionsFailed"
           [icon]="'pi pi-exclamation-triangle'"
           class="block"
         />
@@ -155,7 +159,7 @@
 
       <div class="mt-5 flex justify-end gap-4">
         <p-button
-          (click)="importState.set(ImportStates.NotInitiated)"
+          (click)="importState.set(DialogState.NotInitiated)"
           label="Try again"
           [rounded]="true"
           i18n-label

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
@@ -16,7 +16,7 @@
     </div>
   </ng-template>
 
-  @if (this.importState() === ImportStates.NotInitiated) {
+  @if (importState() === ImportStates.NotInitiated) {
     <div>
       <p i18n>Import existing registrations from your Kobo form.</p>
       <p i18n>
@@ -46,8 +46,8 @@
   }
 
   @if (
-    this.importState() === ImportStates.ImportedWithoutErrors ||
-    this.importState() === ImportStates.ImportedWithErrors
+    importState() === ImportStates.ImportedWithoutErrors ||
+    importState() === ImportStates.ImportedWithErrors
   ) {
     <div>
       <p>
@@ -77,17 +77,16 @@
     </div>
   }
 
-  @if (this.importState() === ImportStates.ImportedWithoutErrors) {
+  @if (importState() === ImportStates.ImportedWithoutErrors) {
     <div class="mt-5 flex justify-end gap-4">
       <p-button
-        label="Close"
-        i18n-label
+        i18n-label="@@generic-close"
         (click)="closeDialog()"
       />
     </div>
   }
 
-  @if (this.importState() === ImportStates.ImportedWithErrors) {
+  @if (importState() === ImportStates.ImportedWithErrors) {
     <div>
       <div class="mt-4 space-y-2">
         <app-colored-chip
@@ -113,9 +112,9 @@
       </app-query-table>
       <div class="mt-5 flex justify-end gap-4">
         <p-button
+          (click)="importState.set(ImportStates.NotInitiated)"
           label="Try again"
           i18n-label
-          (click)="this.importState.set(ImportStates.NotInitiated)"
         />
       </div>
     </div>

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
@@ -62,7 +62,7 @@
         </p>
 
         <app-colored-chip
-          [label]="`imported succesfully ${importExistingSubmissions.data()?.numberOfSubmissionsImported}`"
+          [label]="`imported successfully ${importExistingSubmissions.data()?.numberOfSubmissionsImported}`"
           [variant]="'green'"
           class="block"
         />

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
@@ -34,12 +34,14 @@
         (click)="responseDialogVisible.set(false)"
         severity="secondary"
         label="Cancel"
+        [rounded]="true"
         i18n-label
       />
       <p-button
         [loading]="importExistingSubmissions.isPending()"
         (click)="importExistingSubmissions.mutate()"
         label="Import registrations"
+        [rounded]="true"
         i18n-label
       />
     </div>
@@ -80,8 +82,10 @@
   @if (importState() === ImportStates.ImportedWithoutErrors) {
     <div class="mt-5 flex justify-end gap-4">
       <p-button
+        label="Close"
         i18n-label="@@generic-close"
         (click)="closeDialog()"
+        [rounded]="true"
       />
     </div>
   }
@@ -115,6 +119,7 @@
           (click)="importState.set(ImportStates.NotInitiated)"
           label="Try again"
           i18n-label
+          [rounded]="true"
         />
       </div>
     </div>

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.html
@@ -3,7 +3,7 @@
   [modal]="true"
   [(visible)]="responseDialogVisible"
   [style]="{ width: dialogWidth() }"
-  (onHide)="closeDialogAndResetDialogState()"
+  (onHide)="resetDialogState()"
   appendTo="body"
 >
   <ng-template pTemplate="header">
@@ -73,7 +73,7 @@
       <p-button
         label="Close"
         i18n-label
-        (click)="responseDialogVisible.set(false)"
+        (click)="closeDialog()"
       />
     </div>
   }

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -49,6 +49,7 @@ interface ValidationErrorTableRow extends ValidationError {
 })
 export class KoboImportExistingRegistrationsDialogComponent {
   private readonly koboApiService = inject(KoboApiService);
+  private readonly toastService = inject(ToastService);
 
   readonly importState = signal(ImportState.NotInitiated);
   readonly responseDialogVisible = signal(false);
@@ -105,6 +106,12 @@ export class KoboImportExistingRegistrationsDialogComponent {
 
       if (response.validationErrors.length === 0)
         this.importState.set(ImportState.ImportedWithoutErrors);
+    },
+    onError: () => {
+      this.toastService.showToast({
+        severity: 'error',
+        detail: $localize`Error while importing existing Kobo registrations`,
+      });
     },
   }));
 

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -65,6 +65,7 @@ export class KoboImportExistingRegistrationsDialogComponent {
         return 'pi pi-download me-2';
     }
   });
+
   readonly dialogTitle = computed(() => {
     switch (this.importState()) {
       case ImportState.ImportedWithErrors:
@@ -84,12 +85,13 @@ export class KoboImportExistingRegistrationsDialogComponent {
     return {
       totalSubmissions: $localize`${this.importExistingSubmissions.data()?.numberOfSubmissionsOnForm ?? 0}:count: total submission(s)`,
       numberOfSubmissionsImportedChipLabel: $localize`Imported successfully: ${this.importExistingSubmissions.data()?.numberOfSubmissionsImported ?? 0}:count:`,
+      // TODO: What is `numberOfSubmissionsSkipped` supposed to be?
       // numberOfSubmissionsSkippedChipLabel: $localize`Submissions skipped: ${this.importExistingSubmissions.data()?.numberOfSubmissionsSkipped ?? 0}:count:`,
       numberOfSubmissionsFailedChipLabel: $localize`Submissions failed: ${this.importExistingSubmissions.data()?.numberOfSubmissionsFailed ?? 0}:count:`,
     };
   });
 
-  // TODO: ADD SUBMISSIONS SKIPPED STATE
+  // TODO: ADD SUBMISSIONS SKIPPED STATE (?)
 
   readonly koboIntegration = injectQuery(() => ({
     ...this.koboApiService.getKoboIntegration(this.programId)(),
@@ -106,6 +108,8 @@ export class KoboImportExistingRegistrationsDialogComponent {
 
       if (response.validationErrors.length === 0)
         this.importState.set(ImportState.ImportedWithoutErrors);
+
+      // TODO: ADD SUBMISSIONS SKIPPED STATE (?)
     },
     onError: () => {
       this.toastService.showToast({
@@ -137,7 +141,7 @@ export class KoboImportExistingRegistrationsDialogComponent {
   >(() => [
     {
       field: 'referenceId',
-      header: $localize`Reference IDs`,
+      header: $localize`Reference ID`,
     },
     {
       field: 'column',

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -24,6 +24,7 @@ import { FormErrorComponent } from '~/components/form-error/form-error.component
 import { InfoTooltipComponent } from '~/components/info-tooltip/info-tooltip.component';
 import { QueryTableComponent } from '~/components/query-table/query-table.component';
 import { QueryTableColumn } from '~/components/query-table/query-table.types';
+import { ImportExistingSubmissionsResultKey } from '~/domains/kobo/kobo.helpers';
 import { KoboApiService } from '~/domains/kobo/kobo-api.service';
 import { DialogState } from '~/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/KoboImportExistingRegistrationsDialogState.enum';
 import { ToastService } from '~/services/toast.service';
@@ -37,13 +38,6 @@ interface ValidationError {
 interface ValidationErrorTableRow extends ValidationError {
   id: number;
 }
-
-export enum SubmissionKey {
-  Failed = 'numberOfSubmissionsFailed',
-  Imported = 'numberOfSubmissionsImported',
-  Skipped = 'numberOfSubmissionsSkipped',
-}
-
 @Component({
   selector: 'app-kobo-import-existing-registration-dialog',
   imports: [
@@ -169,24 +163,28 @@ export class KoboImportExistingRegistrationsDialogComponent {
     },
   ]);
 
-  // Exposing the enum and chip colors to the template
-
   public get DialogState(): typeof DialogState {
     return DialogState;
   }
 
-  public get SubmissionKey(): typeof SubmissionKey {
-    return SubmissionKey;
+  public get importExistingSubmissionsResultKey(): typeof ImportExistingSubmissionsResultKey {
+    return ImportExistingSubmissionsResultKey;
   }
 
   // Methods
 
-  getChipLabelBySubmissionKey(submissionKey: SubmissionKey): string {
-    return getChipDataBySubmissionsKey(submissionKey).chipLabel;
+  getChipLabelBySubmissionKey(
+    importExistingSubmissionsResultKey: ImportExistingSubmissionsResultKey,
+  ): string {
+    return getChipDataBySubmissionsKey(importExistingSubmissionsResultKey)
+      .chipLabel;
   }
 
-  getChipVariantBySubmissionKey(submissionKey: SubmissionKey): ChipVariant {
-    return getChipDataBySubmissionsKey(submissionKey).chipVariant;
+  getChipVariantBySubmissionKey(
+    importExistingSubmissionsResultKey: ImportExistingSubmissionsResultKey,
+  ): ChipVariant {
+    return getChipDataBySubmissionsKey(importExistingSubmissionsResultKey)
+      .chipVariant;
   }
 
   resetDialogState(): void {

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -4,6 +4,7 @@ import {
   computed,
   inject,
   input,
+  model,
   signal,
 } from '@angular/core';
 
@@ -59,7 +60,7 @@ export class KoboImportExistingRegistrationsDialogComponent {
   private readonly toastService = inject(ToastService);
 
   readonly importState = signal(DialogState.NotInitiated);
-  readonly responseDialogVisible = signal(false);
+  readonly dialogVisible = model(false);
   readonly programId = input.required<number | string>();
 
   readonly headerIcon = computed(() => {
@@ -182,16 +183,16 @@ export class KoboImportExistingRegistrationsDialogComponent {
 
   // Methods
 
-  resetDialogState() {
+  resetDialogState(): void {
     this.importState.set(DialogState.NotInitiated);
     this.importExistingSubmissions.reset();
   }
 
-  closeDialog() {
-    this.responseDialogVisible.set(false);
+  closeDialog(): void {
+    this.dialogVisible.set(false);
   }
 
-  show() {
-    this.responseDialogVisible.set(true);
+  show(): void {
+    this.dialogVisible.set(true);
   }
 }

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -15,7 +15,11 @@ import {
 import { ButtonModule } from 'primeng/button';
 import { DialogModule } from 'primeng/dialog';
 
-import { ColoredChipComponent } from '~/components/colored-chip/colored-chip.component';
+import {
+  ChipVariant,
+  ColoredChipComponent,
+} from '~/components/colored-chip/colored-chip.component';
+import { getChipDataBySubmissionsKey } from '~/components/colored-chip/colored-chip.helper';
 import { FormErrorComponent } from '~/components/form-error/form-error.component';
 import { InfoTooltipComponent } from '~/components/info-tooltip/info-tooltip.component';
 import { QueryTableComponent } from '~/components/query-table/query-table.component';
@@ -34,12 +38,17 @@ interface ValidationErrorTableRow extends ValidationError {
   id: number;
 }
 
-const dialogChipColors = {
-  new: 'blue',
-  numberOfSubmissionsFailed: 'red',
-  numberOfSubmissionsImported: 'green',
-  numberOfSubmissionsSkipped: 'orange',
-} as const;
+export enum SubmissionKey {
+  Failed = 'numberOfSubmissionsFailed',
+  Imported = 'numberOfSubmissionsImported',
+  Skipped = 'numberOfSubmissionsSkipped',
+}
+
+export const SUBMISSION_RESULT_LABELS: Record<SubmissionKey, string> = {
+  [SubmissionKey.Failed]: $localize`:@@submission-result-failed:Submissions failed`,
+  [SubmissionKey.Imported]: $localize`:@@submission-result-imported:Imported successfully`,
+  [SubmissionKey.Skipped]: $localize`:@@submission-result-skipped:Submissions skipped`,
+};
 
 @Component({
   selector: 'app-kobo-import-existing-registration-dialog',
@@ -97,13 +106,8 @@ export class KoboImportExistingRegistrationsDialogComponent {
     return $localize`Kobo form ”${this.koboIntegration.data()?.name}” does not have existing registrations. New registrations will be synced to the program automatically.`;
   });
 
-  readonly submissionCountTranslations = computed(() => {
-    return {
-      totalSubmissions: $localize`${this.importExistingSubmissions.data()?.numberOfSubmissionsOnForm ?? 0}:count: total submission(s)`,
-      numberOfSubmissionsImportedChipLabel: $localize`Imported successfully: ${this.importExistingSubmissions.data()?.numberOfSubmissionsImported ?? 0}:count:`,
-      numberOfSubmissionsSkippedChipLabel: $localize`Submissions skipped: ${this.importExistingSubmissions.data()?.numberOfSubmissionsSkipped ?? 0}:count:`,
-      numberOfSubmissionsFailedChipLabel: $localize`Submissions failed: ${this.importExistingSubmissions.data()?.numberOfSubmissionsFailed ?? 0}:count:`,
-    };
+  readonly totalSubmissionsTranslation = computed(() => {
+    return $localize`${this.importExistingSubmissions.data()?.numberOfSubmissionsOnForm ?? 0}:count: total submission(s)`;
   });
 
   // Kobo integration and import existing submissions mutations
@@ -177,11 +181,19 @@ export class KoboImportExistingRegistrationsDialogComponent {
     return DialogState;
   }
 
-  public get chipsColors(): typeof dialogChipColors {
-    return dialogChipColors;
+  public get SubmissionKey(): typeof SubmissionKey {
+    return SubmissionKey;
   }
 
   // Methods
+
+  getChipLabelBySubmissionKey(submissionKey: SubmissionKey): string {
+    return getChipDataBySubmissionsKey(submissionKey).chipLabel;
+  }
+
+  getChipVariantBySubmissionKey(submissionKey: SubmissionKey): ChipVariant {
+    return getChipDataBySubmissionsKey(submissionKey).chipVariant;
+  }
 
   resetDialogState(): void {
     this.importState.set(DialogState.NotInitiated);

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -15,20 +15,36 @@ import { ButtonModule } from 'primeng/button';
 import { DialogModule } from 'primeng/dialog';
 
 import { ColoredChipComponent } from '~/components/colored-chip/colored-chip.component';
+import { FormErrorComponent } from '~/components/form-error/form-error.component';
+import { QueryTableComponent } from '~/components/query-table/query-table.component';
+import { QueryTableColumn } from '~/components/query-table/query-table.types';
 import { KoboApiService } from '~/domains/kobo/kobo-api.service';
 import { ToastService } from '~/services/toast.service';
+
 enum ImportState {
   ImportedWithErrors = 'ImportedWithErrors',
   ImportedWithoutErrors = 'ImportedWithoutErrors',
   NotInitiated = 'NotInitiated',
 }
-
+interface ValidationError {
+  referenceId: string;
+  column: string;
+  error: string;
+}
+interface ValidationErrorTableRow extends ValidationError {
+  id: number;
+}
 @Component({
   selector: 'app-kobo-import-existing-registration-dialog',
-  imports: [DialogModule, ButtonModule, ColoredChipComponent],
+  imports: [
+    DialogModule,
+    ButtonModule,
+    ColoredChipComponent,
+    QueryTableComponent,
+    FormErrorComponent,
+  ],
   providers: [ToastService],
   templateUrl: './kobo-import-existing-registration-dialog.component.html',
-  styles: ``,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class KoboImportExistingRegistrationsDialogComponent {
@@ -48,7 +64,6 @@ export class KoboImportExistingRegistrationsDialogComponent {
         return 'pi pi-download me-2';
     }
   });
-
   readonly dialogTitle = computed(() => {
     switch (this.importState()) {
       case ImportState.ImportedWithErrors:
@@ -63,6 +78,17 @@ export class KoboImportExistingRegistrationsDialogComponent {
   readonly dialogWidth = computed(() =>
     this.importState() === ImportState.ImportedWithErrors ? '70rem' : '42rem',
   );
+
+  readonly submissionCountTranslations = computed(() => {
+    return {
+      totalSubmissions: $localize`${this.importExistingSubmissions.data()?.numberOfSubmissionsOnForm ?? 0}:count: total submission(s)`,
+      numberOfSubmissionsImportedChipLabel: $localize`Imported successfully: ${this.importExistingSubmissions.data()?.numberOfSubmissionsImported ?? 0}:count:`,
+      // numberOfSubmissionsSkippedChipLabel: $localize`Submissions skipped: ${this.importExistingSubmissions.data()?.numberOfSubmissionsSkipped ?? 0}:count:`,
+      numberOfSubmissionsFailedChipLabel: $localize`Submissions failed: ${this.importExistingSubmissions.data()?.numberOfSubmissionsFailed ?? 0}:count:`,
+    };
+  });
+
+  // TODO: ADD SUBMISSIONS SKIPPED STATE
 
   readonly koboIntegration = injectQuery(() => ({
     ...this.koboApiService.getKoboIntegration(this.programId)(),
@@ -81,6 +107,40 @@ export class KoboImportExistingRegistrationsDialogComponent {
         this.importState.set(ImportState.ImportedWithoutErrors);
     },
   }));
+
+  readonly detailedImportErrors = computed(() => {
+    const errors = this.importExistingSubmissions.data()?.validationErrors;
+
+    if (errors?.length) {
+      // We need to add a ID because the table expects it, without <app-query-table> throws a typescript error
+      const detailedErrorsWithIndexedIds: ValidationErrorTableRow[] =
+        errors.map((error: ValidationError, index: number) => ({
+          ...error,
+          id: index,
+        }));
+
+      return detailedErrorsWithIndexedIds;
+    }
+
+    return undefined;
+  });
+
+  readonly detailedErrorsColumns = computed<
+    QueryTableColumn<ValidationErrorTableRow>[]
+  >(() => [
+    {
+      field: 'referenceId',
+      header: $localize`Reference IDs`,
+    },
+    {
+      field: 'column',
+      header: $localize`Column`,
+    },
+    {
+      field: 'error',
+      header: $localize`Error`,
+    },
+  ]);
 
   public get ImportStates(): typeof ImportState {
     return ImportState;

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -45,7 +45,6 @@ export class KoboImportExistingRegistrationsDialogComponent {
   readonly responseDialogVisible = signal(false);
 
   readonly headerIcon = computed(() => {
-    console.log('importState', this.importState);
     switch (this.importState()) {
       case ImportState.ImportedWithErrors:
         return 'pi pi-exclamation-triangle me-2';
@@ -57,8 +56,6 @@ export class KoboImportExistingRegistrationsDialogComponent {
   });
 
   readonly dialogTitle = computed(() => {
-    console.log('importState', this.importState);
-
     switch (this.importState()) {
       case ImportState.ImportedWithErrors:
         return $localize`Import complete with errors`;
@@ -91,9 +88,17 @@ export class KoboImportExistingRegistrationsDialogComponent {
     },
   }));
 
+  public get ImportStates(): typeof ImportState {
+    return ImportState;
+  }
+
+  setToNotInitiatedState() {
+    this.importState.set(ImportState.NotInitiated);
+  }
+
   closeDialogAndResetDialogState() {
     this.responseDialogVisible.set(false);
-    this.importState.set(ImportState.NotInitiated);
+    this.setToNotInitiatedState();
     this.importExistingSubmissions.reset();
   }
 

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -95,8 +95,6 @@ export class KoboImportExistingRegistrationsDialogComponent {
     };
   });
 
-  // TODO: ADD SUBMISSIONS SKIPPED STATE (?)
-
   readonly koboIntegration = injectQuery(() => ({
     ...this.koboApiService.getKoboIntegration(this.programId)(),
     enabled: !!this.programId(),
@@ -115,8 +113,6 @@ export class KoboImportExistingRegistrationsDialogComponent {
 
       if (response.numberOfSubmissionsOnForm === 0)
         this.importState.set(ImportState.ImportedWithoutSubmissions);
-
-      // TODO: ADD SUBMISSIONS SKIPPED STATE (?)
     },
     onError: () => {
       this.toastService.showToast({

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -1,0 +1,103 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  signal,
+  viewChild,
+} from '@angular/core';
+
+import {
+  injectMutation,
+  injectQuery,
+} from '@tanstack/angular-query-experimental';
+import { ButtonModule } from 'primeng/button';
+import { ConfirmDialog } from 'primeng/confirmdialog';
+import { DialogModule } from 'primeng/dialog';
+
+import { ColoredChipComponent } from '~/components/colored-chip/colored-chip.component';
+import { KoboApiService } from '~/domains/kobo/kobo-api.service';
+import { ToastService } from '~/services/toast.service';
+
+enum ImportState {
+  ImportedWithErrors = 'ImportedWithErrors',
+  ImportedWithoutErrors = 'ImportedWithoutErrors',
+  NotInitiated = 'NotInitiated',
+}
+
+@Component({
+  selector: 'app-kobo-import-existing-registration-dialog',
+  imports: [DialogModule, ButtonModule, ColoredChipComponent],
+  providers: [ToastService],
+  templateUrl: './kobo-import-existing-registration-dialog.component.html',
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class KoboImportExistingRegistrationsDialogComponent {
+  readonly importState = signal(ImportState.NotInitiated);
+
+  readonly programId = input.required<number | string>();
+
+  private readonly koboApiService = inject(KoboApiService);
+  readonly confirmDialog = viewChild.required<ConfirmDialog>('confirmDialog');
+
+  readonly responseDialogVisible = signal(false);
+
+  readonly headerIcon = computed(() => {
+    console.log('importState', this.importState);
+    switch (this.importState()) {
+      case ImportState.ImportedWithErrors:
+        return 'pi pi-exclamation-triangle me-2';
+      case ImportState.ImportedWithoutErrors:
+        return 'pi pi-check me-2';
+      case ImportState.NotInitiated:
+        return 'pi pi-download me-2';
+    }
+  });
+
+  readonly dialogTitle = computed(() => {
+    console.log('importState', this.importState);
+
+    switch (this.importState()) {
+      case ImportState.ImportedWithErrors:
+        return $localize`Import complete with errors`;
+      case ImportState.ImportedWithoutErrors:
+        return $localize`Import complete`;
+      case ImportState.NotInitiated:
+        return $localize`Import existing registrations`;
+    }
+  });
+
+  readonly dialogWidth = computed(() =>
+    this.importState() === ImportState.ImportedWithErrors ? '70rem' : '42rem',
+  );
+
+  readonly koboIntegration = injectQuery(() => ({
+    ...this.koboApiService.getKoboIntegration(this.programId)(),
+    enabled: !!this.programId(),
+  }));
+
+  readonly importExistingSubmissions = injectMutation(() => ({
+    mutationFn: () => {
+      return this.koboApiService.importExistingSubmissions(this.programId);
+    },
+    onSuccess: (response) => {
+      if (response.validationErrors.length)
+        this.importState.set(ImportState.ImportedWithErrors);
+
+      if (response.validationErrors.length === 0)
+        this.importState.set(ImportState.ImportedWithoutErrors);
+    },
+  }));
+
+  closeDialogAndResetDialogState() {
+    this.responseDialogVisible.set(false);
+    this.importState.set(ImportState.NotInitiated);
+    this.importExistingSubmissions.reset();
+  }
+
+  show() {
+    this.responseDialogVisible.set(true);
+  }
+}

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -16,25 +16,30 @@ import { DialogModule } from 'primeng/dialog';
 
 import { ColoredChipComponent } from '~/components/colored-chip/colored-chip.component';
 import { FormErrorComponent } from '~/components/form-error/form-error.component';
+import { InfoTooltipComponent } from '~/components/info-tooltip/info-tooltip.component';
 import { QueryTableComponent } from '~/components/query-table/query-table.component';
 import { QueryTableColumn } from '~/components/query-table/query-table.types';
 import { KoboApiService } from '~/domains/kobo/kobo-api.service';
+import { DialogState } from '~/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/KoboImportExistingRegistrationsDialogState.enum';
 import { ToastService } from '~/services/toast.service';
 
-enum ImportState {
-  ImportedWithErrors = 'ImportedWithErrors',
-  ImportedWithoutErrors = 'ImportedWithoutErrors',
-  ImportedWithoutSubmissions = 'ImportedWithoutSubmissions',
-  NotInitiated = 'NotInitiated',
-}
 interface ValidationError {
   referenceId: string;
   column: string;
   error: string;
 }
+
 interface ValidationErrorTableRow extends ValidationError {
   id: number;
 }
+
+const dialogChipColors = {
+  new: 'blue',
+  numberOfSubmissionsFailed: 'red',
+  numberOfSubmissionsImported: 'green',
+  numberOfSubmissionsSkipped: 'orange',
+} as const;
+
 @Component({
   selector: 'app-kobo-import-existing-registration-dialog',
   imports: [
@@ -43,6 +48,7 @@ interface ValidationErrorTableRow extends ValidationError {
     ColoredChipComponent,
     QueryTableComponent,
     FormErrorComponent,
+    InfoTooltipComponent,
   ],
   providers: [ToastService],
   templateUrl: './kobo-import-existing-registration-dialog.component.html',
@@ -52,39 +58,43 @@ export class KoboImportExistingRegistrationsDialogComponent {
   private readonly koboApiService = inject(KoboApiService);
   private readonly toastService = inject(ToastService);
 
-  readonly importState = signal(ImportState.NotInitiated);
+  readonly importState = signal(DialogState.NotInitiated);
   readonly responseDialogVisible = signal(false);
   readonly programId = input.required<number | string>();
 
   readonly headerIcon = computed(() => {
     switch (this.importState()) {
-      case ImportState.ImportedWithErrors:
+      case DialogState.ImportedWithErrors:
         return 'pi pi-exclamation-triangle me-2';
-      case ImportState.ImportedWithoutErrors:
+      case DialogState.ImportedWithoutErrors:
         return 'pi pi-check me-2';
-      case ImportState.NotInitiated:
+      case DialogState.NotInitiated:
         return 'pi pi-download me-2';
-      case ImportState.ImportedWithoutSubmissions:
+      case DialogState.ImportedWithoutSubmissions:
         return 'pi pi-exclamation-circle me-2';
     }
   });
 
   readonly dialogTitle = computed(() => {
     switch (this.importState()) {
-      case ImportState.ImportedWithErrors:
+      case DialogState.ImportedWithErrors:
         return $localize`Import complete with errors`;
-      case ImportState.ImportedWithoutErrors:
+      case DialogState.ImportedWithoutErrors:
         return $localize`Import complete`;
-      case ImportState.NotInitiated:
+      case DialogState.NotInitiated:
         return $localize`Import existing registrations`;
-      case ImportState.ImportedWithoutSubmissions:
+      case DialogState.ImportedWithoutSubmissions:
         return $localize`No submissions found`;
     }
   });
 
   readonly dialogWidth = computed(() =>
-    this.importState() === ImportState.ImportedWithErrors ? '70rem' : '42rem',
+    this.importState() === DialogState.ImportedWithErrors ? '70rem' : '42rem',
   );
+
+  readonly noExistingSubmissionsTranslation = computed(() => {
+    return $localize`Kobo form ”${this.koboIntegration.data()?.name}” does not have existing registrations. New registrations will be synced to the program automatically.`;
+  });
 
   readonly submissionCountTranslations = computed(() => {
     return {
@@ -94,6 +104,8 @@ export class KoboImportExistingRegistrationsDialogComponent {
       numberOfSubmissionsFailedChipLabel: $localize`Submissions failed: ${this.importExistingSubmissions.data()?.numberOfSubmissionsFailed ?? 0}:count:`,
     };
   });
+
+  // Kobo integration and import existing submissions mutations
 
   readonly koboIntegration = injectQuery(() => ({
     ...this.koboApiService.getKoboIntegration(this.programId)(),
@@ -106,13 +118,13 @@ export class KoboImportExistingRegistrationsDialogComponent {
     },
     onSuccess: (response) => {
       if (response.validationErrors.length)
-        this.importState.set(ImportState.ImportedWithErrors);
+        this.importState.set(DialogState.ImportedWithErrors);
 
       if (response.validationErrors.length === 0)
-        this.importState.set(ImportState.ImportedWithoutErrors);
+        this.importState.set(DialogState.ImportedWithoutErrors);
 
       if (response.numberOfSubmissionsOnForm === 0)
-        this.importState.set(ImportState.ImportedWithoutSubmissions);
+        this.importState.set(DialogState.ImportedWithoutSubmissions);
     },
     onError: () => {
       this.toastService.showToast({
@@ -121,6 +133,8 @@ export class KoboImportExistingRegistrationsDialogComponent {
       });
     },
   }));
+
+  // Error table
 
   readonly detailedImportErrors = computed(() => {
     const errors = this.importExistingSubmissions.data()?.validationErrors;
@@ -156,12 +170,20 @@ export class KoboImportExistingRegistrationsDialogComponent {
     },
   ]);
 
-  public get ImportStates(): typeof ImportState {
-    return ImportState;
+  // Exposing the enum and chip colors to the template
+
+  public get DialogState(): typeof DialogState {
+    return DialogState;
   }
 
+  public get chipsColors(): typeof dialogChipColors {
+    return dialogChipColors;
+  }
+
+  // Methods
+
   resetDialogState() {
-    this.importState.set(ImportState.NotInitiated);
+    this.importState.set(DialogState.NotInitiated);
     this.importExistingSubmissions.reset();
   }
 

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -44,12 +44,6 @@ export enum SubmissionKey {
   Skipped = 'numberOfSubmissionsSkipped',
 }
 
-export const SUBMISSION_RESULT_LABELS: Record<SubmissionKey, string> = {
-  [SubmissionKey.Failed]: $localize`:@@submission-result-failed:Submissions failed`,
-  [SubmissionKey.Imported]: $localize`:@@submission-result-imported:Imported successfully`,
-  [SubmissionKey.Skipped]: $localize`:@@submission-result-skipped:Submissions skipped`,
-};
-
 @Component({
   selector: 'app-kobo-import-existing-registration-dialog',
   imports: [

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -36,7 +36,6 @@ export class KoboImportExistingRegistrationsDialogComponent {
 
   readonly importState = signal(ImportState.NotInitiated);
   readonly responseDialogVisible = signal(false);
-
   readonly programId = input.required<number | string>();
 
   readonly headerIcon = computed(() => {
@@ -87,15 +86,13 @@ export class KoboImportExistingRegistrationsDialogComponent {
     return ImportState;
   }
 
-  setToNotInitiatedState() {
+  resetDialogState() {
     this.importState.set(ImportState.NotInitiated);
+    this.importExistingSubmissions.reset();
   }
 
-  // This needs to be a close() and a reset()
-  closeDialogAndResetDialogState() {
+  closeDialog() {
     this.responseDialogVisible.set(false);
-    this.setToNotInitiatedState();
-    this.importExistingSubmissions.reset();
   }
 
   show() {

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -24,6 +24,7 @@ import { ToastService } from '~/services/toast.service';
 enum ImportState {
   ImportedWithErrors = 'ImportedWithErrors',
   ImportedWithoutErrors = 'ImportedWithoutErrors',
+  ImportedWithoutSubmissions = 'ImportedWithoutSubmissions',
   NotInitiated = 'NotInitiated',
 }
 interface ValidationError {
@@ -63,6 +64,8 @@ export class KoboImportExistingRegistrationsDialogComponent {
         return 'pi pi-check me-2';
       case ImportState.NotInitiated:
         return 'pi pi-download me-2';
+      case ImportState.ImportedWithoutSubmissions:
+        return 'pi pi-exclamation-circle me-2';
     }
   });
 
@@ -74,6 +77,8 @@ export class KoboImportExistingRegistrationsDialogComponent {
         return $localize`Import complete`;
       case ImportState.NotInitiated:
         return $localize`Import existing registrations`;
+      case ImportState.ImportedWithoutSubmissions:
+        return $localize`No submissions found`;
     }
   });
 
@@ -85,8 +90,7 @@ export class KoboImportExistingRegistrationsDialogComponent {
     return {
       totalSubmissions: $localize`${this.importExistingSubmissions.data()?.numberOfSubmissionsOnForm ?? 0}:count: total submission(s)`,
       numberOfSubmissionsImportedChipLabel: $localize`Imported successfully: ${this.importExistingSubmissions.data()?.numberOfSubmissionsImported ?? 0}:count:`,
-      // TODO: What is `numberOfSubmissionsSkipped` supposed to be?
-      // numberOfSubmissionsSkippedChipLabel: $localize`Submissions skipped: ${this.importExistingSubmissions.data()?.numberOfSubmissionsSkipped ?? 0}:count:`,
+      numberOfSubmissionsSkippedChipLabel: $localize`Submissions skipped: ${this.importExistingSubmissions.data()?.numberOfSubmissionsSkipped ?? 0}:count:`,
       numberOfSubmissionsFailedChipLabel: $localize`Submissions failed: ${this.importExistingSubmissions.data()?.numberOfSubmissionsFailed ?? 0}:count:`,
     };
   });
@@ -108,6 +112,9 @@ export class KoboImportExistingRegistrationsDialogComponent {
 
       if (response.validationErrors.length === 0)
         this.importState.set(ImportState.ImportedWithoutErrors);
+
+      if (response.numberOfSubmissionsOnForm === 0)
+        this.importState.set(ImportState.ImportedWithoutSubmissions);
 
       // TODO: ADD SUBMISSIONS SKIPPED STATE (?)
     },

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -5,7 +5,6 @@ import {
   inject,
   input,
   signal,
-  viewChild,
 } from '@angular/core';
 
 import {
@@ -13,13 +12,11 @@ import {
   injectQuery,
 } from '@tanstack/angular-query-experimental';
 import { ButtonModule } from 'primeng/button';
-import { ConfirmDialog } from 'primeng/confirmdialog';
 import { DialogModule } from 'primeng/dialog';
 
 import { ColoredChipComponent } from '~/components/colored-chip/colored-chip.component';
 import { KoboApiService } from '~/domains/kobo/kobo-api.service';
 import { ToastService } from '~/services/toast.service';
-
 enum ImportState {
   ImportedWithErrors = 'ImportedWithErrors',
   ImportedWithoutErrors = 'ImportedWithoutErrors',
@@ -35,14 +32,12 @@ enum ImportState {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class KoboImportExistingRegistrationsDialogComponent {
+  private readonly koboApiService = inject(KoboApiService);
+
   readonly importState = signal(ImportState.NotInitiated);
+  readonly responseDialogVisible = signal(false);
 
   readonly programId = input.required<number | string>();
-
-  private readonly koboApiService = inject(KoboApiService);
-  readonly confirmDialog = viewChild.required<ConfirmDialog>('confirmDialog');
-
-  readonly responseDialogVisible = signal(false);
 
   readonly headerIcon = computed(() => {
     switch (this.importState()) {
@@ -96,6 +91,7 @@ export class KoboImportExistingRegistrationsDialogComponent {
     this.importState.set(ImportState.NotInitiated);
   }
 
+  // This needs to be a close() and a reset()
   closeDialogAndResetDialogState() {
     this.responseDialogVisible.set(false);
     this.setToNotInitiatedState();

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.html
@@ -24,7 +24,9 @@
         i18n-title="@@generic-opens-in-new-window"
         class="inline-block [&_span:first-child]:underline hover:[&_span:first-child]:no-underline focus:[&_span:first-child]:no-underline"
         ><span>{{ koboIntegration.data()?.name ?? externalFormUrl() }}</span>
-        <span class="p-button-icon pi pi-external-link ms-1 text-sm"></span>
+        <span
+          class="p-button-icon pi pi-external-link relative top-0.5 ms-2 text-sm"
+        ></span>
       </a>
     }
   </ng-container>
@@ -43,5 +45,10 @@
 
 <app-kobo-configuration-dialog
   #koboConfigurationDialog
+  [programId]="programId()"
+/>
+
+<app-kobo-import-existing-registration-dialog
+  #koboImportExistingDialog
   [programId]="programId()"
 />

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.html
@@ -9,6 +9,7 @@
   [subtitle]="cardSubtitle()"
   [image]="'assets/registration-data/kobo-toolbox.svg'"
   [enableLink]="!isKoboIntegrated()"
+  [attr.data-testid]="'kobo-integration-card'"
 >
   <ng-container card-content>
     @if (isKoboIntegrated()) {

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.ts
@@ -19,6 +19,7 @@ import {
 } from '~/domains/kobo/kobo.helpers';
 import { KoboApiService } from '~/domains/kobo/kobo-api.service';
 import { KoboConfigurationDialogComponent } from '~/pages/program-settings-registration-data/components/kobo-configuration-dialog/kobo-configuration-dialog.component';
+import { KoboImportExistingRegistrationsDialogComponent } from '~/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component';
 
 @Component({
   selector: 'app-kobo-integration-card',
@@ -27,6 +28,7 @@ import { KoboConfigurationDialogComponent } from '~/pages/program-settings-regis
     EllipsisMenuComponent,
     DatePipe,
     KoboConfigurationDialogComponent,
+    KoboImportExistingRegistrationsDialogComponent,
   ],
   templateUrl: './kobo-integration-card.component.html',
   styles: ``,
@@ -40,6 +42,10 @@ export class KoboIntegrationCardComponent {
   readonly koboConfigurationDialog =
     viewChild.required<KoboConfigurationDialogComponent>(
       'koboConfigurationDialog',
+    );
+  readonly koboImportExistingDialog =
+    viewChild.required<KoboImportExistingRegistrationsDialogComponent>(
+      'koboImportExistingDialog',
     );
 
   readonly koboIntegration = injectQuery(() => ({
@@ -76,9 +82,14 @@ export class KoboIntegrationCardComponent {
   readonly menuItems = computed<MenuItem[]>(() => [
     {
       label: $localize`Reconfigure`,
-      icon: 'pi pi-pencil',
       command: () => {
         this.koboConfigurationDialog().show();
+      },
+    },
+    {
+      label: $localize`Import existing reg.`,
+      command: () => {
+        this.koboImportExistingDialog().show();
       },
     },
   ]);

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en-GB" datatype="plaintext" original="ng2.template">
     <body>
@@ -2262,9 +2262,6 @@
       <trans-unit id="2159130950882492111" datatype="html">
         <source>Cancel</source>
       </trans-unit>
-      <trans-unit id="2168486587823521907" datatype="html">
-        <source><x equiv-text="{{ importExistingSubmissions.data()?.numberOfSubmissionsImported }}" id="INTERPOLATION"/> total submissions</source>
-      </trans-unit>
       <trans-unit id="2200828314484557158" datatype="html">
         <source>Import complete</source>
       </trans-unit>
@@ -2307,17 +2304,11 @@
       <trans-unit id="5918723526444903137" datatype="html">
         <source>Add user</source>
       </trans-unit>
-      <trans-unit id="1519954996184640001" datatype="html">
-        <source>Error</source>
-      </trans-unit>
       <trans-unit id="3077263560424048384" datatype="html">
         <source>The import takes about 1 minute per 100 records.</source>
       </trans-unit>
       <trans-unit id="6555318547274416232" datatype="html">
         <source>Value</source>
-      </trans-unit>
-      <trans-unit id="763982378603811482" datatype="html">
-        <source>Column</source>
       </trans-unit>
       <trans-unit id="7761072359529249164" datatype="html">
         <source>Line number</source>
@@ -2339,6 +2330,21 @@
       </trans-unit>
       <trans-unit id="debit-card-status-closed" datatype="html">
         <source>Closed</source>
+      </trans-unit>
+      <trans-unit id="123437398532695378" datatype="html">
+        <source>Submissions skipped: <x equiv-text="this.importExistingSubmissions.data()?.numberOfSubmissionsSkipped ?? 0" id="count"/></source>
+      </trans-unit>
+      <trans-unit id="4686419033610227407" datatype="html">
+        <source>No submissions found</source>
+      </trans-unit>
+      <trans-unit id="6554222446236271125" datatype="html">
+        <source>The import takes about 1 minute per 100 records.</source>
+      </trans-unit>
+      <trans-unit id="7819314041543176992" datatype="html">
+        <source>Close</source>
+      </trans-unit>
+      <trans-unit id="9098487756295934908" datatype="html">
+        <source>Kobo form ”25042025 Prototype Sprint” does not have existing registrations. New registrations will be synced to the program automatically.</source>
       </trans-unit>
       <trans-unit id="2986249053713735246" datatype="html">
         <source>Export refunded debit cards</source>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -2266,7 +2266,7 @@
         <source>Import complete</source>
       </trans-unit>
       <trans-unit id="3851949706407638075" datatype="html">
-        <source>The system will create registrations with the status <x ctype="x-app_colored_chip" equiv-text="&lt;app-colored-chip [variant]=&quot;&apos;blue&apos;&quot; [label]=&quot;&apos;New&apos;&quot; /&gt;" id="START_TAG_APP_COLORED_CHIP"/><x ctype="x-app_colored_chip" equiv-text="&lt;app-colored-chip [variant]=&quot;&apos;blue&apos;&quot; [label]=&quot;&apos;New&apos;&quot; /&gt;" id="CLOSE_TAG_APP_COLORED_CHIP"/></source>
+        <source>The system will create registrations with the status <x ctype="x-app_colored_chip" equiv-text="&lt;app-colored-chip [variant]=&quot;chipsColors.new&quot; [label]=&quot;&apos;New&apos;&quot; /&gt;" id="START_TAG_APP_COLORED_CHIP"/><x ctype="x-app_colored_chip" equiv-text="&lt;app-colored-chip [variant]=&quot;chipsColors.new&quot; [label]=&quot;&apos;New&apos;&quot; /&gt;" id="CLOSE_TAG_APP_COLORED_CHIP"/></source>
       </trans-unit>
       <trans-unit id="4513666009026562086" datatype="html">
         <source>Import existing reg.</source>
@@ -2343,8 +2343,11 @@
       <trans-unit id="7819314041543176992" datatype="html">
         <source>Close</source>
       </trans-unit>
-      <trans-unit id="9098487756295934908" datatype="html">
-        <source>Kobo form ”25042025 Prototype Sprint” does not have existing registrations. New registrations will be synced to the program automatically.</source>
+      <trans-unit id="3608877004778230790" datatype="html">
+        <source>Submissions that have been added to the program already are skipped to avoid duplications.</source>
+      </trans-unit>
+      <trans-unit id="3757859142679780974" datatype="html">
+        <source>Kobo form ”<x equiv-text="this.koboIntegration.data()?.name" id="PH"/>” does not have existing registrations. New registrations will be synced to the program automatically.</source>
       </trans-unit>
       <trans-unit id="2986249053713735246" datatype="html">
         <source>Export refunded debit cards</source>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -2266,7 +2266,7 @@
         <source>Import complete</source>
       </trans-unit>
       <trans-unit id="3851949706407638075" datatype="html">
-        <source>The system will create registrations with the status <x ctype="x-app_colored_chip" equiv-text="&lt;app-colored-chip [variant]=&quot;chipsColors.new&quot; [label]=&quot;&apos;New&apos;&quot; /&gt;" id="START_TAG_APP_COLORED_CHIP"/><x ctype="x-app_colored_chip" equiv-text="&lt;app-colored-chip [variant]=&quot;chipsColors.new&quot; [label]=&quot;&apos;New&apos;&quot; /&gt;" id="CLOSE_TAG_APP_COLORED_CHIP"/></source>
+        <source>The system will create registrations with the status <x ctype="x-app_colored_chip" equiv-text="&lt;app-colored-chip [variant]=&quot;&apos;blue&apos;&quot; label=&quot;&apos;New&apos;&quot; i18n-label /&gt;" id="START_TAG_APP_COLORED_CHIP"/><x ctype="x-app_colored_chip" equiv-text="&lt;app-colored-chip [variant]=&quot;&apos;blue&apos;&quot; label=&quot;&apos;New&apos;&quot; i18n-label /&gt;" id="CLOSE_TAG_APP_COLORED_CHIP"/></source>
       </trans-unit>
       <trans-unit id="4513666009026562086" datatype="html">
         <source>Import existing reg.</source>
@@ -2283,20 +2283,11 @@
       <trans-unit id="1519954996184640001" datatype="html">
         <source>Error</source>
       </trans-unit>
-      <trans-unit id="3615628700898095994" datatype="html">
-        <source>Imported successfully: <x equiv-text="this.importExistingSubmissions.data()?.numberOfSubmissionsImported ?? 0" id="count"/></source>
-      </trans-unit>
       <trans-unit id="4135275683761793881" datatype="html">
         <source><x equiv-text="this.importExistingSubmissions.data()?.numberOfSubmissionsOnForm ?? 0" id="count"/> total submission(s)</source>
       </trans-unit>
       <trans-unit id="763982378603811482" datatype="html">
         <source>Column</source>
-      </trans-unit>
-      <trans-unit id="8692166966874863401" datatype="html">
-        <source>Successfully imported submissions from Kobo form</source>
-      </trans-unit>
-      <trans-unit id="8807448248336812904" datatype="html">
-        <source>Submissions failed: <x equiv-text="this.importExistingSubmissions.data()?.numberOfSubmissionsFailed ?? 0" id="count"/></source>
       </trans-unit>
       <trans-unit id="4421433274861560863" datatype="html">
         <source>Add a user to the 121 platform. Fill in the fields below to create a new user account.</source>
@@ -2331,9 +2322,6 @@
       <trans-unit id="debit-card-status-closed" datatype="html">
         <source>Closed</source>
       </trans-unit>
-      <trans-unit id="123437398532695378" datatype="html">
-        <source>Submissions skipped: <x equiv-text="this.importExistingSubmissions.data()?.numberOfSubmissionsSkipped ?? 0" id="count"/></source>
-      </trans-unit>
       <trans-unit id="4686419033610227407" datatype="html">
         <source>No submissions found</source>
       </trans-unit>
@@ -2357,6 +2345,20 @@
       </trans-unit>
       <trans-unit id="export-refunded-debit-cards" datatype="html">
         <source>Refunded debit cards</source>
+      <trans-unit id="3443177849607577586" datatype="html">
+        <source>Successfully imported submissions from Kobo form</source>
+      </trans-unit>
+      <trans-unit id="4033651697146421557" datatype="html">
+        <source>&apos;New&apos;</source>
+      </trans-unit>
+      <trans-unit id="submission-result-failed" datatype="html">
+        <source>Submissions failed</source>
+      </trans-unit>
+      <trans-unit id="submission-result-imported" datatype="html">
+        <source>Imported successfully</source>
+      </trans-unit>
+      <trans-unit id="submission-result-skipped" datatype="html">
+        <source>Submissions skipped</source>
       </trans-unit>
     </body>
   </file>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en-GB" datatype="plaintext" original="ng2.template">
     <body>
@@ -2255,6 +2255,42 @@
       </trans-unit>
       <trans-unit id="4892553839051604445" datatype="html">
         <source>Payment</source>
+      </trans-unit>
+      <trans-unit id="1200823711484456499" datatype="html">
+        <source>All is wrong</source>
+      </trans-unit>
+      <trans-unit id="1872549287181572098" datatype="html">
+        <source>Import existing registrations from your Kobo form.</source>
+      </trans-unit>
+      <trans-unit id="2159130950882492111" datatype="html">
+        <source>Cancel</source>
+      </trans-unit>
+      <trans-unit id="2168486587823521907" datatype="html">
+        <source><x equiv-text="{{ importExistingSubmissions.data()?.numberOfSubmissionsImported }}" id="INTERPOLATION"/> total submissions</source>
+      </trans-unit>
+      <trans-unit id="2200828314484557158" datatype="html">
+        <source>Import complete</source>
+      </trans-unit>
+      <trans-unit id="3851949706407638075" datatype="html">
+        <source>The system will create registrations with the status <x ctype="x-app_colored_chip" equiv-text="&lt;app-colored-chip [label]=&quot;&apos;New&apos;&quot; [variant]=&quot;&apos;blue&apos;&quot; /&gt;" id="START_TAG_APP_COLORED_CHIP"/><x ctype="x-app_colored_chip" equiv-text="&lt;app-colored-chip [label]=&quot;&apos;New&apos;&quot; [variant]=&quot;&apos;blue&apos;&quot; /&gt;" id="CLOSE_TAG_APP_COLORED_CHIP"/></source>
+      </trans-unit>
+      <trans-unit id="4513666009026562086" datatype="html">
+        <source>Import existing reg.</source>
+      </trans-unit>
+      <trans-unit id="4680756702302858333" datatype="html">
+        <source>Import registrations</source>
+      </trans-unit>
+      <trans-unit id="4964612859944755976" datatype="html">
+        <source>Import complete with errors</source>
+      </trans-unit>
+      <trans-unit id="6245136461829083125" datatype="html">
+        <source>Import existing registrations</source>
+      </trans-unit>
+      <trans-unit id="705007315301299017" datatype="html">
+        <source>Successfully imported submissions from Kobo form ”<x equiv-text="{{ koboIntegration.data()?.name }}" id="INTERPOLATION"/>”</source>
+      </trans-unit>
+      <trans-unit id="7819314041543176992" datatype="html">
+        <source>Close</source>
       </trans-unit>
       <trans-unit id="4421433274861560863" datatype="html">
         <source>Add a user to the 121 platform. Fill in the fields below to create a new user account.</source>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -2256,9 +2256,6 @@
       <trans-unit id="4892553839051604445" datatype="html">
         <source>Payment</source>
       </trans-unit>
-      <trans-unit id="1200823711484456499" datatype="html">
-        <source>All is wrong</source>
-      </trans-unit>
       <trans-unit id="1872549287181572098" datatype="html">
         <source>Import existing registrations from your Kobo form.</source>
       </trans-unit>
@@ -2272,7 +2269,7 @@
         <source>Import complete</source>
       </trans-unit>
       <trans-unit id="3851949706407638075" datatype="html">
-        <source>The system will create registrations with the status <x ctype="x-app_colored_chip" equiv-text="&lt;app-colored-chip [label]=&quot;&apos;New&apos;&quot; [variant]=&quot;&apos;blue&apos;&quot; /&gt;" id="START_TAG_APP_COLORED_CHIP"/><x ctype="x-app_colored_chip" equiv-text="&lt;app-colored-chip [label]=&quot;&apos;New&apos;&quot; [variant]=&quot;&apos;blue&apos;&quot; /&gt;" id="CLOSE_TAG_APP_COLORED_CHIP"/></source>
+        <source>The system will create registrations with the status <x ctype="x-app_colored_chip" equiv-text="&lt;app-colored-chip [variant]=&quot;&apos;blue&apos;&quot; [label]=&quot;&apos;New&apos;&quot; /&gt;" id="START_TAG_APP_COLORED_CHIP"/><x ctype="x-app_colored_chip" equiv-text="&lt;app-colored-chip [variant]=&quot;&apos;blue&apos;&quot; [label]=&quot;&apos;New&apos;&quot; /&gt;" id="CLOSE_TAG_APP_COLORED_CHIP"/></source>
       </trans-unit>
       <trans-unit id="4513666009026562086" datatype="html">
         <source>Import existing reg.</source>
@@ -2286,11 +2283,29 @@
       <trans-unit id="6245136461829083125" datatype="html">
         <source>Import existing registrations</source>
       </trans-unit>
-      <trans-unit id="705007315301299017" datatype="html">
-        <source>Successfully imported submissions from Kobo form ”<x equiv-text="{{ koboIntegration.data()?.name }}" id="INTERPOLATION"/>”</source>
-      </trans-unit>
       <trans-unit id="7819314041543176992" datatype="html">
         <source>Close</source>
+      </trans-unit>
+      <trans-unit id="1519954996184640001" datatype="html">
+        <source>Error</source>
+      </trans-unit>
+      <trans-unit id="1995807518299722501" datatype="html">
+        <source>Reference IDs</source>
+      </trans-unit>
+      <trans-unit id="3615628700898095994" datatype="html">
+        <source>Imported successfully: <x equiv-text="this.importExistingSubmissions.data()?.numberOfSubmissionsImported ?? 0" id="count"/></source>
+      </trans-unit>
+      <trans-unit id="4135275683761793881" datatype="html">
+        <source><x equiv-text="this.importExistingSubmissions.data()?.numberOfSubmissionsOnForm ?? 0" id="count"/> total submission(s)</source>
+      </trans-unit>
+      <trans-unit id="763982378603811482" datatype="html">
+        <source>Column</source>
+      </trans-unit>
+      <trans-unit id="8692166966874863401" datatype="html">
+        <source>Successfully imported submissions from Kobo form</source>
+      </trans-unit>
+      <trans-unit id="8807448248336812904" datatype="html">
+        <source>Submissions failed: <x equiv-text="this.importExistingSubmissions.data()?.numberOfSubmissionsFailed ?? 0" id="count"/></source>
       </trans-unit>
       <trans-unit id="4421433274861560863" datatype="html">
         <source>Add a user to the 121 platform. Fill in the fields below to create a new user account.</source>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -2283,9 +2283,6 @@
       <trans-unit id="6245136461829083125" datatype="html">
         <source>Import existing registrations</source>
       </trans-unit>
-      <trans-unit id="7819314041543176992" datatype="html">
-        <source>Close</source>
-      </trans-unit>
       <trans-unit id="1519954996184640001" datatype="html">
         <source>Error</source>
       </trans-unit>
@@ -2328,6 +2325,9 @@
       <trans-unit id="7761072359529249164" datatype="html">
         <source>Line number</source>
       </trans-unit>
+      <trans-unit id="7703736032933423612" datatype="html">
+        <source>Error while importing existing Kobo registrations</source>
+	  </trans-unit>
       <trans-unit id="debit-card-actions-close-card" datatype="html">
         <source>Close card</source>
       </trans-unit>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -2315,7 +2315,7 @@
       </trans-unit>
       <trans-unit id="7703736032933423612" datatype="html">
         <source>Error while importing existing Kobo registrations</source>
-	  </trans-unit>
+      </trans-unit>
       <trans-unit id="debit-card-actions-close-card" datatype="html">
         <source>Close card</source>
       </trans-unit>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -2345,6 +2345,7 @@
       </trans-unit>
       <trans-unit id="export-refunded-debit-cards" datatype="html">
         <source>Refunded debit cards</source>
+      </trans-unit>
       <trans-unit id="3443177849607577586" datatype="html">
         <source>Successfully imported submissions from Kobo form</source>
       </trans-unit>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -2286,9 +2286,6 @@
       <trans-unit id="1519954996184640001" datatype="html">
         <source>Error</source>
       </trans-unit>
-      <trans-unit id="1995807518299722501" datatype="html">
-        <source>Reference IDs</source>
-      </trans-unit>
       <trans-unit id="3615628700898095994" datatype="html">
         <source>Imported successfully: <x equiv-text="this.importExistingSubmissions.data()?.numberOfSubmissionsImported ?? 0" id="count"/></source>
       </trans-unit>

--- a/services/121-service/test/kobo/kobo-import-existing-submissions.test.ts
+++ b/services/121-service/test/kobo/kobo-import-existing-submissions.test.ts
@@ -95,6 +95,33 @@ describe('Import new Kobo submissions via PATCH endpoint', () => {
     return { programId, assetUid: uid };
   }
 
+  it('should handle case with no submissions', async () => {
+    // Arrange
+    const assetUid = 'without-submissions';
+    const expectedReferenceId = `${KoboMockSubmissionUuids.success}-${assetUid}`;
+    const { programId } = await setup(assetUid);
+
+    // Act§
+    const response = await patchKoboSubmissions({ programId, accessToken });
+
+    // Assert
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.body).toMatchObject({
+      numberOfSubmissionsOnForm: 0,
+      numberOfSubmissionsImported: 0,
+      numberOfSubmissionsSkipped: 0,
+      numberOfSubmissionsFailed: 0,
+      validationErrors: [],
+    });
+
+    const searchResponse = await searchRegistrationByReferenceId(
+      expectedReferenceId,
+      programId,
+      accessToken,
+    );
+    expect(searchResponse.body.data).toBeArrayOfSize(0);
+  });
+
   it('should import new submissions and create registrations', async () => {
     // Arrange
     const assetUid = 'import-happy-flow';

--- a/services/mock-service/src/kobo/kobo.mock.service.ts
+++ b/services/mock-service/src/kobo/kobo.mock.service.ts
@@ -509,6 +509,10 @@ export class KoboMockService {
       });
     }
 
+    if (uid_asset.includes('without-submissions')) {
+      return { count: 0, next: null, previous: null, results: [] };
+    }
+
     return { count: results.length, next: null, previous: null, results };
   }
 


### PR DESCRIPTION
[AB#35947](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/35947)

Import existing registrations UI

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes
- [x] I have added tests for my changes
- [x] I have made sure that all automated checks pass before requesting a review
(https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8178.westeurope.3.azurestaticapps.net
