### PR TITLE
Refactor interface of adding messages to queue

### DIFF
--- a/services/121-service/module-dependencies.md
+++ b/services/121-service/module-dependencies.md
@@ -49,13 +49,10 @@ graph LR
   IntersolveVoucherModule-->ImageCodeModule
   IntersolveVoucherModule-->MessageQueuesModule
   IntersolveVoucherModule-->MessageTemplateModule
-  IntersolveVoucherModule-->QueuesRegistryModule
-  IntersolveVoucherModule-->RedisModule
   IntersolveVoucherModule-->RegistrationDataModule
   IntersolveVoucherModule-->RegistrationUtilsModule
-  IntersolveVoucherModule-->TransactionEventsModule
+  IntersolveVoucherModule-->RegistrationsModule
   IntersolveVoucherModule-->TransactionsModule
-  IntersolveVoucherModule-->UserModule
   IntersolveVoucherReconciliationModule-->IntersolveVoucherModule
   IntersolveVoucherReconciliationModule-->ProgramFspConfigurationsModule
   IntersolveVoucherReconciliationModule-->ProgramModule
@@ -69,6 +66,7 @@ graph LR
   MessageIncomingModule-->MessageTemplateModule
   MessageIncomingModule-->QueuesRegistryModule
   MessageIncomingModule-->RegistrationDataModule
+  MessageIncomingModule-->RegistrationsModule
   MessageIncomingModule-->TransactionsModule
   MessageIncomingModule-->UserModule
   MessageIncomingModule-->WhatsappModule

--- a/services/121-service/src/fsp-integrations/account-management/intersolve-visa/intersolve-visa-account-management.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/account-management/intersolve-visa/intersolve-visa-account-management.service.spec.ts
@@ -12,7 +12,6 @@ import { FspConfigurationProperties } from '@121-service/src/fsp-integrations/sh
 import { MessageProcessTypeExtension } from '@121-service/src/notifications/dto/message-job.dto';
 import { MessageContentType } from '@121-service/src/notifications/enum/message-type.enum';
 import { ProgramNotificationEnum } from '@121-service/src/notifications/enum/program-notification.enum';
-import { MessageQueuesService } from '@121-service/src/notifications/message-queues/message-queues.service';
 import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { RegistrationsService } from '@121-service/src/registration/services/registrations.service';
