### PR TITLE
feat: Add a styled modal/popup for "Do you want to discard changes?" when leaving a page with edits

### DIFF
--- a/interfaces/portal/src/app/app.component.html
+++ b/interfaces/portal/src/app/app.component.html
@@ -1,9 +1,20 @@
 <router-outlet />
-<p-toast
-  [key]="toastKey"
-  [position]="toastPosition"
-></p-toast>
-<app-session-expired-dialog
-  [(dialogVisible)]="showSessionExpiredDialog"
-  [returnUrl]="sessionExpiredReturnUrl()"
-/>
+@defer (on idle) {
+  <p-toast
+    [key]="toastKey"
+    [position]="toastPosition"
+  ></p-toast>
+}
+@defer (on idle) {
+  <app-session-expired-dialog
+    [(dialogVisible)]="showSessionExpiredDialog"
+    [returnUrl]="sessionExpiredReturnUrl()"
+  />
+}
+@defer (on idle) {
+  <app-unsaved-changes-dialog
+    [visible]="unsavedChangesService.visible()"
+    (confirmDialog)="unsavedChangesService.resolve(true)"
+    (cancelDialog)="unsavedChangesService.resolve(false)"
+  />
+}

--- a/interfaces/portal/src/app/app.component.ts
+++ b/interfaces/portal/src/app/app.component.ts
@@ -14,15 +14,22 @@ import { Subscription } from 'rxjs';
 
 import { AppRoutes } from '~/app.routes';
 import { SessionExpiredDialogComponent } from '~/components/session-expired-dialog/session-expired-dialog.component';
+import { UnsavedChangesDialogComponent } from '~/components/unsaved-changes-dialog/unsaved-changes-dialog.component';
 import { AuthService } from '~/services/auth.service';
 import { LogService } from '~/services/log.service';
 import { RtlHelperService } from '~/services/rtl-helper.service';
 import { ToastService } from '~/services/toast.service';
+import { UnsavedChangesService } from '~/services/unsaved-changes.service';
 import { environment } from '~environment';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, ToastModule, SessionExpiredDialogComponent],
+  imports: [
+    RouterOutlet,
+    ToastModule,
+    SessionExpiredDialogComponent,
+    UnsavedChangesDialogComponent,
+  ],
   templateUrl: './app.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -39,6 +46,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
   readonly showSessionExpiredDialog = this.authService.showSessionExpiredDialog;
   readonly sessionExpiredReturnUrl = this.authService.sessionExpiredReturnUrl;
+  protected readonly unsavedChangesService = inject(UnsavedChangesService);
 
   private readonly logService = inject(LogService);
 

--- a/interfaces/portal/src/app/components/unsaved-changes-dialog/unsaved-changes-dialog.component.html
+++ b/interfaces/portal/src/app/components/unsaved-changes-dialog/unsaved-changes-dialog.component.html
@@ -1,0 +1,68 @@
+<p-dialog
+  [visible]="visible()"
+  (visibleChange)="cancelDialog.emit()"
+  [modal]="true"
+  [closable]="false"
+  [closeOnEscape]="false"
+  [showHeader]="false"
+  styleClass="max-w-[calc(100vw-2rem)] md:min-w-184 [&_.p-dialog-content]:rounded-lg [&_.p-dialog-content]:p-6 [&_.p-dialog-content]:shadow-xl"
+  maskStyleClass="bg-black/40"
+  aria-label="Unsaved changes warning"
+  i18n-aria-label="@@unsaved-changes-warning-label"
+>
+  <div class="flex flex-col gap-6">
+    <div class="flex items-start justify-between gap-3">
+      <div class="flex items-center gap-3">
+        <span
+          class="pi pi-exclamation-triangle text-xl text-red-700"
+          aria-hidden="true"
+        ></span>
+        <h2
+          class="text-xl leading-none font-semibold text-red-700"
+          i18n="@@unsaved-changes-title"
+        >
+          Unsaved changes
+        </h2>
+      </div>
+
+      <button
+        type="button"
+        class="hover:bg-grey-100 flex size-8 items-center justify-center rounded-full text-black transition"
+        (click)="cancelDialog.emit()"
+        aria-label="Stay on page"
+        i18n-aria-label="@@unsaved-changes-stay-page"
+      >
+        <span
+          class="pi pi-times text-lg"
+          aria-hidden="true"
+        ></span>
+      </button>
+    </div>
+
+    <p
+      class="text-xl/10 text-black"
+      i18n="@@unsaved-changes-message"
+    >
+      This page contains unsaved changes. Do you still wish to leave this page?
+    </p>
+
+    <div class="flex flex-wrap justify-end gap-3">
+      <p-button
+        label="Leave page"
+        i18n-label="@@unsaved-changes-leave-page"
+        [rounded]="true"
+        severity="secondary"
+        styleClass="border-grey-300 min-w-36 border bg-white px-5 py-2 text-sm font-semibold text-black shadow-none"
+        (click)="confirmDialog.emit()"
+      />
+      <p-button
+        label="Stay on page"
+        i18n-label="@@unsaved-changes-stay-page"
+        [rounded]="true"
+        severity="primary"
+        styleClass="min-w-36 border border-violet-700 bg-violet-700 px-5 py-2 text-sm font-semibold text-white shadow-none"
+        (click)="cancelDialog.emit()"
+      />
+    </div>
+  </div>
+</p-dialog>

