### PR TITLE
E2E for maximum kobo registrations exceeded

### DIFF
--- a/e2e/portal/pages/RegistrationDataPage.ts
+++ b/e2e/portal/pages/RegistrationDataPage.ts
@@ -1,6 +1,8 @@
 import { Locator, Page } from 'playwright';
+import { expect } from 'playwright/test';
 
 import DialogComponent from '../components/DialogComponent';
+import TableComponent from '../components/TableComponent';
 import BasePage from './BasePage';
 
 class RegistrationDataPage extends BasePage {
@@ -125,6 +127,25 @@ class RegistrationDataPage extends BasePage {
 
     await ellipsisMenuButton.click();
     await this.page.getByText('Import existing reg.').click();
+  }
+
+  async validateErrorTable() {
+    const fileDialogErrorTable = new TableComponent(
+      this.page,
+      'kobo-import-existing-registration-dialog-errors-table',
+    );
+
+    const columnHeaders = await fileDialogErrorTable.getTextArrayFromHeader();
+    const rows = await fileDialogErrorTable.tableRows
+      .locator('td')
+      .allInnerTexts();
+
+    expect(columnHeaders).toEqual(['Reference ID', 'Column', 'Error']);
+    expect(rows).toEqual([
+      'failure-import-with-failure',
+      'programFspConfigurationName',
+      'FspConfigurationName undefined not found in program. Allowed values: Safaricom',
+    ]);
   }
 }
 

--- a/e2e/portal/tests/ProgramSettings/RegistrationData/ImportExistingKoboRegistrations.spec.ts
+++ b/e2e/portal/tests/ProgramSettings/RegistrationData/ImportExistingKoboRegistrations.spec.ts
@@ -87,6 +87,40 @@ test('Import existing Kobo registrations immediately after adding Kobo integrati
   });
 });
 