@@ -20,7 +19,6 @@ import { RegistrationsService } from '@121-service/src/registration/services/reg
 describe('IntersolveVisaAccountManagementService', () => {
   let service: IntersolveVisaAccountManagementService;
   let intersolveVisaService: jest.Mocked<IntersolveVisaService>;
-  let queueMessageService: jest.Mocked<MessageQueuesService>;
   let registrationsService: jest.Mocked<RegistrationsService>;
   let intersolveVisaChildWalletScopedRepository: jest.Mocked<IntersolveVisaChildWalletScopedRepository>;
   let walletClosureScopedRepository: jest.Mocked<IntersolveVisaWalletClosureScopedRepository>;
@@ -39,6 +37,7 @@ describe('IntersolveVisaAccountManagementService', () => {
           provide: RegistrationsService,
           useValue: {
             getRegistrationOrThrow: jest.fn(),
+            createMessageJobForRegistration: jest.fn(),
             getContactInformation: jest.fn().mockResolvedValue({
               name: 'Jane Doe',
               addressStreet: 'Main',
@@ -54,12 +53,6 @@ describe('IntersolveVisaAccountManagementService', () => {
           provide: IntersolveVisaDataSynchronizationService,
           useValue: {
             syncData: jest.fn(),
-          },
-        },
-        {
-          provide: MessageQueuesService,
-          useValue: {
-            addMessageJob: jest.fn(),
           },
         },
         {
@@ -110,7 +103,6 @@ describe('IntersolveVisaAccountManagementService', () => {
     }).compile();
 
     service = module.get(IntersolveVisaAccountManagementService);
-    queueMessageService = module.get(MessageQueuesService);
     intersolveVisaService = module.get(IntersolveVisaService);
     registrationsService = module.get(
       RegistrationsService,
@@ -195,11 +187,14 @@ describe('IntersolveVisaAccountManagementService', () => {
         'token-1',
         true,
       );
-      expect(queueMessageService.addMessageJob).toHaveBeenCalledWith({
-        registration,
+      expect(
+        registrationsService.createMessageJobForRegistration,
+      ).toHaveBeenCalledWith({
+        referenceId: 'ref-1',
+        programId: 1,
         messageTemplateKey: ProgramNotificationEnum.pauseVisaCard,
         messageContentType: MessageContentType.custom,
-        messageProcessType:
+        extendedMessageProcessType:
           MessageProcessTypeExtension.smsOrWhatsappTemplateGeneric,
         userId: 9,
       });
@@ -212,11 +207,14 @@ describe('IntersolveVisaAccountManagementService', () => {
 
       await service.pauseCardAndSendMessage('ref-1', 1, 'token-1', false, 9);
 
-      expect(queueMessageService.addMessageJob).toHaveBeenCalledWith({
-        registration,
+      expect(
+        registrationsService.createMessageJobForRegistration,
+      ).toHaveBeenCalledWith({
+        referenceId: 'ref-1',
+        programId: 1,
         messageTemplateKey: ProgramNotificationEnum.unpauseVisaCard,
         messageContentType: MessageContentType.custom,
-        messageProcessType:
+        extendedMessageProcessType:
           MessageProcessTypeExtension.smsOrWhatsappTemplateGeneric,
         userId: 9,
       });

--- a/services/121-service/src/fsp-integrations/account-management/intersolve-visa/intersolve-visa-account-management.service.ts
+++ b/services/121-service/src/fsp-integrations/account-management/intersolve-visa/intersolve-visa-account-management.service.ts
@@ -16,7 +16,6 @@ import { FspConfigurationProperties } from '@121-service/src/fsp-integrations/sh
 import { MessageProcessTypeExtension } from '@121-service/src/notifications/dto/message-job.dto';
 import { MessageContentType } from '@121-service/src/notifications/enum/message-type.enum';
 import { ProgramNotificationEnum } from '@121-service/src/notifications/enum/program-notification.enum';
-import { MessageQueuesService } from '@121-service/src/notifications/message-queues/message-queues.service';
 import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { RegistrationsService } from '@121-service/src/registration/services/registrations.service';
@@ -24,7 +23,6 @@ import { RegistrationsService } from '@121-service/src/registration/services/reg
 @Injectable()
 export class IntersolveVisaAccountManagementService {
   public constructor(
-    private readonly queueMessageService: MessageQueuesService,
     private readonly intersolveVisaService: IntersolveVisaService,
     private readonly programFspConfigurationRepository: ProgramFspConfigurationRepository,
     private readonly registrationsService: RegistrationsService,
@@ -124,11 +122,12 @@ export class IntersolveVisaAccountManagementService {
       programFspConfigurationId: registration.programFspConfigurationId,
     });
 
-    await this.queueMessageService.addMessageJob({
-      registration,
+    await this.registrationsService.createMessageJobForRegistration({
+      referenceId,
+      programId,
       messageTemplateKey: ProgramNotificationEnum.replaceVisaCard,
       messageContentType: MessageContentType.custom,
-      messageProcessType:
+      extendedMessageProcessType:
         MessageProcessTypeExtension.smsOrWhatsappTemplateGeneric,
       userId,
     });
@@ -314,23 +313,18 @@ export class IntersolveVisaAccountManagementService {
     pause: boolean,
     userId: number,
   ): Promise<IntersolveVisaChildWalletEntity> {
-    const registration = await this.registrationsService.getRegistrationOrThrow(
-      {
-        referenceId,
-        programId,
-      },
-    );
     const updatedWallet = await this.intersolveVisaService.pauseCardOrThrow(
       tokenCode,
       pause,
     );
-    await this.queueMessageService.addMessageJob({
-      registration,
+    await this.registrationsService.createMessageJobForRegistration({
+      referenceId,
+      programId,
       messageTemplateKey: pause
         ? ProgramNotificationEnum.pauseVisaCard
         : ProgramNotificationEnum.unpauseVisaCard,
       messageContentType: MessageContentType.custom,
-      messageProcessType:
+      extendedMessageProcessType:
         MessageProcessTypeExtension.smsOrWhatsappTemplateGeneric,
       userId,
     });

--- a/services/121-service/src/fsp-integrations/integrations/intersolve-voucher/intersolve-voucher.module.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-voucher/intersolve-voucher.module.ts
@@ -14,22 +14,16 @@ import { TwilioMessageEntity } from '@121-service/src/notifications/entities/twi
 import { MessageQueuesModule } from '@121-service/src/notifications/message-queues/message-queues.module';
 import { MessageTemplateModule } from '@121-service/src/notifications/message-template/message-template.module';
 import { ImageCodeModule } from '@121-service/src/payments/imagecode/image-code.module';
-import { RedisModule } from '@121-service/src/payments/redis/redis.module';
 import { TransactionEntity } from '@121-service/src/payments/transactions/entities/transaction.entity';
-import { TransactionEventsModule } from '@121-service/src/payments/transactions/transaction-events/transaction-events.module';
 import { TransactionsModule } from '@121-service/src/payments/transactions/transactions.module';
 import { ProgramFspConfigurationEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration.entity';
 import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
-import { ProgramAidworkerAssignmentEntity } from '@121-service/src/programs/program-aidworker-assignments/program-aidworker-assignment.entity';
-import { QueuesRegistryModule } from '@121-service/src/queues-registry/queues-registry.module';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { RegistrationDataModule } from '@121-service/src/registration/modules/registration-data/registration-data.module';
 import { RegistrationUtilsModule } from '@121-service/src/registration/modules/registration-utils/registration-utils.module';
-import { RegistrationScopedRepository } from '@121-service/src/registration/repositories/registration-scoped.repository';
-import { AzureLogService } from '@121-service/src/shared/services/azure-log.service';
+import { RegistrationsModule } from '@121-service/src/registration/registrations.module';
 import { CustomHttpService } from '@121-service/src/shared/services/custom-http.service';
-import { UserModule } from '@121-service/src/user/user.module';
 import { createScopedRepositoryProvider } from '@121-service/src/utils/scope/createScopedRepositoryProvider.helper';
 import { SoapService } from '@121-service/src/utils/soap/soap.service';
 
@@ -43,30 +37,24 @@ import { SoapService } from '@121-service/src/utils/soap/soap.service';
       TransactionEntity,
       ProgramEntity,
       ProgramFspConfigurationEntity,
-      ProgramAidworkerAssignmentEntity,
       IntersolveVoucherEntity,
       TwilioMessageEntity,
     ]),
     ImageCodeModule,
-    UserModule,
     TransactionsModule,
-    TransactionEventsModule,
     MessageQueuesModule,
     MessageTemplateModule,
     RegistrationDataModule,
     RegistrationUtilsModule,
-    RedisModule,
-    QueuesRegistryModule,
+    RegistrationsModule,
   ],
   providers: [
-    AzureLogService,
     IntersolveVoucherService,
     IntersolveVoucherApiService,
     SoapService,
     IntersolveVoucherMockService,
     IntersolveVoucherCronService,
     CustomHttpService,
-    RegistrationScopedRepository,
     createScopedRepositoryProvider(IntersolveVoucherEntity),
     ProgramFspConfigurationRepository,
   ],

--- a/services/121-service/src/fsp-integrations/integrations/intersolve-voucher/services/intersolve-voucher-cron.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-voucher/services/intersolve-voucher-cron.service.ts
@@ -10,13 +10,13 @@ import { Fsps } from '@121-service/src/fsp-integrations/shared/enum/fsp-name.enu
 import { MessageProcessType } from '@121-service/src/notifications/dto/message-job.dto';
 import { MessageContentType } from '@121-service/src/notifications/enum/message-type.enum';
 import { ProgramNotificationEnum } from '@121-service/src/notifications/enum/program-notification.enum';
-import { MessageQueuesService } from '@121-service/src/notifications/message-queues/message-queues.service';
 import { TransactionEntity } from '@121-service/src/payments/transactions/entities/transaction.entity';
 import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { DefaultRegistrationDataAttributeNames } from '@121-service/src/registration/enum/registration-attribute.enum';
 import { RegistrationDataService } from '@121-service/src/registration/modules/registration-data/registration-data.service';
+import { RegistrationsService } from '@121-service/src/registration/services/registrations.service';
 import { RegistrationPreferredLanguage } from '@121-service/src/shared/enum/registration-preferred-language.enum';
 
 // TODO: Consider Refactoring this service as intersolve voucher is the only fsp with a cron-service.
@@ -39,9 +39,9 @@ export class IntersolveVoucherCronService {
 
   public constructor(
     private readonly intersolveVoucherApiService: IntersolveVoucherApiService,
-    private readonly queueMessageService: MessageQueuesService,
-    private readonly intersolveVoucherService: IntersolveVoucherService,
     private readonly registrationDataService: RegistrationDataService,
+    private readonly intersolveVoucherService: IntersolveVoucherService,
+    private readonly registrationsService: RegistrationsService,
     private readonly programFspConfigurationRepository: ProgramFspConfigurationRepository,
   ) {}
 
@@ -159,6 +159,7 @@ export class IntersolveVoucherCronService {
           where: { referenceId: Equal(referenceId) },
           relations: ['program'],
         });
+
         const fromNumber =
           await this.registrationDataService.getRegistrationDataValueByName(
             registration,
@@ -171,6 +172,7 @@ export class IntersolveVoucherCronService {
           );
           continue;
         }
+
         const language = await this.getLanguageForRegistration(referenceId);
         const contentSid =
           await this.intersolveVoucherService.getNotificationContentSid({
@@ -179,11 +181,12 @@ export class IntersolveVoucherCronService {
             language,
           });
 
-        await this.queueMessageService.addMessageJob({
-          registration,
+        await this.registrationsService.createMessageJobForRegistration({
+          referenceId,
+          programId: registration.program.id,
           contentSid,
           messageContentType: MessageContentType.paymentReminder,
-          messageProcessType:
+          extendedMessageProcessType:
             MessageProcessType.whatsappTemplateVoucherReminder,
           userId: unsentIntersolveVoucher.userId,
         });

--- a/services/121-service/src/fsp-integrations/integrations/intersolve-voucher/services/intersolve-voucher.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-voucher/services/intersolve-voucher.service.ts
@@ -169,6 +169,11 @@ export class IntersolveVoucherService {
       return paResult;
     }
 
+    if (!whatsappPhoneNumber) {
+      // This should never happen because the API layer should prevent this, it's to make TS happy
+      throw Error('WhatsApp phone number is required when useWhatsapp is true');
+    }
+
     // Continue with WhatsApp:
     return await this.sendWhatsapp({
       programFspConfigurationId,
@@ -176,6 +181,7 @@ export class IntersolveVoucherService {
       paResult,
       transactionId,
       bulkSize,
+      whatsappPhoneNumber,
       userId,
     });
   }
@@ -273,6 +279,7 @@ export class IntersolveVoucherService {
     transactionId,
     bulkSize,
     userId,
+    whatsappPhoneNumber,
   }: {
     programFspConfigurationId: number;
     referenceId: string;
@@ -280,6 +287,7 @@ export class IntersolveVoucherService {
     transactionId: number;
     bulkSize: number;
     userId: number;
+    whatsappPhoneNumber: string;
   }): Promise<PaTransactionResultDto> {
     const transferResult = await this.sendVoucherWhatsapp({
       referenceId,
@@ -287,6 +295,7 @@ export class IntersolveVoucherService {
       bulkSize,
       userId,
       programFspConfigurationId,
+      whatsappPhoneNumber,
     });
 
     paResult.status = transferResult.status;
@@ -301,12 +310,14 @@ export class IntersolveVoucherService {
     bulkSize,
     userId,
     programFspConfigurationId,
+    whatsappPhoneNumber,
   }: {
     referenceId: string;
     transactionId: number;
     bulkSize: number;
     userId: number;
     programFspConfigurationId: number;
+    whatsappPhoneNumber: string;
   }): Promise<PaTransactionResultDto> {
     const result = new PaTransactionResultDto();
     result.referenceId = referenceId;
@@ -328,15 +339,20 @@ export class IntersolveVoucherService {
       language,
     });
 
+    // TODO: Refactor this to be called from the TransactionJobsIntersolveVoucherService
+    // As the IntersolveVoucherService should ideally not have to import other modules such as transactions or notifications
     await this.queueMessageService.addMessageJob({
-      registration,
+      registrationId: registration.id,
+      programId,
+      referenceId,
+      whatsappPhoneNumber,
       contentSid: contentSid ?? undefined,
       messageContentType: MessageContentType.paymentTemplated,
-      messageProcessType: MessageProcessType.whatsappTemplateVoucher,
+      extendedMessageProcessType: MessageProcessType.whatsappTemplateVoucher,
       customData: {
         transactionData: { transactionId, programFspConfigurationId },
       },
-      bulksize: bulkSize,
+      bulkSize,
       userId,
     });
     result.status = TransactionStatusEnum.waiting;

--- a/services/121-service/src/fsp-integrations/transaction-jobs/services/transaction-jobs-helper.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/transaction-jobs/services/transaction-jobs-helper.service.spec.ts
@@ -46,9 +46,6 @@ describe('TransactionJobsHelperService', () => {
     );
 
     jest
-      .spyOn(registrationScopedRepository, 'getByReferenceId')
-      .mockResolvedValue(mockedRegistration);
-    jest
       .spyOn(registrationScopedRepository, 'updateUnscoped')
       .mockResolvedValue({} as UpdateResult);
 
@@ -57,25 +54,6 @@ describe('TransactionJobsHelperService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
-  });
-
-  describe('getRegistrationOrThrow', () => {
-    it('should return registration if found', async () => {
-      const result = await service.getRegistrationOrThrow('ref-123');
-      expect(result).toBe(mockedRegistration);
-      expect(
-        registrationScopedRepository.getByReferenceId,
-      ).toHaveBeenCalledWith({ referenceId: 'ref-123' });
-    });
-
-    it('should throw if registration not found', async () => {
-      jest
-        .spyOn(registrationScopedRepository, 'getByReferenceId')
-        .mockResolvedValueOnce(null);
-      await expect(service.getRegistrationOrThrow('not-found')).rejects.toThrow(
-        'Registration was not found for referenceId not-found',
-      );
-    });
   });
 
   describe('logTransactionJobStart', () => {

--- a/services/121-service/src/fsp-integrations/transaction-jobs/services/transaction-jobs-helper.service.ts
+++ b/services/121-service/src/fsp-integrations/transaction-jobs/services/transaction-jobs-helper.service.ts
@@ -5,17 +5,15 @@ import { MessageProcessTypeExtension } from '@121-service/src/notifications/dto/
 import { MessageContentType } from '@121-service/src/notifications/enum/message-type.enum';
 import { ProgramNotificationEnum } from '@121-service/src/notifications/enum/program-notification.enum';
 import { MessageContentDetails } from '@121-service/src/notifications/interfaces/message-content-details.interface';
-import { MessageQueuesService } from '@121-service/src/notifications/message-queues/message-queues.service';
 import { MessageTemplateService } from '@121-service/src/notifications/message-template/message-template.service';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { TransactionRepository } from '@121-service/src/payments/transactions/transaction.repository';
 import { TransactionEventDescription } from '@121-service/src/payments/transactions/transaction-events/enum/transaction-event-description.enum';
 import { TransactionEventCreationContext } from '@121-service/src/payments/transactions/transaction-events/interfaces/transaction-event-creation-context.interfac';
 import { TransactionsService } from '@121-service/src/payments/transactions/transactions.service';
-import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
-import { RegistrationViewEntity } from '@121-service/src/registration/entities/registration-view.entity';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { RegistrationScopedRepository } from '@121-service/src/registration/repositories/registration-scoped.repository';
+import { RegistrationsService } from '@121-service/src/registration/services/registrations.service';
 import { RegistrationsBulkService } from '@121-service/src/registration/services/registrations-bulk.service';
 import { RegistrationPreferredLanguage } from '@121-service/src/shared/enum/registration-preferred-language.enum';
 
@@ -24,71 +22,36 @@ export class TransactionJobsHelperService {
   public constructor(
     private readonly messageTemplateService: MessageTemplateService,
     private readonly registrationScopedRepository: RegistrationScopedRepository,
-    private readonly queueMessageService: MessageQueuesService,
+    private readonly registrationsService: RegistrationsService,
     private readonly transactionsService: TransactionsService,
     private readonly registrationsBulkService: RegistrationsBulkService,
     private readonly transactionRepository: TransactionRepository,
   ) {}
 
-  public async getRegistrationOrThrow(
-    referenceId: string,
-  ): Promise<RegistrationEntity> {
-    const registration =
-      await this.registrationScopedRepository.getByReferenceId({
-        referenceId,
-      });
-    if (!registration) {
-      throw new Error(
-        `Registration was not found for referenceId ${referenceId}`,
-      );
-    }
-    return registration;
-  }
-
-  private async addMessageJobToQueue({
-    registration,
-    userId,
-    message,
-    bulksize,
-  }: {
-    registration: RegistrationEntity | Omit<RegistrationViewEntity, 'data'>;
-    userId: number;
-    message?: string;
-    bulksize?: number;
-  }): Promise<void> {
-    await this.queueMessageService.addMessageJob({
-      registration,
-      message,
-      messageContentType: MessageContentType.payment,
-      messageProcessType:
-        MessageProcessTypeExtension.smsOrWhatsappTemplateGeneric,
-      bulksize,
-      userId,
-    });
-  }
-
   public async createMessageAndAddToQueue({
     type,
     programId,
-    registration,
+    referenceId,
     amountTransferred,
     bulkSize,
     userId,
+    preferredLanguage,
   }: {
     type: ProgramNotificationEnum;
     programId: number;
-    registration: RegistrationEntity;
+    referenceId: string;
     amountTransferred: number;
     bulkSize: number;
     userId: number;
-  }) {
+    preferredLanguage: RegistrationPreferredLanguage | null;
+  }): Promise<void> {
     const templates =
       await this.messageTemplateService.getMessageTemplatesByProgramId(
         programId,
         type,
       );
     let messageContent = templates.find(
-      (template) => template.language === registration.preferredLanguage,
+      (template) => template.language === preferredLanguage,
     )?.message;
     if (!messageContent) {
       messageContent = templates.find(
@@ -110,10 +73,14 @@ export class TransactionJobsHelperService {
       }
     }
 
-    await this.addMessageJobToQueue({
-      registration,
+    await this.registrationsService.createMessageJobForRegistration({
+      referenceId,
+      programId,
+      extendedMessageProcessType:
+        MessageProcessTypeExtension.smsOrWhatsappTemplateGeneric,
       message: messageContent ?? undefined,
-      bulksize: bulkSize,
+      messageContentType: MessageContentType.payment,
+      bulkSize,
       userId,
     });
   }

--- a/services/121-service/src/fsp-integrations/transaction-jobs/services/transaction-jobs-intersolve-visa.service.ts
+++ b/services/121-service/src/fsp-integrations/transaction-jobs/services/transaction-jobs-intersolve-visa.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { Equal } from 'typeorm';
 
 import { DoTransferOrIssueCardResult } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/interfaces/do-transfer-or-issue-card-result.interface';
 import { IntersolveVisaApiError } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/intersolve-visa-api.error';
@@ -15,17 +16,17 @@ import { TransactionEventDescription } from '@121-service/src/payments/transacti
 import { TransactionEventCreationContext } from '@121-service/src/payments/transactions/transaction-events/interfaces/transaction-event-creation-context.interfac';
 import { TransactionsService } from '@121-service/src/payments/transactions/transactions.service';
 import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';
+import { RegistrationScopedRepository } from '@121-service/src/registration/repositories/registration-scoped.repository';
 
 @Injectable()
-export class TransactionJobsIntersolveVisaService
-  implements TransactionJobService<IntersolveVisaTransactionJobDto>
-{
+export class TransactionJobsIntersolveVisaService implements TransactionJobService<IntersolveVisaTransactionJobDto> {
   constructor(
     private readonly intersolveVisaService: IntersolveVisaService,
     private readonly programFspConfigurationRepository: ProgramFspConfigurationRepository,
     private readonly transactionJobsHelperService: TransactionJobsHelperService,
     private readonly transactionsService: TransactionsService,
     private readonly transactionRepository: TransactionRepository,
+    private readonly registrationScopedRepository: RegistrationScopedRepository,
     private readonly intersolveVisaChildWalletScopedRepository: IntersolveVisaChildWalletScopedRepository,
   ) {}
 
@@ -43,10 +44,11 @@ export class TransactionJobsIntersolveVisaService
       isRetry: transactionJob.isRetry,
     });
 
-    const registration =
-      await this.transactionJobsHelperService.getRegistrationOrThrow(
-        transactionJob.referenceId,
-      );
+    const { id: registrationId, preferredLanguage } =
+      await this.registrationScopedRepository.findOneOrFail({
+        where: { referenceId: Equal(transactionJob.referenceId) },
+        select: { id: true, preferredLanguage: true },
+      });
 
     let transferValueInMajorUnit: number;
     try {
@@ -57,7 +59,7 @@ export class TransactionJobsIntersolveVisaService
       transferValueInMajorUnit =
         await this.intersolveVisaService.calculateTransferValueWithWalletRetrieval(
           {
-            registrationId: registration.id,
+            registrationId,
             inputTransferValueInMajorUnit: transactionJob.transferValue,
             maxBalanceInCents,
           },
@@ -95,7 +97,7 @@ export class TransactionJobsIntersolveVisaService
 
       const isChildWalletLinkedToRegistration =
         await this.intersolveVisaChildWalletScopedRepository.hasLinkedChildWalletForRegistrationId(
-          registration.id,
+          registrationId,
         );
       if (!cardDistributionByMail && !isChildWalletLinkedToRegistration) {
         throw new IntersolveVisaApiError(
@@ -105,7 +107,7 @@ export class TransactionJobsIntersolveVisaService
 
       intersolveVisaDoTransferOrIssueCardReturnDto =
         await this.intersolveVisaService.doTransferOrIssueCard({
-          registrationId: registration.id,
+          registrationId,
           createCustomerReference: transactionJob.referenceId,
           transferReference: `ReferenceId=${transactionJob.referenceId},TransactionId=${transactionJob.transactionId}`, // Will be used to generate idempotency key for the transfer
           contactInformation: {
@@ -145,11 +147,12 @@ export class TransactionJobsIntersolveVisaService
     await this.transactionJobsHelperService.createMessageAndAddToQueue({
       type: messageType,
       programId: transactionJob.programId,
-      registration,
+      referenceId: transactionJob.referenceId,
       amountTransferred:
         intersolveVisaDoTransferOrIssueCardReturnDto.amountTransferredInMajorUnit,
       bulkSize: transactionJob.bulkSize,
       userId: transactionJob.userId,
+      preferredLanguage,
     });
 
     await this.transactionsService.saveProgress({

--- a/services/121-service/src/notifications/message-incoming/message-incoming.module.ts
+++ b/services/121-service/src/notifications/message-incoming/message-incoming.module.ts
@@ -25,6 +25,7 @@ import { ProgramEntity } from '@121-service/src/programs/entities/program.entity
 import { QueuesRegistryModule } from '@121-service/src/queues-registry/queues-registry.module';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { RegistrationDataModule } from '@121-service/src/registration/modules/registration-data/registration-data.module';
+import { RegistrationsModule } from '@121-service/src/registration/registrations.module';
 import { AzureLogService } from '@121-service/src/shared/services/azure-log.service';
 import { UserEntity } from '@121-service/src/user/entities/user.entity';
 import { UserModule } from '@121-service/src/user/user.module';
@@ -48,6 +49,7 @@ import { UserModule } from '@121-service/src/user/user.module';
     RegistrationDataModule,
     QueuesRegistryModule,
     TransactionsModule,
+    RegistrationsModule,
   ],
   providers: [
     MessageIncomingService,

--- a/services/121-service/src/notifications/message-incoming/message-incoming.service.ts
+++ b/services/121-service/src/notifications/message-incoming/message-incoming.service.ts
@@ -22,10 +22,8 @@ import {
 import { ProcessNameMessage } from '@121-service/src/notifications/enum/process-names.enum';
 import { ProgramNotificationEnum } from '@121-service/src/notifications/enum/program-notification.enum';
 import { TwilioErrorCodes } from '@121-service/src/notifications/enum/twilio-error-codes.enum';
-import { MessageQueuesService } from '@121-service/src/notifications/message-queues/message-queues.service';
 import { MessageTemplateService } from '@121-service/src/notifications/message-template/message-template.service';
 import { WhatsappService } from '@121-service/src/notifications/whatsapp/whatsapp.service';
-import { WhatsappPendingMessageEntity } from '@121-service/src/notifications/whatsapp/whatsapp-pending-message.entity';
 import { ImageCodeService } from '@121-service/src/payments/imagecode/image-code.service';
 import { TransactionViewScopedRepository } from '@121-service/src/payments/transactions/repositories/transaction.view.scoped.repository';
 import { TransactionRepository } from '@121-service/src/payments/transactions/transaction.repository';
@@ -33,6 +31,7 @@ import { ProgramEntity } from '@121-service/src/programs/entities/program.entity
 import { QueuesRegistryService } from '@121-service/src/queues-registry/queues-registry.service';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { DefaultRegistrationDataAttributeNames } from '@121-service/src/registration/enum/registration-attribute.enum';
+import { RegistrationsService } from '@121-service/src/registration/services/registrations.service';
 import { RegistrationPreferredLanguage } from '@121-service/src/shared/enum/registration-preferred-language.enum';
 import { UserEntity } from '@121-service/src/user/entities/user.entity';
 import { isSameAsString } from '@121-service/src/utils/comparison.helper';
@@ -47,8 +46,7 @@ export class MessageIncomingService {
   private readonly registrationRepository: Repository<RegistrationEntity>;
   @InjectRepository(ProgramEntity)
   private programRepository: Repository<ProgramEntity>;
-  @InjectRepository(WhatsappPendingMessageEntity)
-  private readonly whatsappPendingMessageRepo: Repository<WhatsappPendingMessageEntity>;
+
   @InjectRepository(UserEntity)
   private readonly userRepository: Repository<UserEntity>;
 
@@ -61,11 +59,11 @@ export class MessageIncomingService {
     private readonly imageCodeService: ImageCodeService,
     private readonly intersolveVoucherService: IntersolveVoucherService,
     private readonly queuesService: QueuesRegistryService,
-    private readonly queueMessageService: MessageQueuesService,
     private readonly messageTemplateService: MessageTemplateService,
     private readonly whatsappService: WhatsappService,
     private readonly transactionRepository: TransactionRepository,
     private readonly transactionViewScopedRepository: TransactionViewScopedRepository,
+    private readonly registrationsService: RegistrationsService,
   ) {}
 
   public async getGenericNotificationText(
@@ -152,6 +150,7 @@ export class MessageIncomingService {
     ) {
       const message = await this.twilioMessageRepository.findOne({
         where: { sid: Equal(callbackData.MessageSid) },
+        relations: { registration: true },
       });
       if (
         message &&
@@ -159,7 +158,11 @@ export class MessageIncomingService {
         message.retryCount < 3
       ) {
         if (callbackData.MessageStatus === TwilioStatus.undelivered) {
-          await this.handleFaultyTemplateError(callbackData, message);
+          await this.handleFaultyTemplateError({
+            callbackData,
+            message,
+            programId: message.registration.programId,
+          });
         }
         return;
       }
@@ -223,10 +226,15 @@ export class MessageIncomingService {
     }
   }
 
-  private async handleFaultyTemplateError(
-    callbackData: TwilioStatusCallbackDto,
-    message: TwilioMessageEntity,
-  ): Promise<void> {
+  private async handleFaultyTemplateError({
+    callbackData,
+    message,
+    programId,
+  }: {
+    callbackData: TwilioStatusCallbackDto;
+    message: TwilioMessageEntity;
+    programId: number;
+  }): Promise<void> {
     await this.twilioMessageRepository.update(
       {
         sid: callbackData.MessageSid,
@@ -244,9 +252,11 @@ export class MessageIncomingService {
       );
     }
 
-    const registration = await this.registrationRepository.findOneOrFail({
-      where: { id: Equal(message.registrationId) },
-    });
+    const registration =
+      await this.registrationsService.getOnePaginatedRegistrationById({
+        id: message.registrationId,
+        programId,
+      });
 
     if (!message.processType) {
       throw new Error(
@@ -254,12 +264,13 @@ export class MessageIncomingService {
       );
     }
 
-    await this.queueMessageService.addMessageJob({
-      registration,
+    await this.registrationsService.createMessageJobForRegistration({
+      referenceId: registration.referenceId,
+      programId: registration.programId,
       message: message.body,
       messageContentType: message.contentType,
-      messageProcessType: message.processType,
-      mediaUrl: message.mediaUrl,
+      extendedMessageProcessType: message.processType,
+      mediaUrl: message.mediaUrl ?? undefined,
       customData: {
         pendingMessageId: message.id, // This will also get filled (incorrectly) for payment-reply messages, but it will simply not be handled on the processor-side
         existingMessageSid: callbackData.MessageSid,
@@ -400,11 +411,12 @@ export class MessageIncomingService {
             language,
           )
         )[0];
-        await this.queueMessageService.addMessageJob({
-          registration: registrationsWithPhoneNumber[0],
+        await this.registrationsService.createMessageJobForRegistration({
+          referenceId: registrationsWithPhoneNumber[0].referenceId,
+          programId: registrationsWithPhoneNumber[0].programId,
           message: whatsappDefaultReply.message ?? undefined,
           messageContentType: MessageContentType.defaultReply,
-          messageProcessType: MessageProcessType.whatsappDefaultReply,
+          extendedMessageProcessType: MessageProcessType.whatsappDefaultReply,
           userId: userId ? userId.id : 1,
         });
         return;
@@ -466,11 +478,12 @@ export class MessageIncomingService {
             intersolveVoucher.paymentId!,
             registration.id,
           );
-        await this.queueMessageService.addMessageJob({
-          registration,
+        await this.registrationsService.createMessageJobForRegistration({
+          referenceId: registration.referenceId,
+          programId: registration.programId,
           message,
           messageContentType: MessageContentType.paymentVoucher,
-          messageProcessType: MessageProcessType.whatsappPendingVoucher,
+          extendedMessageProcessType: MessageProcessType.whatsappPendingVoucher,
           mediaUrl,
           customData: {
             transactionData: {
@@ -488,11 +501,13 @@ export class MessageIncomingService {
 
       // Send instruction message only once (outside of loops)
       if (registrationsWithOpenVouchers.length > 0) {
-        await this.queueMessageService.addMessageJob({
-          registration,
+        await this.registrationsService.createMessageJobForRegistration({
+          referenceId: registration.referenceId,
+          programId: registration.programId,
           message: '',
           messageContentType: MessageContentType.paymentInstructions,
-          messageProcessType: MessageProcessType.whatsappVoucherInstructions,
+          extendedMessageProcessType:
+            MessageProcessType.whatsappVoucherInstructions,
           mediaUrl: `${EXTERNAL_API.rootApi}/programs/${program.id}/${API_PATHS.voucherInstructions}`,
           userId: intersolveVouchersPerPa[0].userId,
         });
@@ -536,12 +551,14 @@ export class MessageIncomingService {
     for (const registration of registrationsWithPendingMessage) {
       if (registration.whatsappPendingMessages) {
         for (const message of registration.whatsappPendingMessages) {
-          await this.queueMessageService.addMessageJob({
-            registration,
+          await this.registrationsService.createMessageJobForRegistration({
+            referenceId: registration.referenceId,
+            programId: registration.programId,
             message: message.body,
             messageContentType: message.contentType,
-            messageProcessType: MessageProcessType.whatsappPendingMessage,
-            mediaUrl: message.mediaUrl,
+            extendedMessageProcessType:
+              MessageProcessType.whatsappPendingMessage,
+            mediaUrl: message.mediaUrl ?? undefined,
             customData: { pendingMessageId: message.id },
             userId: message.userId,
           });

--- a/services/121-service/src/notifications/message-queues/message-queues.service.spec.ts
+++ b/services/121-service/src/notifications/message-queues/message-queues.service.spec.ts
@@ -5,6 +5,7 @@ import { Repository } from 'typeorm';
 import {
   MessageJobDto,
   MessageProcessType,
+  MessageProcessTypeExtension,
 } from '@121-service/src/notifications/dto/message-job.dto';
 import { MessageContentType } from '@121-service/src/notifications/enum/message-type.enum';
 import { ProcessNameMessage } from '@121-service/src/notifications/enum/process-names.enum';
@@ -12,29 +13,13 @@ import { MessageQueuesService } from '@121-service/src/notifications/message-que
 import { MessageTemplateEntity } from '@121-service/src/notifications/message-template/message-template.entity';
 import { ProgramRegistrationAttributesService } from '@121-service/src/program-registration-attributes/program-registration-attributes.service';
 import { QueuesRegistryService } from '@121-service/src/queues-registry/queues-registry.service';
-import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
-import { RegistrationViewEntity } from '@121-service/src/registration/entities/registration-view.entity';
-import { DefaultRegistrationDataAttributeNames } from '@121-service/src/registration/enum/registration-attribute.enum';
-import { RegistrationDataService } from '@121-service/src/registration/modules/registration-data/registration-data.service';
 import { RegistrationPreferredLanguage } from '@121-service/src/shared/enum/registration-preferred-language.enum';
-
-const defaultMessageJob = {
-  whatsappPhoneNumber: '1234567890',
-  phoneNumber: '1234567890',
-  preferredLanguage: RegistrationPreferredLanguage.en,
-  referenceId: 'ref-test',
-  message: 'test message',
-  messageTemplateKey: 'messageTemplateKey',
-  messageContentType: MessageContentType.custom,
-  userId: 1,
-} as MessageJobDto;
 
 describe('MessageQueuesService', () => {
   let queueMessageService: MessageQueuesService;
   let queuesService: QueuesRegistryService;
   let programRegistrationAttributesService: ProgramRegistrationAttributesService;
   let messageTemplateRepository: Repository<MessageTemplateEntity>;
-  let registrationDataService: RegistrationDataService;
 
   beforeAll(() => {
     const { unit, unitRef } = TestBed.create(MessageQueuesService)
@@ -51,7 +36,6 @@ describe('MessageQueuesService', () => {
     programRegistrationAttributesService = unitRef.get(
       ProgramRegistrationAttributesService,
     );
-    registrationDataService = unitRef.get(RegistrationDataService);
     messageTemplateRepository = unitRef.get(
       getRepositoryToken(MessageTemplateEntity) as any,
     );
@@ -61,88 +45,81 @@ describe('MessageQueuesService', () => {
     expect(queueMessageService).toBeDefined();
   });
 
-  it('should add message to queue registration view', async () => {
+  const baseMessageJob = {
+    registrationId: 2,
+    programId: 1,
+    phoneNumber: '1234567890',
+    preferredLanguage: RegistrationPreferredLanguage.en,
+    referenceId: 'ref-test',
+    message: 'test message',
+    messageTemplateKey: 'messageTemplateKey',
+    messageContentType: MessageContentType.custom,
+    userId: 1,
+  };
+
+  it('should add message to queue', async () => {
     // Arrange
-    const registration = new RegistrationViewEntity();
-    registration.id = 2;
-    registration.referenceId = 'refview';
-    registration.preferredLanguage = RegistrationPreferredLanguage.fr;
-    registration.phoneNumber = '234567891';
-    registration.programId = 1;
-    registration[DefaultRegistrationDataAttributeNames.whatsappPhoneNumber] =
-      '0987654321';
+    const messageJob = {
+      ...baseMessageJob,
+      whatsappPhoneNumber: '1234567890',
+      messageProcessType: MessageProcessType.whatsappTemplateGeneric,
+    } satisfies MessageJobDto;
 
     // Act
     await queueMessageService.addMessageJob({
-      registration,
-      message: 'test message',
-      messageTemplateKey: defaultMessageJob.messageTemplateKey,
-      messageContentType: MessageContentType.custom,
-      messageProcessType: MessageProcessType.whatsappTemplateGeneric,
-      userId: defaultMessageJob.userId,
+      ...messageJob,
+      extendedMessageProcessType: messageJob.messageProcessType,
     });
 
     // Assert
     expect(queuesService.createMessageSmallBulkQueue.add).toHaveBeenCalledWith(
       ProcessNameMessage.send,
       {
-        ...defaultMessageJob,
-        whatsappPhoneNumber:
-          registration[
-            DefaultRegistrationDataAttributeNames.whatsappPhoneNumber
-          ],
-        phoneNumber: registration.phoneNumber,
-        preferredLanguage: registration.preferredLanguage,
-        registrationId: registration.id,
-        programId: registration.programId,
-        referenceId: registration.referenceId,
+        ...messageJob,
         customData: undefined,
         mediaUrl: undefined,
-        messageProcessType: MessageProcessType.whatsappTemplateGeneric,
       },
     );
   });
 
-  it('should add message to queue registration entity', async () => {
+  it('should resolve smsOrWhatsappTemplateGeneric to whatsappTemplateGeneric when whatsappPhoneNumber is set', async () => {
     // Arrange
-    const whatsappNumber = '0987654321';
-    const registration = new RegistrationEntity();
-    registration.id = 1;
-    registration.referenceId = 'ref';
-    registration.preferredLanguage = RegistrationPreferredLanguage.en;
-    registration.phoneNumber = '1234567890';
-    registration.programId = 1;
-
-    const mockGetRegistrationDataValueByName = jest
-      .spyOn(registrationDataService, 'getRegistrationDataValueByName')
-      .mockResolvedValue(whatsappNumber);
+    const whatsappPhoneNumber = '1234567890';
 
     // Act
     await queueMessageService.addMessageJob({
-      registration,
-      message: 'test message',
-      messageTemplateKey: defaultMessageJob.messageTemplateKey,
-      messageContentType: MessageContentType.custom,
-      messageProcessType: MessageProcessType.whatsappTemplateGeneric,
-      userId: defaultMessageJob.userId,
+      ...baseMessageJob,
+      whatsappPhoneNumber,
+      extendedMessageProcessType:
+        MessageProcessTypeExtension.smsOrWhatsappTemplateGeneric,
     });
 
     // Assert
-    expect(mockGetRegistrationDataValueByName).toHaveBeenCalledTimes(1);
     expect(queuesService.createMessageSmallBulkQueue.add).toHaveBeenCalledWith(
       ProcessNameMessage.send,
-      {
-        ...defaultMessageJob,
-        whatsappPhoneNumber: whatsappNumber,
-        phoneNumber: registration.phoneNumber,
-        preferredLanguage: registration.preferredLanguage,
-        registrationId: registration.id,
-        referenceId: registration.referenceId,
-        programId: registration.programId,
-        customData: undefined,
-        mediaUrl: undefined,
+      expect.objectContaining({
         messageProcessType: MessageProcessType.whatsappTemplateGeneric,
-      },
+        whatsappPhoneNumber,
+      }),
+    );
+  });
+
+  it('should resolve smsOrWhatsappTemplateGeneric to sms when whatsappPhoneNumber is not set', async () => {
+    // Act
+    await queueMessageService.addMessageJob({
+      ...baseMessageJob,
+      whatsappPhoneNumber: undefined,
+      extendedMessageProcessType:
+        MessageProcessTypeExtension.smsOrWhatsappTemplateGeneric,
+    });
+
+    // Assert
+    expect(queuesService.createMessageSmallBulkQueue.add).toHaveBeenCalledWith(
+      ProcessNameMessage.send,
+      expect.objectContaining({
+        messageProcessType: MessageProcessType.sms,
+        whatsappPhoneNumber: undefined,
+      }),
     );
   });
 

--- a/services/121-service/src/notifications/message-queues/message-queues.service.ts
+++ b/services/121-service/src/notifications/message-queues/message-queues.service.ts
@@ -22,10 +22,6 @@ import { MessageSenderUserId } from '@121-service/src/notifications/types/messag
 import { ProgramRegistrationAttributesService } from '@121-service/src/program-registration-attributes/program-registration-attributes.service';
 import { QueueNames } from '@121-service/src/queues-registry/enum/queue-names.enum';
 import { QueuesRegistryService } from '@121-service/src/queues-registry/queues-registry.service';
-import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
-import { RegistrationViewEntity } from '@121-service/src/registration/entities/registration-view.entity';
-import { DefaultRegistrationDataAttributeNames } from '@121-service/src/registration/enum/registration-attribute.enum';
-import { RegistrationDataService } from '@121-service/src/registration/modules/registration-data/registration-data.service';
 import { RegistrationPreferredLanguage } from '@121-service/src/shared/enum/registration-preferred-language.enum';
 
 @Injectable()
@@ -35,7 +31,6 @@ export class MessageQueuesService {
   private readonly queueNameToQueueMap: Partial<Record<QueueNames, Queue>>;
 
   public constructor(
-    private readonly registrationDataService: RegistrationDataService,
     private readonly programRegistrationAttributesService: ProgramRegistrationAttributesService,
     private readonly queuesService: QueuesRegistryService,
   ) {
@@ -54,64 +49,63 @@ export class MessageQueuesService {
   }
 
   public async addMessageJob({
-    registration,
+    registrationId,
+    referenceId,
+    programId,
+    preferredLanguage,
+    phoneNumber,
+    whatsappPhoneNumber,
+    extendedMessageProcessType,
     message,
     contentSid,
     messageTemplateKey,
     messageContentType,
-    messageProcessType,
     mediaUrl,
     customData,
-    bulksize,
     userId,
+    bulkSize,
   }: {
-    registration: RegistrationEntity | Omit<RegistrationViewEntity, 'data'>;
+    registrationId: number;
+    referenceId: string;
+    programId: number;
+    preferredLanguage?: RegistrationPreferredLanguage | null;
+    phoneNumber?: string;
+    whatsappPhoneNumber?: string;
+    extendedMessageProcessType: ExtendedMessageProccessType;
     message?: string;
     contentSid?: string;
     messageTemplateKey?: string;
     messageContentType: MessageContentType;
-    messageProcessType: ExtendedMessageProccessType;
-    mediaUrl?: string | null;
+    mediaUrl?: string;
     customData?: MessageJobCustomDataDto;
-    bulksize?: number;
     userId: MessageSenderUserId;
+    bulkSize?: number;
   }): Promise<void> {
-    let whatsappPhoneNumber =
-      registration[DefaultRegistrationDataAttributeNames.whatsappPhoneNumber];
-    if (registration instanceof RegistrationEntity) {
-      whatsappPhoneNumber =
-        await this.registrationDataService.getRegistrationDataValueByName(
-          registration,
-          DefaultRegistrationDataAttributeNames.whatsappPhoneNumber,
-        );
-    }
-
     // If messageProcessType is smsOrWhatsappTemplateGeneric, check if registration has whatsappPhoneNumber
-    if (
-      messageProcessType ===
+    const messageProcessType: MessageProcessType =
+      extendedMessageProcessType ===
       MessageProcessTypeExtension.smsOrWhatsappTemplateGeneric
-    ) {
-      messageProcessType = whatsappPhoneNumber
-        ? MessageProcessType.whatsappTemplateGeneric
-        : MessageProcessType.sms;
-    }
+        ? whatsappPhoneNumber
+          ? MessageProcessType.whatsappTemplateGeneric
+          : MessageProcessType.sms
+        : extendedMessageProcessType;
 
     try {
-      const queueName = this.getQueueName(messageProcessType, bulksize);
+      const queueName = this.getQueueName(messageProcessType, bulkSize);
       const messageJob: MessageJobDto = {
         messageProcessType,
-        registrationId: registration.id,
-        referenceId: registration.referenceId,
+        registrationId,
+        referenceId,
         preferredLanguage:
-          registration.preferredLanguage ?? RegistrationPreferredLanguage.en,
+          preferredLanguage ?? RegistrationPreferredLanguage.en,
         whatsappPhoneNumber,
-        phoneNumber: registration.phoneNumber ?? undefined,
-        programId: registration.programId,
+        phoneNumber,
+        programId,
         message,
         contentSid,
         messageTemplateKey,
         messageContentType,
-        mediaUrl: mediaUrl ?? undefined,
+        mediaUrl,
         customData,
         userId,
       };

--- a/services/121-service/src/registration/controllers/registrations.controller.ts
+++ b/services/121-service/src/registration/controllers/registrations.controller.ts
@@ -664,7 +664,7 @@ export class RegistrationsController {
     @Param('id', ParseIntPipe) id: number,
   ): Promise<MappedPaginatedRegistrationDto> {
     const registrationEntity =
-      await this.registrationsService.getPaginateRegistrationById({
+      await this.registrationsService.getOnePaginatedRegistrationById({
         id,
         programId,
       });

--- a/services/121-service/src/registration/modules/registration-data/registration-data.service.ts
+++ b/services/121-service/src/registration/modules/registration-data/registration-data.service.ts
@@ -24,24 +24,6 @@ export class RegistrationDataService {
     private readonly registrationScopedRepository: RegistrationScopedRepository,
   ) {}
 
-  public async getRegistrationValueByName(
-    registration: RegistrationEntity,
-    name: string,
-  ): Promise<string | undefined> {
-    const registrationDataResult = await this.getRegistrationDataValueByName(
-      registration,
-      name,
-    );
-    if (registrationDataResult) {
-      return registrationDataResult;
-    } else {
-      const registrationResult = registration[name];
-      if (registrationResult) {
-        return registrationResult;
-      }
-    }
-  }
-
   // TODO: Refactor this to accept an array of keys
   public async getRegistrationDataValueByName(
     registration: RegistrationEntity,

--- a/services/121-service/src/registration/repositories/registration-scoped.repository.ts
+++ b/services/121-service/src/registration/repositories/registration-scoped.repository.ts
@@ -144,12 +144,6 @@ export class RegistrationScopedRepository extends RegistrationScopedBaseReposito
     });
   }
 
-  public async getByReferenceId({ referenceId }: { referenceId: string }) {
-    return await this.getWithRelationsByReferenceIdAndProgramId({
-      referenceId,
-    });
-  }
-
   public async getWithRelationsByReferenceIdAndProgramId({
     referenceId,
     programId,
@@ -309,8 +303,7 @@ export class RegistrationScopedRepository extends RegistrationScopedBaseReposito
   public async getDebitCardsDetailsForExport(
     programId: number,
   ): Promise<ExportVisaCardDetailsRawData[]> {
-    const wallets = await this
-      .createQueryBuilder('registration')
+    const wallets = await this.createQueryBuilder('registration')
       .leftJoin('registration.intersolveVisaCustomer', 'customer')
       .leftJoin(
         'customer.intersolveVisaParentWallet',
@@ -364,8 +357,7 @@ export class RegistrationScopedRepository extends RegistrationScopedBaseReposito
   }: {
     referenceId: string;
   }): Promise<boolean> {
-    const registrationToComplete = await this
-      .createQueryBuilder('registration')
+    const registrationToComplete = await this.createQueryBuilder('registration')
       .andWhere('registration."paymentCount" >= registration."maxPayments"')
       .andWhere('registration."registrationStatus" != :completedStatus', {
         completedStatus: RegistrationStatusEnum.completed,

--- a/services/121-service/src/registration/services/registrations-bulk.service.ts
+++ b/services/121-service/src/registration/services/registrations-bulk.service.ts
@@ -659,14 +659,23 @@ export class RegistrationsBulkService {
         placeholderData[placeholder] = registration[placeholder];
       }
       await this.queueMessageService.addMessageJob({
-        registration,
+        registrationId: registration.id,
+        referenceId: registration.referenceId,
+        programId: registration.programId,
+        preferredLanguage: registration.preferredLanguage,
+        phoneNumber:
+          registration[DefaultRegistrationDataAttributeNames.phoneNumber],
+        whatsappPhoneNumber:
+          registration[
+            DefaultRegistrationDataAttributeNames.whatsappPhoneNumber
+          ],
         message: messageContentDetails.message,
         messageTemplateKey: messageContentDetails.messageTemplateKey,
         messageContentType: messageContentDetails.messageContentType!, // already validated to be present
-        messageProcessType:
+        extendedMessageProcessType:
           MessageProcessTypeExtension.smsOrWhatsappTemplateGeneric,
         customData: { placeholderData },
-        bulksize,
+        bulkSize: bulksize,
         userId,
       });
     }

--- a/services/121-service/src/registration/services/registrations.service.ts
+++ b/services/121-service/src/registration/services/registrations.service.ts
@@ -5,7 +5,14 @@ import { Equal, FindOneOptions, In, Repository } from 'typeorm';
 import { IntersolveVisaDataSynchronizationService } from '@121-service/src/fsp-integrations/data-synchronization/intersolve-visa/intersolve-visa-data-synchronization.service';
 import { ContactInformation } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/interfaces/partials/contact-information.interface';
 import { FspAttributes } from '@121-service/src/fsp-integrations/shared/enum/fsp-attributes.enum';
+import {
+  ExtendedMessageProccessType,
+  MessageJobCustomDataDto,
+} from '@121-service/src/notifications/dto/message-job.dto';
+import { MessageContentType } from '@121-service/src/notifications/enum/message-type.enum';
 import { LookupService } from '@121-service/src/notifications/lookup/lookup.service';
+import { MessageQueuesService } from '@121-service/src/notifications/message-queues/message-queues.service';
+import { MessageSenderUserId } from '@121-service/src/notifications/types/message-sender-user-id.type';
 import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/entities/program-registration-attribute.entity';
@@ -22,6 +29,7 @@ import {
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import {
   DefaultRegistrationDataAttributeNames,
+  GenericRegistrationAttributes,
   RegistrationAttributeTypes,
 } from '@121-service/src/registration/enum/registration-attribute.enum';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
@@ -70,6 +78,7 @@ export class RegistrationsService {
     private readonly registrationsInputValidator: RegistrationsInputValidator,
     private readonly uniqueRegistrationPairRepository: UniqueRegistrationPairRepository,
     private readonly intersolveVisaDataSynchronizationService: IntersolveVisaDataSynchronizationService,
+    private readonly messageQueuesService: MessageQueuesService,
   ) {}
 
   public async getRegistrationOrThrow({
@@ -100,26 +109,99 @@ export class RegistrationsService {
     return registration;
   }
 
-  // This methods can be used to get the same formatted data as the pagination query using referenceId
-  public async getPaginateRegistrationForReferenceId(
-    referenceId: string,
-    programId: number,
-  ) {
+  public async createMessageJobForRegistration({
+    referenceId,
+    programId,
+    extendedMessageProcessType,
+    message,
+    contentSid,
+    messageTemplateKey,
+    messageContentType,
+    mediaUrl,
+    customData,
+    userId,
+    bulkSize,
+  }: {
+    referenceId: string;
+    programId: number;
+    extendedMessageProcessType: ExtendedMessageProccessType;
+    message?: string;
+    contentSid?: string;
+    messageTemplateKey?: string;
+    messageContentType: MessageContentType;
+    mediaUrl?: string;
+    customData?: MessageJobCustomDataDto;
+    userId: MessageSenderUserId;
+    bulkSize?: number;
+  }): Promise<void> {
+    const registration = await this.getOnePaginatedRegistrationByReferenceId({
+      referenceId,
+      programId,
+      select: [
+        'id',
+        GenericRegistrationAttributes.preferredLanguage,
+        DefaultRegistrationDataAttributeNames.phoneNumber,
+        DefaultRegistrationDataAttributeNames.whatsappPhoneNumber,
+      ],
+    });
+
+    await this.messageQueuesService.addMessageJob({
+      registrationId: registration.id,
+      referenceId,
+      programId,
+      preferredLanguage: registration.preferredLanguage,
+      phoneNumber:
+        registration[DefaultRegistrationDataAttributeNames.phoneNumber],
+      whatsappPhoneNumber:
+        registration[DefaultRegistrationDataAttributeNames.whatsappPhoneNumber],
+      extendedMessageProcessType,
+      message,
+      contentSid,
+      messageTemplateKey,
+      messageContentType,
+      mediaUrl,
+      customData,
+      userId,
+      bulkSize,
+    });
+  }
+
+  /**
+   * This method can be used to get the same formatted data as the pagination query using referenceId.
+   * This is a registration view with flattened version of its registrationData.
+   */
+  private async getOnePaginatedRegistrationByReferenceId({
+    referenceId,
+    programId,
+    select,
+  }: {
+    referenceId: string;
+    programId: number;
+    select?: string[];
+  }) {
     const queryBuilder = this.registrationViewScopedRepository
       .createQueryBuilder('registration')
       .andWhere({ referenceId });
     const paginateResult =
       await this.registrationsPaginationService.getPaginate({
-        query: { path: '', limit: 1 },
+        query: { path: '', limit: 1, select },
         programId,
         hasPersonalReadPermission: true,
         queryBuilder,
       });
+    if (paginateResult.data.length !== 1) {
+      throw new Error(
+        `Unexpected error: ReferenceId '${referenceId}' not found in pagination query results.`,
+      );
+    }
     return paginateResult.data[0];
   }
 
-  // This methods can be used to get the same formatted data as the pagination query using referenceId
-  public async getPaginateRegistrationById({
+  /**
+   * This method can be used to get the same formatted data as the pagination query using referenceId.
+   * This is a registration view with flattened version of its registrationData.
+   */
+  public async getOnePaginatedRegistrationById({
     id,
     programId,
   }: {
@@ -391,7 +473,10 @@ export class RegistrationsService {
     const program = registrationToUpdate.program;
 
     const oldViewRegistration =
-      await this.getPaginateRegistrationForReferenceId(referenceId, programId);
+      await this.getOnePaginatedRegistrationByReferenceId({
+        referenceId,
+        programId,
+      });
 
     // Track whether maxPayments has been updated to match paymentCount
     let maxPaymentsMatchesPaymentCount = false;
@@ -448,9 +533,11 @@ export class RegistrationsService {
       nrAttributesUpdated++;
     }
 
-    const newRegistration = await this.getPaginateRegistrationForReferenceId(
-      referenceId,
-      programId,
+    const newRegistration = await this.getOnePaginatedRegistrationByReferenceId(
+      {
+        referenceId,
+        programId,
+      },
     );
 
     if (nrAttributesUpdated > 0) {
@@ -612,10 +699,10 @@ export class RegistrationsService {
 
     return await Promise.all(
       filteredRegistrations.map(async (uniqueRegistration) => {
-        return await this.getPaginateRegistrationForReferenceId(
-          uniqueRegistration.referenceId,
-          uniqueRegistration.programId,
-        );
+        return await this.getOnePaginatedRegistrationByReferenceId({
+          referenceId: uniqueRegistration.referenceId,
+          programId: uniqueRegistration.programId,
+        });
       }),
     );
   }

--- a/services/121-service/swagger.json
+++ b/services/121-service/swagger.json
@@ -300,16 +300,193 @@
     ]
   },
   {
+    "method": "post",
+    "path": "/api/programs/{programId}/registrations/import",
+    "params": [
+      "programId"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/programs/{programId}/registrations",
+    "params": [
+      "programId"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/programs/{programId}/registrations",
+    "params": [
+      "programId",
+      "page",
+      "limit",
+      "filter.referenceId",
+      "filter.status",
+      "filter.id",
+      "filter.created",
+      "filter.phoneNumber",
+      "filter.preferredLanguage",
+      "filter.inclusionScore",
+      "filter.paymentAmountMultiplier",
+      "filter.fspName",
+      "filter.programFspConfigurationName",
+      "filter.programFspConfigurationLabel",
+      "filter.registrationProgramId",
+      "filter.maxPayments",
+      "filter.paymentCount",
+      "filter.paymentCountRemaining",
+      "filter.personAffectedSequence",
+      "filter.lastMessageStatus",
+      "filter.duplicateStatus",
+      "sortBy",
+      "search",
+      "searchBy"
+    ]
+  },
+  {
     "method": "patch",
-    "path": "/api/programs/{programId}/fsps/intersolve-voucher/all",
+    "path": "/api/programs/{programId}/registrations",
+    "params": [
+      "programId"
+    ]
+  },
+  {
+    "method": "delete",
+    "path": "/api/programs/{programId}/registrations",
+    "params": [
+      "programId",
+      "page",
+      "limit",
+      "dryRun",
+      "filter.referenceId",
+      "filter.status",
+      "filter.id",
+      "filter.created",
+      "filter.phoneNumber",
+      "filter.preferredLanguage",
+      "filter.inclusionScore",
+      "filter.paymentAmountMultiplier",
+      "filter.fspName",
+      "filter.programFspConfigurationName",
+      "filter.programFspConfigurationLabel",
+      "filter.registrationProgramId",
+      "filter.maxPayments",
+      "filter.paymentCount",
+      "filter.paymentCountRemaining",
+      "filter.personAffectedSequence",
+      "filter.lastMessageStatus",
+      "filter.duplicateStatus",
+      "search",
+      "searchBy"
+    ],
+    "returnType": "BulkActionResultDto"
+  },
+  {
+    "method": "get",
+    "path": "/api/programs/{programId}/registrations/import/template",
     "params": [
       "programId"
     ]
   },
   {
     "method": "patch",
-    "path": "/api/fsps/intersolve-voucher/unused-vouchers",
-    "params": []
+    "path": "/api/programs/{programId}/registrations/status",
+    "params": [
+      "programId",
+      "page",
+      "limit",
+      "dryRun",
+      "filter.referenceId",
+      "filter.status",
+      "filter.id",
+      "filter.created",
+      "filter.phoneNumber",
+      "filter.preferredLanguage",
+      "filter.inclusionScore",
+      "filter.paymentAmountMultiplier",
+      "filter.fspName",
+      "filter.programFspConfigurationName",
+      "filter.programFspConfigurationLabel",
+      "filter.registrationProgramId",
+      "filter.maxPayments",
+      "filter.paymentCount",
+      "filter.paymentCountRemaining",
+      "filter.personAffectedSequence",
+      "filter.lastMessageStatus",
+      "filter.duplicateStatus",
+      "search",
+      "searchBy"
+    ],
+    "returnType": "BulkActionResultDto"
+  },
+  {
+    "method": "patch",
+    "path": "/api/programs/{programId}/registrations/{referenceId}",
+    "params": [
+      "programId",
+      "referenceId"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/programs/{programId}/registrations/message",
+    "params": [
+      "programId",
+      "page",
+      "limit",
+      "dryRun",
+      "filter.referenceId",
+      "filter.status",
+      "filter.id",
+      "filter.created",
+      "filter.phoneNumber",
+      "filter.preferredLanguage",
+      "filter.inclusionScore",
+      "filter.paymentAmountMultiplier",
+      "filter.fspName",
+      "filter.programFspConfigurationName",
+      "filter.programFspConfigurationLabel",
+      "filter.registrationProgramId",
+      "filter.maxPayments",
+      "filter.paymentCount",
+      "filter.paymentCountRemaining",
+      "filter.personAffectedSequence",
+      "filter.lastMessageStatus",
+      "filter.duplicateStatus",
+      "search",
+      "searchBy"
+    ],
+    "returnType": "BulkActionResultDto"
+  },
+  {
+    "method": "get",
+    "path": "/api/programs/{programId}/registrations/{referenceId}/duplicates",
+    "params": [
+      "referenceId",
+      "programId"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/programs/{programId}/registrations/uniques",
+    "params": [
+      "programId"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/programs/{programId}/registrations/{id}",
+    "params": [
+      "programId",
+      "id"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/registrations",
+    "params": [
+      "phonenumber"
+    ]
   },
   {
     "method": "get",
@@ -510,210 +687,6 @@
     ]
   },
   {
-    "method": "put",
-    "path": "/api/programs/{programId}/fsps/commercial-bank-ethiopia/accounts",
-    "params": [
-      "programId"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/api/programs/{programId}/fsps/commercial-bank-ethiopia/accounts",
-    "params": [
-      "programId"
-    ],
-    "returnType": "CommercialBankEthiopiaValidationReportDto"
-  },
-  {
-    "method": "post",
-    "path": "/api/programs/{programId}/registrations/import",
-    "params": [
-      "programId"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/api/programs/{programId}/registrations",
-    "params": [
-      "programId"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/api/programs/{programId}/registrations",
-    "params": [
-      "programId",
-      "page",
-      "limit",
-      "filter.referenceId",
-      "filter.status",
-      "filter.id",
-      "filter.created",
-      "filter.phoneNumber",
-      "filter.preferredLanguage",
-      "filter.inclusionScore",
-      "filter.paymentAmountMultiplier",
-      "filter.fspName",
-      "filter.programFspConfigurationName",
-      "filter.programFspConfigurationLabel",
-      "filter.registrationProgramId",
-      "filter.maxPayments",
-      "filter.paymentCount",
-      "filter.paymentCountRemaining",
-      "filter.personAffectedSequence",
-      "filter.lastMessageStatus",
-      "filter.duplicateStatus",
-      "sortBy",
-      "search",
-      "searchBy"
-    ]
-  },
-  {
-    "method": "patch",
-    "path": "/api/programs/{programId}/registrations",
-    "params": [
-      "programId"
-    ]
-  },
-  {
-    "method": "delete",
-    "path": "/api/programs/{programId}/registrations",
-    "params": [
-      "programId",
-      "page",
-      "limit",
-      "dryRun",
-      "filter.referenceId",
-      "filter.status",
-      "filter.id",
-      "filter.created",
-      "filter.phoneNumber",
-      "filter.preferredLanguage",
-      "filter.inclusionScore",
-      "filter.paymentAmountMultiplier",
-      "filter.fspName",
-      "filter.programFspConfigurationName",
-      "filter.programFspConfigurationLabel",
-      "filter.registrationProgramId",
-      "filter.maxPayments",
-      "filter.paymentCount",
-      "filter.paymentCountRemaining",
-      "filter.personAffectedSequence",
-      "filter.lastMessageStatus",
-      "filter.duplicateStatus",
-      "search",
-      "searchBy"
-    ],
-    "returnType": "BulkActionResultDto"
-  },
-  {
-    "method": "get",
-    "path": "/api/programs/{programId}/registrations/import/template",
-    "params": [
-      "programId"
-    ]
-  },
-  {
-    "method": "patch",
-    "path": "/api/programs/{programId}/registrations/status",
-    "params": [
-      "programId",
-      "page",
-      "limit",
-      "dryRun",
-      "filter.referenceId",
-      "filter.status",
-      "filter.id",
-      "filter.created",
-      "filter.phoneNumber",
-      "filter.preferredLanguage",
-      "filter.inclusionScore",
-      "filter.paymentAmountMultiplier",
-      "filter.fspName",
-      "filter.programFspConfigurationName",
-      "filter.programFspConfigurationLabel",
-      "filter.registrationProgramId",
-      "filter.maxPayments",
-      "filter.paymentCount",
-      "filter.paymentCountRemaining",
-      "filter.personAffectedSequence",
-      "filter.lastMessageStatus",
-      "filter.duplicateStatus",
-      "search",
-      "searchBy"
-    ],
-    "returnType": "BulkActionResultDto"
-  },
-  {
-    "method": "patch",
-    "path": "/api/programs/{programId}/registrations/{referenceId}",
-    "params": [
-      "programId",
-      "referenceId"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/api/programs/{programId}/registrations/message",
-    "params": [
-      "programId",
-      "page",
-      "limit",
-      "dryRun",
-      "filter.referenceId",
-      "filter.status",
-      "filter.id",
-      "filter.created",
-      "filter.phoneNumber",
-      "filter.preferredLanguage",
-      "filter.inclusionScore",
-      "filter.paymentAmountMultiplier",
-      "filter.fspName",
-      "filter.programFspConfigurationName",
-      "filter.programFspConfigurationLabel",
-      "filter.registrationProgramId",
-      "filter.maxPayments",
-      "filter.paymentCount",
-      "filter.paymentCountRemaining",
-      "filter.personAffectedSequence",
-      "filter.lastMessageStatus",
-      "filter.duplicateStatus",
-      "search",
-      "searchBy"
-    ],
-    "returnType": "BulkActionResultDto"
-  },
-  {
-    "method": "get",
-    "path": "/api/programs/{programId}/registrations/{referenceId}/duplicates",
-    "params": [
-      "referenceId",
-      "programId"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/api/programs/{programId}/registrations/uniques",
-    "params": [
-      "programId"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/api/programs/{programId}/registrations/{id}",
-    "params": [
-      "programId",
-      "id"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/api/registrations",
-    "params": [
-      "phonenumber"
-    ]
-  },
-  {
     "method": "get",
     "path": "/api/programs/{programId}/registration-events",
     "params": [
@@ -739,6 +712,33 @@
       "filter.reason",
       "sortBy"
     ]
+  },
+  {
+    "method": "patch",
+    "path": "/api/programs/{programId}/fsps/intersolve-voucher/all",
+    "params": [
+      "programId"
+    ]
+  },
+  {
+    "method": "patch",
+    "path": "/api/fsps/intersolve-voucher/unused-vouchers",
+    "params": []
+  },
+  {
+    "method": "put",
+    "path": "/api/programs/{programId}/fsps/commercial-bank-ethiopia/accounts",
+    "params": [
+      "programId"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/api/programs/{programId}/fsps/commercial-bank-ethiopia/accounts",
+    "params": [
+      "programId"
+    ],
+    "returnType": "CommercialBankEthiopiaValidationReportDto"
   },
   {
     "method": "put",


### PR DESCRIPTION
Signed-off-by: Ruben <vandervalk@geoit.nl>[AB#42246](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42246) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Refactors the interface of adding messages to queue & centralizes message-job creation in RegistrationsService

**Why I created this refactor?**

- I tried to remove the phonenumber from the registration entity (the goal of the main item of subtask [AB#42246](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42246))
- However I ran into the fact that the widely used `queueMessageService.addMessageJob` required a complete registration entity of which it used the phonenumber (which I tried to remove from the registrationEntity). It required a lot of hassle and hacks to work around it without a more wider refactor
- Passing a complete entity is not in line with our [guidelines](https://github.com/global-121/121-platform/wiki/Guidelines-Software-Architecture#naming-guidelines) B.4
- To keep stuff simple for the reviewer and myself I decided to do this refactor as a seperate PR 

**Why did I decide to add a method to the registration service?**

I refactored the MessageQueuesService.addMessageJob to accept flat fields (registrationId, phoneNumber, whatsappPhoneNumber, preferredLanguage) instead of complete registration entities. So each call side now has to get this information from the database. This means that each call side should already have knowledge of the 'concept' of a registration and should have used the registration repository or registration pagination service to get this information. This means that dependency wise this already makes sense.

**Alternatives I considered where:**

-  fetching the registration data in the MessageQueuesService (this was already done before in [hacky way](https://github.com/global-121/121-platform/pull/8246/changes#diff-394e74645996831e0fc1a084411df57691a86c2984f88757a3757b0304829a0dR83-R84) by using the RegistrationDataService), which is now removed in this PR. I would argue it would make a lot more sense conceptually for the registration module to know about the messaque module than the other way around
- Adding a method to the RegistrationModule called something like '`fetchRegistrationAttributesNeededForMessages`'  and than calling that at each call side just before calling addMessageJob. However the RegistrationModule already uses the MessageQueuesService to send message itself and a method like `fetchRegistrationAttributesNeededForMessages` also implies that the registration module knows about messaging. So I think such as solution would only result in overhead compared to the current implementation. 

**No we tests were added?**

I considered adding unit tests. However the only method I really added was createMessageJobForRegistration and I does not contains extra logic that is not already tested by integration tests


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