--- a/interfaces/portal/src/app/components/unsaved-changes-dialog/unsaved-changes-dialog.component.ts
+++ b/interfaces/portal/src/app/components/unsaved-changes-dialog/unsaved-changes-dialog.component.ts
@@ -1,0 +1,22 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+} from '@angular/core';
+
+import { ButtonModule } from 'primeng/button';
+import { DialogModule } from 'primeng/dialog';
+
+@Component({
+  selector: 'app-unsaved-changes-dialog',
+  standalone: true,
+  imports: [DialogModule, ButtonModule],
+  templateUrl: './unsaved-changes-dialog.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UnsavedChangesDialogComponent {
+  readonly visible = input.required<boolean>();
+  readonly confirmDialog = output();
+  readonly cancelDialog = output();
+}

--- a/interfaces/portal/src/app/guards/pending-changes.guard.spec.ts
+++ b/interfaces/portal/src/app/guards/pending-changes.guard.spec.ts
@@ -1,0 +1,102 @@
+import { Signal, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ComponentCanDeactivate,
+  pendingChangesGuard,
+} from '~/guards/pending-changes.guard';
+import { UnsavedChangesService } from '~/services/unsaved-changes.service';
+
+describe('pendingChangesGuard', () => {
+  const routeSnapshot = {} as ActivatedRouteSnapshot;
+  const stateSnapshot = {} as RouterStateSnapshot;
+
+  let dialogServiceMock: Pick<UnsavedChangesService, 'confirm'>;
+
+  const runGuard = async ({
+    canDeactivateResult,
+  }: {
+    canDeactivateResult: boolean | Signal<boolean>;
+  }): Promise<boolean> => {
+    const component: ComponentCanDeactivate = {
+      canDeactivate: () => canDeactivateResult,
+    };
+
+    const guardResult = await TestBed.runInInjectionContext(() =>
+      pendingChangesGuard(
+        component,
+        routeSnapshot,
+        stateSnapshot,
+        stateSnapshot,
+      ),
+    );
+
+    if (typeof guardResult !== 'boolean') {
+      throw new Error('Expected pendingChangesGuard to return a boolean value');
+    }
+
+    return guardResult;
+  };
+
+  beforeEach(() => {
+    dialogServiceMock = {
+      confirm: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: UnsavedChangesService,
+          useValue: dialogServiceMock,
+        },
+      ],
+    });
+  });
+
+  it('returns true and does not call confirm when canDeactivate returns true', async () => {
+    const confirmSpy = vi
+      .mocked(dialogServiceMock.confirm)
+      .mockResolvedValue(false);
+
+    const result = await runGuard({ canDeactivateResult: true });
+
+    expect(result).toBe(true);
+    expect(confirmSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls confirm when canDeactivate returns false', async () => {
+    const confirmSpy = vi
+      .mocked(dialogServiceMock.confirm)
+      .mockResolvedValue(true);
+
+    const result = await runGuard({ canDeactivateResult: false });
+
+    expect(result).toBe(true);
+    expect(confirmSpy).toHaveBeenCalledOnce();
+  });
+
+  it('returns true and does not call confirm when canDeactivate returns signal(true)', async () => {
+    const confirmSpy = vi
+      .mocked(dialogServiceMock.confirm)
+      .mockResolvedValue(false);
+
+    const result = await runGuard({ canDeactivateResult: signal(true) });
+
+    expect(result).toBe(true);
+    expect(confirmSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls confirm when canDeactivate returns signal(false)', async () => {
+    const confirmSpy = vi
+      .mocked(dialogServiceMock.confirm)
+      .mockResolvedValue(false);
+
+    const result = await runGuard({ canDeactivateResult: signal(false) });
+
+    expect(result).toBe(false);
+    expect(confirmSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/interfaces/portal/src/app/guards/pending-changes.guard.ts
+++ b/interfaces/portal/src/app/guards/pending-changes.guard.ts
@@ -1,18 +1,24 @@
+import { inject, isSignal, Signal } from '@angular/core';
 import { CanDeactivateFn } from '@angular/router';
 
+import { UnsavedChangesService } from '~/services/unsaved-changes.service';
+
 export interface ComponentCanDeactivate {
-  canDeactivate: () => boolean;
+  canDeactivate: () => boolean | Signal<boolean>;
 }
 
 export const pendingChangesGuard: CanDeactivateFn<ComponentCanDeactivate> = (
   component: ComponentCanDeactivate,
-) =>
-  // if there are no pending changes, just allow deactivation; else confirm first
-  component.canDeactivate()
-    ? true
-    : // NOTE: this warning message will only be shown when navigating elsewhere within your angular app;
-      // when navigating away from your angular app, the browser will show a generic warning message
-      // see http://stackoverflow.com/a/42207299/7307355
-      confirm(
-        $localize`Changes that you made may not be saved. Are you sure you wish to proceed?`,
-      );
+) => {
+  const canDeactivateResult = component.canDeactivate();
+  const canDeactivate = isSignal(canDeactivateResult)
+    ? canDeactivateResult()
+    : canDeactivateResult;
+
+  if (canDeactivate) {
+    return true;
+  }
+
+  const dialogService = inject(UnsavedChangesService);
+  return dialogService.confirm();
+};

--- a/interfaces/portal/src/app/services/unsaved-changes.service.spec.ts
+++ b/interfaces/portal/src/app/services/unsaved-changes.service.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { UnsavedChangesService } from '~/services/unsaved-changes.service';
+
+describe('UnsavedChangesService', () => {
+  let service: UnsavedChangesService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UnsavedChangesService);
+  });
+
+  it('returns the same pending confirmation promise for re-entrant confirm calls', () => {
+    const firstConfirmation = service.confirm();
+    const secondConfirmation = service.confirm();
+
+    expect(secondConfirmation).toBe(firstConfirmation);
+  });
+
+  it('resolves pending confirmation and creates a new promise for the next confirm call', async () => {
+    const firstConfirmation = service.confirm();
+    service.resolve(true);
+
+    await expect(firstConfirmation).resolves.toBe(true);
+
+    const secondConfirmation = service.confirm();
+
+    expect(secondConfirmation).not.toBe(firstConfirmation);
+
+    service.resolve(false);
+    await expect(secondConfirmation).resolves.toBe(false);
+  });
+
+  it('does not throw when resolve is called without a pending confirmation', () => {
+    expect(() => {
+      service.resolve(false);
+    }).not.toThrow();
+  });
+});

--- a/interfaces/portal/src/app/services/unsaved-changes.service.ts
+++ b/interfaces/portal/src/app/services/unsaved-changes.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class UnsavedChangesService {
+  private readonly _visible = signal(false);
+  private _resolver: ((confirmed: boolean) => void) | null = null;
+  private _pendingConfirmation: null | Promise<boolean> = null;
+
+  get visible() {
+    return this._visible.asReadonly();
+  }
+
+  confirm(): Promise<boolean> {
+    if (this._pendingConfirmation) {
+      return this._pendingConfirmation;
+    }
+
+    this._visible.set(true);
+    this._pendingConfirmation = new Promise((resolve) => {
+      this._resolver = resolve;
+    });
+
+    return this._pendingConfirmation;
+  }
+
+  resolve(result: boolean): void {
+    this._visible.set(false);
+
+    const resolver = this._resolver;
+    this._resolver = null;
+    this._pendingConfirmation = null;
+
+    if (resolver) {
+      resolver(result);
+    }
+  }
+}

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -1039,9 +1039,6 @@
       <trans-unit id="generic-save" datatype="html">
         <source>Save</source>
       </trans-unit>
-      <trans-unit id="8602877633844729884" datatype="html">
-        <source>Changes that you made may not be saved. Are you sure you wish to proceed?</source>
-      </trans-unit>
       <trans-unit id="attribute-edit-info-paymentCountRemaining" datatype="html">
         <source>This field is calculated by subtracting the sent payments from the planned payments. If the limit is removed from the planned payments this field will be empty.</source>
       </trans-unit>
@@ -2408,6 +2405,21 @@
       </trans-unit>
       <trans-unit id="page-title-program-settings-payment-approval" datatype="html">
         <source>Payment approval</source>
+      </trans-unit>
+      <trans-unit id="unsaved-changes-leave-page" datatype="html">
+        <source>Leave page</source>
+      </trans-unit>
+      <trans-unit id="unsaved-changes-message" datatype="html">
+        <source>This page contains unsaved changes. Do you still wish to leave this page?</source>
+      </trans-unit>
+      <trans-unit id="unsaved-changes-stay-page" datatype="html">
+        <source>Stay on page</source>
+      </trans-unit>
+      <trans-unit id="unsaved-changes-title" datatype="html">
+        <source>Unsaved changes</source>
+      </trans-unit>
+      <trans-unit id="unsaved-changes-warning-label" datatype="html">
+        <source>Unsaved changes warning</source>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
[AB#42238](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42238) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8254.westeurope.3.azurestaticapps.net