+test('Import existing Kobo registrations that include errors in the registrations', async ({
+  registrationDataPage,
+}) => {
+  await test.step('Re-add Kobo integration with over-limit asset', async () => {
+    await registrationDataPage.addKoboIntegration({
+      url: `${env.MOCK_SERVICE_URL}/api/kobo/#/forms/import-with-failure/summary`,
+      apiKey: 'mock-token',
+    });
+    await registrationDataPage.koboSuccessfullyLinkedDialog({
+      closeDialog: true,
+    });
+  });
+
+  await test.step('Import existing Kobo registrations', async () => {
+    await registrationDataPage.openImportExistingKoboRegistrationsDialog();
+    await registrationDataPage.initiateImportButton.click();
+  });
+
+  await test.step('validate error message after importing existing Kobo registrations with errors', async () => {
+    await expect(
+      registrationDataPage.importDialog.getByText('Submissions failed: 1'),
+    ).toBeVisible();
+    await expect(
+      registrationDataPage.importDialog.getByText(
+        'Below are the errors corresponding to the failed submissions. Correct the submissions in the kobo form and try again.',
+      ),
+    ).toBeVisible();
+  });
+
+  await test.step('Validate error table with details of the errors in the registrations', async () => {
+    await registrationDataPage.validateErrorTable();
+  });
+});
+
 test('Import error when importing too many existing Kobo registrations', async ({
   registrationDataPage,
 }) => {
@@ -104,6 +138,7 @@ test('Import error when importing too many existing Kobo registrations', async (
     await registrationDataPage.openImportExistingKoboRegistrationsDialog();
     await registrationDataPage.initiateImportButton.click();
   });
+
   await test.step('Validate error message when importing too many existing Kobo registrations', async () => {
     await registrationDataPage.validateKoboIntegration({
       message:

--- a/e2e/portal/tests/ProgramSettings/RegistrationData/ImportExistingKoboRegistrations.spec.ts
+++ b/e2e/portal/tests/ProgramSettings/RegistrationData/ImportExistingKoboRegistrations.spec.ts
@@ -15,17 +15,18 @@ const koboIntegrationDetails = {
   apiKey: 'mock-token',
 };
 
-test('Import existing Kobo registrations after adding Kobo integration', async ({
-  resetDBAndSeedRegistrations,
-  registrationDataPage,
-}) => {
+test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   await resetDBAndSeedRegistrations({
     seedScript: SeedScript.safaricomProgram,
     registrations: registrationsSafaricom,
     programId: programIdSafaricom,
     navigateToPage: `/program/${programIdSafaricom}/settings/registration-data`,
   });
+});
 
+test('Import existing Kobo registrations after adding Kobo integration', async ({
+  registrationDataPage,
+}) => {
   await test.step('Add Kobo integration', async () => {
     await registrationDataPage.addKoboIntegration(koboIntegrationDetails);
     await registrationDataPage.koboSuccessfullyLinkedDialog({
@@ -63,16 +64,8 @@ test('Import existing Kobo registrations after adding Kobo integration', async (
 });
 
 test('Import existing Kobo registrations immediately after adding Kobo integration', async ({
-  resetDBAndSeedRegistrations,
   registrationDataPage,
 }) => {
-  await resetDBAndSeedRegistrations({
-    seedScript: SeedScript.safaricomProgram,
-    registrations: registrationsSafaricom,
-    programId: programIdSafaricom,
-    navigateToPage: `/program/${programIdSafaricom}/settings/registration-data`,
-  });
-
   await test.step('Add Kobo integration', async () => {
     await registrationDataPage.addKoboIntegration(koboIntegrationDetails);
     await registrationDataPage.koboSuccessfullyLinkedDialog({
@@ -95,16 +88,8 @@ test('Import existing Kobo registrations immediately after adding Kobo integrati
 });
 
 test('Import error when importing too many existing Kobo registrations', async ({
-  resetDBAndSeedRegistrations,
   registrationDataPage,
 }) => {
-  await resetDBAndSeedRegistrations({
-    seedScript: SeedScript.safaricomProgram,
-    registrations: registrationsSafaricom,
-    programId: programIdSafaricom,
-    navigateToPage: `/program/${programIdSafaricom}/settings/registration-data`,
-  });
-
   await test.step('Re-add Kobo integration with over-limit asset', async () => {
     await registrationDataPage.addKoboIntegration({
       url: `${env.MOCK_SERVICE_URL}/api/kobo/#/forms/asset-id-over-limit/summary`,

--- a/e2e/portal/tests/ProgramSettings/RegistrationData/ImportExistingKoboRegistrations.spec.ts
+++ b/e2e/portal/tests/ProgramSettings/RegistrationData/ImportExistingKoboRegistrations.spec.ts
@@ -93,3 +93,36 @@ test('Import existing Kobo registrations immediately after adding Kobo integrati
     ).toBeVisible();
   });
 });
+
+test('Import error when importing too many existing Kobo registrations', async ({
+  resetDBAndSeedRegistrations,
+  registrationDataPage,
+}) => {
+  await resetDBAndSeedRegistrations({
+    seedScript: SeedScript.safaricomProgram,
+    registrations: registrationsSafaricom,
+    programId: programIdSafaricom,
+    navigateToPage: `/program/${programIdSafaricom}/settings/registration-data`,
+  });
+
+  await test.step('Re-add Kobo integration with over-limit asset', async () => {
+    await registrationDataPage.addKoboIntegration({
+      url: `${env.MOCK_SERVICE_URL}/api/kobo/#/forms/asset-id-over-limit/summary`,
+      apiKey: 'mock-token',
+    });
+    await registrationDataPage.koboSuccessfullyLinkedDialog({
+      closeDialog: true,
+    });
+  });
+
+  await test.step('Import existing Kobo registrations', async () => {
+    await registrationDataPage.openImportExistingKoboRegistrationsDialog();
+    await registrationDataPage.initiateImportButton.click();
+  });
+  await test.step('Validate error message when importing too many existing Kobo registrations', async () => {
+    await registrationDataPage.validateKoboIntegration({
+      message:
+        'Something went wrong: "The Kobo form has 1001 total submissions, which exceeds the maximum of 1000 that can be fetched at once. Not all submissions could be retrieved, so some new ones may be missing. Please use the CSV import instead and split the data into smaller batches.',
+    });
+  });
+});

--- a/services/121-service/test/fixtures/kobo-mock-asset-uids.ts
+++ b/services/121-service/test/fixtures/kobo-mock-asset-uids.ts
@@ -11,4 +11,5 @@ export enum KoboMockAssetUids {
   notFound = 'asset-id-not-found',
   happyFlowWithChanges = 'asset-id-happy-flow-with-changes',
   withExistingWebhook = 'asset-id-with-existing-webhook',
+  overLimit = 'asset-id-over-limit',
 }

--- a/services/mock-service/src/kobo/kobo-mock-asset-uids.ts
+++ b/services/mock-service/src/kobo/kobo-mock-asset-uids.ts
@@ -10,4 +10,5 @@ export enum KoboMockAssetUids {
   notFound = 'asset-id-not-found',
   happyFlowWithChanges = 'asset-id-happy-flow-with-changes',
   withExistingWebhook = 'asset-id-with-existing-webhook',
+  overLimit = 'asset-id-over-limit',
 }

--- a/services/mock-service/src/kobo/kobo.mock.service.ts
+++ b/services/mock-service/src/kobo/kobo.mock.service.ts
@@ -513,6 +513,10 @@ export class KoboMockService {
       return { count: 0, next: null, previous: null, results: [] };
     }
 
+    if (uid_asset.includes('over-limit')) {
+      return { count: 1001, next: null, previous: null, results };
+    }
+
     return { count: results.length, next: null, previous: null, results };
   }
 


### PR DESCRIPTION
[AB#42481](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42481)

Adds a E2E test for error message when existing kobo submissions exceed 1000

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] I have added tests for my changes
- [x] I have made sure that all automated checks pass before requesting a review

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
