### PR TITLE
'Fix' for 'flaky' e2e test - forcing reload before card validation

### DIFF
--- a/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithCbe.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithCbe.spec.ts
@@ -61,6 +61,12 @@ test('Do successful payment for Cbe fsp', async ({
   await test.step('Validate payment card', async () => {
     await paymentPage.waitForPaymentToComplete();
     await paymentPage.navigateToProgramPage('Payments');
+
+    // TODO: AB#42066
+    // Remove the need for this reload() by making sure the payment card updates after the transactions have completed, without needing to refresh the page
+    // This reload() 'fixes' the issue of the payment card not updating after the transactions have completed
+    await paymentsPage.page.reload();
+
     await paymentsPage.validatePaymentCard({
       paymentAmount: defaultMaxTransferValue,
       registrationsNumber: numberOfPas,


### PR DESCRIPTION
[AB#42175](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42175)

## Describe your changes

'Fix' for 'flaky' E2E test by forcing reload before card validation

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [ ] I have addressed all Copilot comments
- [x] Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
