### PR TITLE
Only count started transactions towards payment count

### DIFF
--- a/services/121-service/src/fsp-integrations/transaction-jobs/services/transaction-jobs-helper.service.ts
+++ b/services/121-service/src/fsp-integrations/transaction-jobs/services/transaction-jobs-helper.service.ts
@@ -99,13 +99,6 @@ export class TransactionJobsHelperService {
     context: TransactionEventCreationContext;
     isRetry: boolean;
   }) {
-    if (!isRetry) {
-      await this.updatePaymentCountAndSetToCompleted({
-        transactionId: context.transactionId,
-        userId: context.userId!,
-      });
-    }
-
     await this.transactionsService.saveProgress({
       context,
       description: isRetry
@@ -113,6 +106,12 @@ export class TransactionJobsHelperService {
         : TransactionEventDescription.initiated,
       newTransactionStatus: TransactionStatusEnum.waiting,
     });
+    if (!isRetry) {
+      await this.updatePaymentCountAndSetToCompleted({
+        transactionId: context.transactionId,
+        userId: context.userId!,
+      });
+    }
   }
 
   /**
@@ -130,7 +129,7 @@ export class TransactionJobsHelperService {
         transactionId,
       );
     const newPaymentCount =
-      await this.transactionRepository.countTransactionsByReferenceId(
+      await this.transactionRepository.countStartedTransactionsByReferenceId(
         referenceId,
       );
     await this.registrationScopedRepository.updatePaymentCount({

--- a/services/121-service/src/payments/transactions/transaction.repository.ts
+++ b/services/121-service/src/payments/transactions/transaction.repository.ts
@@ -63,10 +63,12 @@ export class TransactionRepository extends Repository<TransactionEntity> {
   public async countStartedTransactionsByReferenceId(
     referenceId: string,
   ): Promise<number> {
-    // Started transactions are transactions that are not in 'pendingApproval' or 'approved' status
-    // Only these transactions should be counted for payment count and completion of registration, as transactions in 'pendingApproval' or 'approved' status might still be deleted or rolled back
-    // If a registrations would be in 2 payments at the same time (and 1 transaction away from completion) and the first payment is started the registration would move to completed
-    // and than het would be exluded from the second payment, which is desired behavior (we expect this to rarely happen)
+    // Count only transactions that have progressed beyond 'pendingApproval' and
+    // 'approved'. Those earlier states may still be deleted or rolled back, so
+    // they should not contribute to payment counts or trigger registration
+    // completion. This also ensures that if a registration is included in two
+    // payments at once, starting the first payment can complete the registration
+    // and exclude it from the second payment, which is the intended behavior.
     return await this.createQueryBuilder('transaction')
       .leftJoin('transaction.registration', 'registration')
       .where('registration."referenceId" = :referenceId', { referenceId })

--- a/services/121-service/src/payments/transactions/transaction.repository.ts
+++ b/services/121-service/src/payments/transactions/transaction.repository.ts
@@ -60,12 +60,22 @@ export class TransactionRepository extends Repository<TransactionEntity> {
     return transaction.registration.referenceId;
   }
 
-  public async countTransactionsByReferenceId(
+  public async countStartedTransactionsByReferenceId(
     referenceId: string,
   ): Promise<number> {
+    // Started transactions are transactions that are not in 'pendingApproval' or 'approved' status
+    // Only these transactions should be counted for payment count and completion of registration, as transactions in 'pendingApproval' or 'approved' status might still be deleted or rolled back
+    // If a registrations would be in 2 payments at the same time (and 1 transaction away from completion) and the first payment is started the registration would move to completed
+    // and than het would be exluded from the second payment, which is desired behavior (we expect this to rarely happen)
     return await this.createQueryBuilder('transaction')
       .leftJoin('transaction.registration', 'registration')
       .where('registration."referenceId" = :referenceId', { referenceId })
+      .andWhere('transaction.status NOT IN (:...statuses)', {
+        statuses: [
+          TransactionStatusEnum.pendingApproval,
+          TransactionStatusEnum.approved,
+        ],
+      })
       .getCount();
   }
 

--- a/services/121-service/test/payment/payment-set-to-completed.test.ts
+++ b/services/121-service/test/payment/payment-set-to-completed.test.ts
@@ -145,14 +145,15 @@ describe('Set registration to completed after payment', () => {
 
     await waitForPaymentAndTransactionsToComplete({
       programId,
+      paymentId: firstPaymentId,
       paymentReferenceIds: referenceIds,
       accessToken,
       maxWaitTimeMs: 20_000,
     });
 
     // Assert - paymentCount should be 1 because only the started/completed
-    // transaction counts; the second payment's transaction is still in
-    // is excluded from the count.
+    // transaction counts; the second payment's transaction remains in
+    // `approved` status and is therefore excluded from the count.
     const registrationAfterFirstPayment =
       await waitForRegistrationToHaveUpdatedPaymentCount({
         programId,

--- a/services/121-service/test/payment/payment-set-to-completed.test.ts
+++ b/services/121-service/test/payment/payment-set-to-completed.test.ts
@@ -4,11 +4,19 @@ import { TransactionStatusEnum } from '@121-service/src/payments/transactions/en
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { messageTemplateGeneric } from '@121-service/src/seed-data/message-template/message-template-generic.const';
-import { waitForMessagesToComplete } from '@121-service/test/helpers/program.helper';
+import {
+  approvePayment,
+  createPayment,
+  startPayment,
+  waitForMessagesToComplete,
+  waitForPaymentAndTransactionsToComplete,
+} from '@121-service/test/helpers/program.helper';
 import {
   getMessageHistory,
   getRegistrationEvents,
+  seedIncludedRegistrations,
   seedPaidRegistrations,
+  waitForRegistrationToHaveUpdatedPaymentCount,
 } from '@121-service/test/helpers/registration.helper';
 import {
   getAccessToken,
@@ -90,6 +98,72 @@ describe('Set registration to completed after payment', () => {
     );
     expect(new Date(initialVoucherMessage!.created).getTime()).toBeLessThan(
       new Date(completedMessage.created).getTime(),
+    );
+  });
+
+  it('should only count started transactions toward paymentCount and marking as completed', async () => {
+    // Arrange
+    const registration = { ...registrationPV5, maxPayments: 1 };
+    await seedIncludedRegistrations([registration], programId, accessToken);
+    const referenceIds = [registration.referenceId];
+
+    // Create two payments for the same registration (both get transactions in approved status)
+    const createFirstPaymentResponse = await createPayment({
+      programId,
+      transferValue,
+      referenceIds,
+      accessToken,
+      name: 'First Payment',
+    });
+    const firstPaymentId = createFirstPaymentResponse.body.id;
+    await approvePayment({
+      programId,
+      paymentId: firstPaymentId,
+      accessToken,
+    });
+
+    const createSecondPaymentResponse = await createPayment({
+      programId,
+      transferValue,
+      referenceIds,
+      accessToken,
+      name: 'Second Payment',
+    });
+    const secondPaymentId = createSecondPaymentResponse.body.id;
+    await approvePayment({
+      programId,
+      paymentId: secondPaymentId,
+      accessToken,
+    });
+
+    // Act - start only the first payment
+    await startPayment({
+      programId,
+      paymentId: firstPaymentId,
+      accessToken,
+    });
+
+    await waitForPaymentAndTransactionsToComplete({
+      programId,
+      paymentReferenceIds: referenceIds,
+      accessToken,
+      maxWaitTimeMs: 20_000,
+    });
+
+    // Assert - paymentCount should be 1 because only the started/completed
+    // transaction counts; the second payment's transaction is still in
+    // is excluded from the count.
+    const registrationAfterFirstPayment =
+      await waitForRegistrationToHaveUpdatedPaymentCount({
+        programId,
+        referenceId: registration.referenceId,
+        expectedPaymentCount: 1,
+        accessToken,
+      });
+
+    expect(registrationAfterFirstPayment!.paymentCount).toBe(1);
+    expect(registrationAfterFirstPayment!.status).toBe(
+      RegistrationStatusEnum.completed,
     );
   });
 });


### PR DESCRIPTION
[AB#42389](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42389) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Bug fix: incorrect paymentCount when a registration is part of multiple concurrent payments

When a registration was included in more than one payment, its paymentCount was being incremented based on all of its transactions including those still in pendingApproval or approved status. This meant a registration could be (incorrectly) set to completed before any of its payments had actually started

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
