### PR TITLE
Fix E2E flaky CBE payment test

### DIFF
--- a/e2e/portal/pages/PaymentsPage.ts
+++ b/e2e/portal/pages/PaymentsPage.ts
@@ -135,8 +135,8 @@ class PaymentsPage extends BasePage {
     expectedValue: number,
   ) {
     if (!elementText) throw new Error('Element text is null');
-    const extractedValue = elementText.replace(/[^0-9.]/g, '');
-    const actualNumber = parseFloat(extractedValue);
+    const extractedValue = elementText.replaceAll(/[^0-9.]/g, '');
+    const actualNumber = Number.parseFloat(extractedValue);
     expect(actualNumber).toBeCloseTo(expectedValue, 2);
   }
 

--- a/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithCbe.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithCbe.spec.ts
@@ -60,6 +60,7 @@ test('Do successful payment for Cbe fsp', async ({
 
   await test.step('Validate payment card', async () => {
     await paymentPage.waitForPaymentToComplete();
+    await page.waitForTimeout(500); // Wait for all the processes to complete and UI to update
     await paymentPage.navigateToProgramPage('Payments');
     await paymentsPage.validatePaymentCard({
       paymentAmount: defaultMaxTransferValue,


### PR DESCRIPTION
[AB#42036](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42036)

## Describe your changes

This pull request makes minor improvements to the payments end-to-end test suite, focusing on increasing test reliability and improving code clarity.

Test reliability improvements:
* Added a short delay (`page.waitForTimeout(500)`) after waiting for payment completion to ensure all processes finish and the UI updates before validation steps. (`e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithCbe.spec.ts`)

Code clarity and consistency:
* Updated the extraction and parsing of numeric values from element text in `PaymentsPage` to use `replaceAll` and `Number.parseFloat` for improved clarity and consistency. (`e2e/portal/pages/PaymentsPage.ts`) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
