### PR TITLE
Fix for flaky e2e test - invalidateCacheAgainAfterDelay added

### DIFF
--- a/interfaces/portal/src/app/components/page-layout-payment/components/start-payment/start-payment.component.ts
+++ b/interfaces/portal/src/app/components/page-layout-payment/components/start-payment/start-payment.component.ts
@@ -46,6 +46,7 @@ export class StartPaymentComponent {
         programId: this.programId,
         paymentId: this.paymentId,
       }),
+    meta: { invalidateCacheAgainAfterDelay: 1000 },
     onSuccess: () => {
       this.startPaymentDialog().hide();
       this.toastService.showToast({


### PR DESCRIPTION
[AB#42066](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42066) 

Asked Claude, fix confirmed.
Ran flaky CBE e2e **90** times without failure.

> ## Root Cause: Race Condition in `refetchInterval`
> 
> There are **two interacting mechanisms**:
> 
> **1. The global `MutationCache.onSuccess` in app.config.ts**
> 
> Every mutation success triggers `invalidateQueries()`, which causes `paymentAggregate` to refetch once. There is no `invalidateQueries` in either mutation individually — it all comes from the global handler.
> 
> **2. The `refetchInterval` logic in page-layout-payment.component.ts**
> 
> ```typescript
> const isPaymentWaitingToStart =
>   statuses.approved.count + statuses.pendingApproval.count ===
>   this.totalTransactions();
> 
> if (isPaymentWaitingToStart || isPaymentFinished) {
>   return false; // polling stops
> }
> ```
> 
> This stops polling when all transactions are in `approved`/`pendingApproval` — which is exactly the state **right before** the user clicks "Start Payment".
> 
> ## The Race Condition
> 
> The sequence that produces the stuck UI (roughly 1-in-5):
> 
> 1. Payment is ready to start → all transactions are `approved` → `isPaymentWaitingToStart === true` → `refetchInterval` returns `false` → **polling already stopped**
> 2. User clicks "Start Payment"
> 3. `startPaymentMutation` succeeds → global `MutationCache.onSuccess` fires → `invalidateQueries()` → `paymentAggregate` refetches **once**
> 4. **Race**: if the backend hasn't yet moved any transaction out of `approved` by the time this refetch completes, the data still shows `isPaymentWaitingToStart === true`
> 5. `refetchInterval` returns `false` **again**
> 6. The refetched data is now "fresh" with the 5-minute `staleTime`, so even `refetchOnWindowFocus` won't trigger another refetch for 5 minutes
> 7. **UI is permanently stuck**
> 
> When the backend is fast enough (the other 4-in-5 times), the data already has some `waiting` transactions by the time the refetch lands, `isPaymentWaitingToStart` becomes `false`, and polling resumes normally.
> 
> ## The Fix
> 
> The `startPaymentMutation` in start-payment.component.ts should use `meta.invalidateCacheAgainAfterDelay`, which the global handler already supports:
> 
> ```typescript
> startPaymentMutation = injectMutation(() => ({
>   mutationFn: () => ...,
>   meta: { invalidateCacheAgainAfterDelay: 1000 }, // ← add this
>   onSuccess: () => { ... },
> }));
> ```
> 
> This causes a **second** `invalidateQueries()` 1 second after the mutation succeeds — by which time the backend will typically have processed the start and moved transactions out of `approved`. That second refetch will see the in-progress state and restart polling correctly.
> 
> The same fix might be worth applying to `approvePaymentMutation` depending on whether the approve endpoint also has a processing delay.


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8240.westeurope.3.azurestaticapps.net
