### PR TITLE
Add purple outline in portal when editing properties

### DIFF
--- a/interfaces/portal/src/app/components/card-editable/card-editable.component.html
+++ b/interfaces/portal/src/app/components/card-editable/card-editable.component.html
@@ -1,4 +1,4 @@
-<p-card>
+<p-card [class]="isEditing() ? 'outline-purple outline-2' : ''">
   <form
     (ngSubmit)="onFormSubmit()"
     (keydown.control.enter)="onFormSubmit()"
@@ -6,7 +6,7 @@
     pFocusTrap
     [pFocusTrapDisabled]="!isEditing()"
   >
-    <div class="flex min-h-12 items-center gap-x-2">
+    <div class="mb-5 flex min-h-12 items-center gap-x-2">
       <h2>{{ header() }}</h2>
       @if (canEdit()) {
         <div class="ms-auto space-x-2">

--- a/interfaces/portal/src/app/components/card-editable/card-editable.component.html
+++ b/interfaces/portal/src/app/components/card-editable/card-editable.component.html
@@ -6,7 +6,7 @@
     pFocusTrap
     [pFocusTrapDisabled]="!isEditing()"
   >
-    <div class="mb-5 flex min-h-12 items-center gap-x-2">
+    <div class="flex min-h-12 items-center gap-x-2">
       <h2>{{ header() }}</h2>
       @if (canEdit()) {
         <div class="ms-auto space-x-2">

--- a/interfaces/portal/src/app/components/card-editable/card-editable.component.spec.ts
+++ b/interfaces/portal/src/app/components/card-editable/card-editable.component.spec.ts
@@ -1,0 +1,70 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MessageService } from 'primeng/api';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CardEditableComponent } from '~/components/card-editable/card-editable.component';
+
+@Component({
+  selector: 'app-test-host',
+  standalone: true,
+  imports: [CardEditableComponent],
+  template: `
+    <app-card-editable
+      header="Basic information"
+      i18n-header="@@card-title-program-settings-basic-information"
+      editPencilTitle="Edit basic information"
+      i18n-editPencilTitle
+      [canEdit]="canEdit()"
+      [(isEditing)]="isEditing"
+    >
+    </app-card-editable>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TestHostComponent {
+  readonly canEdit = signal(true);
+  readonly isEditing = signal(false);
+}
+
+describe('CardEditableComponent', () => {
+  let component: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CardEditableComponent, TestHostComponent],
+      providers: [MessageService],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should add outline classes to the card when isEditing is true', () => {
+    component.isEditing.set(true);
+    fixture.detectChanges();
+
+    const cardElement = (fixture.nativeElement as HTMLElement).querySelector(
+      'p-card',
+    );
+    expect(cardElement?.classList).toContain('outline-purple');
+    expect(cardElement?.classList).toContain('outline-2');
+  });
+
+  it('should NOT add outline classes to the card when isEditing is false', () => {
+    fixture.detectChanges();
+
+    const cardElement = (fixture.nativeElement as HTMLElement).querySelector(
+      'p-card',
+    );
+    expect(cardElement?.classList).not.toContain('outline-purple');
+    expect(cardElement?.classList).not.toContain('outline-2');
+  });
+});


### PR DESCRIPTION
[AB#42123](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42123) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Adds a purple outline to the card when editing.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes
- [x] I have added tests for my changes
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8219.westeurope.3.azurestaticapps.net
