### PR TITLE
feature: frontend for refreshing Kobo integrations

### DIFF
--- a/interfaces/portal/src/app/domains/kobo/kobo-api.service.ts
+++ b/interfaces/portal/src/app/domains/kobo/kobo-api.service.ts
@@ -57,6 +57,15 @@ export class KoboApiService extends DomainApiService {
     });
   }
 
+  refreshKoboForm(programId: Signal<number | string>) {
+    return this.httpWrapperService.perform121ServiceRequest<
+      Dto<KoboIntegrationResultDto>
+    >({
+      method: 'PATCH',
+      endpoint: this.pathToQueryKey([...BASE_ENDPOINT(programId)]).join('/'),
+    });
+  }
+
   importExistingSubmissions(programId: Signal<number | string>) {
     return this.httpWrapperService.perform121ServiceRequest<
       Dto<ImportExistingSubmissionsResultDto>

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.ts
@@ -8,7 +8,10 @@ import {
   viewChild,
 } from '@angular/core';
 
-import { injectQuery } from '@tanstack/angular-query-experimental';
+import {
+  injectMutation,
+  injectQuery,
+} from '@tanstack/angular-query-experimental';
 import { MenuItem } from 'primeng/api';
 
 import { CardWithLinkComponent } from '~/components/card-with-link/card-with-link.component';
@@ -20,6 +23,7 @@ import {
 import { KoboApiService } from '~/domains/kobo/kobo-api.service';
 import { KoboConfigurationDialogComponent } from '~/pages/program-settings-registration-data/components/kobo-configuration-dialog/kobo-configuration-dialog.component';
 import { KoboImportExistingRegistrationsDialogComponent } from '~/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component';
+import { ToastService } from '~/services/toast.service';
 
 @Component({
   selector: 'app-kobo-integration-card',
@@ -32,12 +36,14 @@ import { KoboImportExistingRegistrationsDialogComponent } from '~/pages/program-
   ],
   templateUrl: './kobo-integration-card.component.html',
   styles: ``,
+  providers: [ToastService],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class KoboIntegrationCardComponent {
   readonly programId = input.required<number | string>();
 
   private readonly koboApiService = inject(KoboApiService);
+  private readonly toastService = inject(ToastService);
 
   readonly koboConfigurationDialog =
     viewChild.required<KoboConfigurationDialogComponent>(
@@ -79,11 +85,40 @@ export class KoboIntegrationCardComponent {
     });
   });
 
+  readonly refreshKoboFormMutation = injectMutation(() => ({
+    mutationFn: () => this.koboApiService.refreshKoboForm(this.programId),
+    onSuccess: (response) => {
+      if (response.alreadyUpToDate) {
+        this.toastService.showToast({
+          severity: 'info',
+          summary: $localize`:@@generic-info:Info`,
+          detail: $localize`Integration is already up to date.`,
+        });
+        return;
+      }
+      this.toastService.showToast({
+        detail: $localize`Integration updated successfully.`,
+      });
+    },
+    onError: () => {
+      this.toastService.showToast({
+        severity: 'error',
+        detail: $localize`Integration update unsuccessful. Please try again.`,
+      });
+    },
+  }));
+
   readonly menuItems = computed<MenuItem[]>(() => [
     {
       label: $localize`Reconfigure`,
       command: () => {
         this.koboConfigurationDialog().show();
+      },
+    },
+    {
+      label: $localize`Refresh link`,
+      command: () => {
+        this.refreshKoboFormMutation.mutate();
       },
     },
     {

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.ts
@@ -1,5 +1,4 @@
 import { DatePipe } from '@angular/common';
-import { HttpStatusCode } from '@angular/common/http';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -25,7 +24,6 @@ import { KoboApiService } from '~/domains/kobo/kobo-api.service';
 import { KoboConfigurationDialogComponent } from '~/pages/program-settings-registration-data/components/kobo-configuration-dialog/kobo-configuration-dialog.component';
 import { KoboImportExistingRegistrationsDialogComponent } from '~/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component';
 import { ToastService } from '~/services/toast.service';
-import { isErrorWithStatusCode } from '~/utils/is-error-with-status-code.helper';
 
 @Component({
   selector: 'app-kobo-integration-card',
@@ -89,25 +87,20 @@ export class KoboIntegrationCardComponent {
 
   readonly refreshKoboFormMutation = injectMutation(() => ({
     mutationFn: () => this.koboApiService.refreshKoboForm(this.programId),
-    onSuccess: () => {
-      this.toastService.showToast({
-        detail: $localize`Integration updated successfully.`,
-      });
-    },
-    onError: (error) => {
-      if (
-        isErrorWithStatusCode({
-          error,
-          statusCode: HttpStatusCode.NotModified,
-        })
-      ) {
+    onSuccess: (result) => {
+      if (result.updated) {
         this.toastService.showToast({
-          severity: 'info',
-          summary: $localize`:@@generic-info:Info`,
-          detail: $localize`Integration is already up to date.`,
+          detail: $localize`Integration updated successfully.`,
         });
         return;
       }
+      this.toastService.showToast({
+        severity: 'info',
+        summary: $localize`:@@generic-info:Info`,
+        detail: $localize`Integration is already up to date.`,
+      });
+    },
+    onError: () => {
       this.toastService.showToast({
         severity: 'error',
         detail: $localize`Integration update unsuccessful. Please try again.`,

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.ts
@@ -1,4 +1,5 @@
 import { DatePipe } from '@angular/common';
+import { HttpStatusCode } from '@angular/common/http';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -24,6 +25,7 @@ import { KoboApiService } from '~/domains/kobo/kobo-api.service';
 import { KoboConfigurationDialogComponent } from '~/pages/program-settings-registration-data/components/kobo-configuration-dialog/kobo-configuration-dialog.component';
 import { KoboImportExistingRegistrationsDialogComponent } from '~/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component';
 import { ToastService } from '~/services/toast.service';
+import { isErrorWithStatusCode } from '~/utils/is-error-with-status-code.helper';
 
 @Component({
   selector: 'app-kobo-integration-card',
@@ -87,8 +89,18 @@ export class KoboIntegrationCardComponent {
 
   readonly refreshKoboFormMutation = injectMutation(() => ({
     mutationFn: () => this.koboApiService.refreshKoboForm(this.programId),
-    onSuccess: (response) => {
-      if (response.alreadyUpToDate) {
+    onSuccess: () => {
+      this.toastService.showToast({
+        detail: $localize`Integration updated successfully.`,
+      });
+    },
+    onError: (error) => {
+      if (
+        isErrorWithStatusCode({
+          error,
+          statusCode: HttpStatusCode.NotModified,
+        })
+      ) {
         this.toastService.showToast({
           severity: 'info',
           summary: $localize`:@@generic-info:Info`,
@@ -96,11 +108,6 @@ export class KoboIntegrationCardComponent {
         });
         return;
       }
-      this.toastService.showToast({
-        detail: $localize`Integration updated successfully.`,
-      });
-    },
-    onError: () => {
       this.toastService.showToast({
         severity: 'error',
         detail: $localize`Integration update unsuccessful. Please try again.`,

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -2433,6 +2433,21 @@
       <trans-unit id="debit-card-status-blocked" datatype="html">
         <source>Blocked</source>
       </trans-unit>
+      <trans-unit id="1817782792448180446" datatype="html">
+        <source>Integration is already up to date.</source>
+      </trans-unit>
+      <trans-unit id="508499092676439201" datatype="html">
+        <source>Integration update unsuccessful. Please try again.</source>
+      </trans-unit>
+      <trans-unit id="5656654201977017111" datatype="html">
+        <source>Refresh link</source>
+      </trans-unit>
+      <trans-unit id="7131024915833130123" datatype="html">
+        <source>Integration updated successfully.</source>
+      </trans-unit>
+      <trans-unit id="generic-info" datatype="html">
+        <source>Info</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/services/121-service/src/kobo/dtos/kobo-integration-result.dto.ts
+++ b/services/121-service/src/kobo/dtos/kobo-integration-result.dto.ts
@@ -13,4 +13,12 @@ export class KoboIntegrationResultDto {
     nullable: true,
   })
   public readonly name: string | null;
+
+  @ApiProperty({
+    example: true,
+    description:
+      'Whether the refresh applied changes to the program. False when the Kobo form was already up to date.',
+    required: false,
+  })
+  public readonly updated?: boolean;
 }

--- a/services/121-service/src/kobo/dtos/kobo-integration-result.dto.ts
+++ b/services/121-service/src/kobo/dtos/kobo-integration-result.dto.ts
@@ -13,12 +13,4 @@ export class KoboIntegrationResultDto {
     nullable: true,
   })
   public readonly name: string | null;
-
-  @ApiProperty({
-    example: false,
-    description:
-      'Whether the program was already up to date with the latest Kobo form definition, meaning no changes were applied. Only set by the refresh endpoint.',
-    required: false,
-  })
-  public readonly alreadyUpToDate?: boolean;
 }

--- a/services/121-service/src/kobo/dtos/kobo-integration-result.dto.ts
+++ b/services/121-service/src/kobo/dtos/kobo-integration-result.dto.ts
@@ -13,4 +13,12 @@ export class KoboIntegrationResultDto {
     nullable: true,
   })
   public readonly name: string | null;
+
+  @ApiProperty({
+    example: false,
+    description:
+      'Whether the program was already up to date with the latest Kobo form definition, meaning no changes were applied. Only set by the refresh endpoint.',
+    required: false,
+  })
+  public readonly alreadyUpToDate?: boolean;
 }

--- a/services/121-service/src/kobo/kobo.controller.ts
+++ b/services/121-service/src/kobo/kobo.controller.ts
@@ -188,6 +188,11 @@ export class KoboController {
     type: KoboIntegrationResultDto,
   })
   @ApiResponse({
+    status: HttpStatus.NOT_MODIFIED,
+    description:
+      'The Kobo form is already up to date - no changes were applied.',
+  })
+  @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description:
       'Validation failed - the latest Kobo form definition does not meet program requirements.',
@@ -203,11 +208,8 @@ export class KoboController {
   ): Promise<KoboIntegrationResultDto> {
     const result = await this.koboService.refreshKoboForm({ programId });
     return {
-      message: result.alreadyUpToDate
-        ? 'Kobo form was already up to date'
-        : 'Kobo form refreshed successfully',
+      message: 'Kobo form refreshed successfully',
       name: result.name,
-      alreadyUpToDate: result.alreadyUpToDate,
     };
   }
 

--- a/services/121-service/src/kobo/kobo.controller.ts
+++ b/services/121-service/src/kobo/kobo.controller.ts
@@ -184,13 +184,9 @@ export class KoboController {
   })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Kobo form refreshed successfully',
-    type: KoboIntegrationResultDto,
-  })
-  @ApiResponse({
-    status: HttpStatus.NOT_MODIFIED,
     description:
-      'The Kobo form is already up to date - no changes were applied.',
+      'Kobo form refresh completed. Inspect the `updated` field to determine whether changes were applied or the form was already up to date.',
+    type: KoboIntegrationResultDto,
   })
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
@@ -208,8 +204,11 @@ export class KoboController {
   ): Promise<KoboIntegrationResultDto> {
     const result = await this.koboService.refreshKoboForm({ programId });
     return {
-      message: 'Kobo form refreshed successfully',
+      message: result.updated
+        ? 'Kobo form refreshed successfully'
+        : 'Kobo form is already up to date',
       name: result.name,
+      updated: result.updated,
     };
   }
 

--- a/services/121-service/src/kobo/kobo.controller.ts
+++ b/services/121-service/src/kobo/kobo.controller.ts
@@ -203,8 +203,11 @@ export class KoboController {
   ): Promise<KoboIntegrationResultDto> {
     const result = await this.koboService.refreshKoboForm({ programId });
     return {
-      message: 'Kobo form refreshed successfully',
+      message: result.alreadyUpToDate
+        ? 'Kobo form was already up to date'
+        : 'Kobo form refreshed successfully',
       name: result.name,
+      alreadyUpToDate: result.alreadyUpToDate,
     };
   }
 

--- a/services/121-service/src/kobo/services/kobo.service.ts
+++ b/services/121-service/src/kobo/services/kobo.service.ts
@@ -150,7 +150,7 @@ export class KoboService {
     programId,
   }: {
     programId: number;
-  }): Promise<{ name: string | null }> {
+  }): Promise<{ name: string | null; updated: boolean }> {
     const koboIntegration = await this.koboRepository.findOne({
       where: { programId: Equal(programId) },
     });
@@ -168,10 +168,7 @@ export class KoboService {
     });
 
     if (formDefinition.versionId === koboIntegration.versionId) {
-      throw new HttpException(
-        'Kobo form is already up to date',
-        HttpStatus.NOT_MODIFIED,
-      );
+      return { name: formDefinition.name, updated: false };
     }
 
     await this.applyFormDefinitionToProgram({
@@ -180,7 +177,7 @@ export class KoboService {
       currentVersionId: koboIntegration.versionId,
     });
 
-    return { name: formDefinition.name };
+    return { name: formDefinition.name, updated: true };
   }
 
   public async applyFormDefinitionToProgram({

--- a/services/121-service/src/kobo/services/kobo.service.ts
+++ b/services/121-service/src/kobo/services/kobo.service.ts
@@ -150,7 +150,7 @@ export class KoboService {
     programId,
   }: {
     programId: number;
-  }): Promise<{ name: string | null }> {
+  }): Promise<{ name: string | null; alreadyUpToDate: boolean }> {
     const koboIntegration = await this.koboRepository.findOne({
       where: { programId: Equal(programId) },
     });
@@ -167,13 +167,16 @@ export class KoboService {
       url: koboIntegration.url,
     });
 
+    const alreadyUpToDate =
+      formDefinition.versionId === koboIntegration.versionId;
+
     await this.applyFormDefinitionToProgram({
       formDefinition,
       programId,
       currentVersionId: koboIntegration.versionId,
     });
 
-    return { name: formDefinition.name };
+    return { name: formDefinition.name, alreadyUpToDate };
   }
 
   public async applyFormDefinitionToProgram({

--- a/services/121-service/src/kobo/services/kobo.service.ts
+++ b/services/121-service/src/kobo/services/kobo.service.ts
@@ -150,7 +150,7 @@ export class KoboService {
     programId,
   }: {
     programId: number;
-  }): Promise<{ name: string | null; alreadyUpToDate: boolean }> {
+  }): Promise<{ name: string | null }> {
     const koboIntegration = await this.koboRepository.findOne({
       where: { programId: Equal(programId) },
     });
@@ -167,8 +167,12 @@ export class KoboService {
       url: koboIntegration.url,
     });
 
-    const alreadyUpToDate =
-      formDefinition.versionId === koboIntegration.versionId;
+    if (formDefinition.versionId === koboIntegration.versionId) {
+      throw new HttpException(
+        'Kobo form is already up to date',
+        HttpStatus.NOT_MODIFIED,
+      );
+    }
 
     await this.applyFormDefinitionToProgram({
       formDefinition,
@@ -176,7 +180,7 @@ export class KoboService {
       currentVersionId: koboIntegration.versionId,
     });
 
-    return { name: formDefinition.name, alreadyUpToDate };
+    return { name: formDefinition.name };
   }
 
   public async applyFormDefinitionToProgram({

--- a/services/121-service/test/fixtures/kobo-mock-asset-uids.ts
+++ b/services/121-service/test/fixtures/kobo-mock-asset-uids.ts
@@ -10,5 +10,6 @@ export enum KoboMockAssetUids {
   bodyThatTriggersErrors = 'asset-id-body-that-triggers-errors',
   notFound = 'asset-id-not-found',
   happyFlowWithChanges = 'asset-id-happy-flow-with-changes',
+  happyFlowAlwaysNewVersion = 'asset-id-happy-flow-always-new-version',
   withExistingWebhook = 'asset-id-with-existing-webhook',
 }

--- a/services/121-service/test/kobo/kobo-refresh-form.test.ts
+++ b/services/121-service/test/kobo/kobo-refresh-form.test.ts
@@ -13,7 +13,11 @@ import {
   refreshKoboForm,
   setupProgramWithKoboIntegration,
 } from '@121-service/test/helpers/kobo.helper';
-import { postProgram } from '@121-service/test/helpers/program.helper';
+import {
+  getProgram,
+  patchProgram,
+  postProgram,
+} from '@121-service/test/helpers/program.helper';
 import { postProgramFspConfiguration } from '@121-service/test/helpers/program-fsp-configuration.helper';
 import {
   getAccessToken,
@@ -99,6 +103,53 @@ describe('Refresh Kobo form', () => {
 
     // Assert
     expect(response.status).toBe(HttpStatus.NOT_MODIFIED);
+  });
+
+  it('should successfully refresh when the Kobo form has a new version', async () => {
+    // Arrange: this mock asset returns a freshly randomized version_id on
+    // every fetch, so the version stored at integration time will not match
+    // the one returned by the refresh fetch.
+    const program: CreateProgramDto = {
+      ...baseProgram,
+      titlePortal: { en: 'Program with stale Kobo integration' },
+      languages: [RegistrationPreferredLanguage.en],
+    } as CreateProgramDto;
+
+    const { programId } = await setupProgramWithKoboIntegration({
+      assetUid: KoboMockAssetUids.happyFlowAlwaysNewVersion,
+      program,
+      fspConfiguration,
+      accessToken,
+    });
+
+    // Remove Dutch to prove refresh restores languages from the form definition.
+    await patchProgram(
+      programId,
+      { languages: [RegistrationPreferredLanguage.en] },
+      accessToken,
+    );
+
+    // Act
+    const response = await refreshKoboForm({
+      programId,
+      accessToken,
+    });
+
+    // Assert
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.body).toMatchObject({
+      message: 'Kobo form refreshed successfully',
+      name: '25042025 Prototype Sprint',
+    });
+
+    // Verify Dutch (nl) was added back from the Kobo form definition
+    const programAfterRefresh = await getProgram(programId, accessToken);
+    expect(programAfterRefresh.body.languages).toEqual(
+      expect.arrayContaining([
+        RegistrationPreferredLanguage.en,
+        RegistrationPreferredLanguage.nl,
+      ]),
+    );
   });
 });
 

--- a/services/121-service/test/kobo/kobo-refresh-form.test.ts
+++ b/services/121-service/test/kobo/kobo-refresh-form.test.ts
@@ -13,11 +13,7 @@ import {
   refreshKoboForm,
   setupProgramWithKoboIntegration,
 } from '@121-service/test/helpers/kobo.helper';
-import {
-  getProgram,
-  patchProgram,
-  postProgram,
-} from '@121-service/test/helpers/program.helper';
+import { postProgram } from '@121-service/test/helpers/program.helper';
 import { postProgramFspConfiguration } from '@121-service/test/helpers/program-fsp-configuration.helper';
 import {
   getAccessToken,
@@ -80,7 +76,7 @@ describe('Refresh Kobo form', () => {
     expect(response.status).toBe(HttpStatus.NOT_FOUND);
   });
 
-  it('should successfully refresh an existing kobo integration', async () => {
+  it('should return 304 Not Modified when the Kobo form is already up to date', async () => {
     // Arrange
     const program: CreateProgramDto = {
       ...baseProgram,
@@ -95,13 +91,6 @@ describe('Refresh Kobo form', () => {
       accessToken,
     });
 
-    // Remove Dutch to prove refresh restores languages from the form definition.
-    await patchProgram(
-      programId,
-      { languages: [RegistrationPreferredLanguage.en] },
-      accessToken,
-    );
-
     // Act
     const response = await refreshKoboForm({
       programId,
@@ -109,21 +98,7 @@ describe('Refresh Kobo form', () => {
     });
 
     // Assert
-    expect(response.status).toBe(HttpStatus.OK);
-    expect(response.body).toMatchObject({
-      message: 'Kobo form was already up to date',
-      name: '25042025 Prototype Sprint',
-      alreadyUpToDate: true,
-    });
-
-    // Verify Dutch (nl) was added back from the Kobo form definition
-    const programAfterRefresh = await getProgram(programId, accessToken);
-    expect(programAfterRefresh.body.languages).toEqual(
-      expect.arrayContaining([
-        RegistrationPreferredLanguage.en,
-        RegistrationPreferredLanguage.nl,
-      ]),
-    );
+    expect(response.status).toBe(HttpStatus.NOT_MODIFIED);
   });
 });
 

--- a/services/121-service/test/kobo/kobo-refresh-form.test.ts
+++ b/services/121-service/test/kobo/kobo-refresh-form.test.ts
@@ -80,7 +80,7 @@ describe('Refresh Kobo form', () => {
     expect(response.status).toBe(HttpStatus.NOT_FOUND);
   });
 
-  it('should return 304 Not Modified when the Kobo form is already up to date', async () => {
+  it('should report no changes when the Kobo form is already up to date', async () => {
     // Arrange
     const program: CreateProgramDto = {
       ...baseProgram,
@@ -102,7 +102,11 @@ describe('Refresh Kobo form', () => {
     });
 
     // Assert
-    expect(response.status).toBe(HttpStatus.NOT_MODIFIED);
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.body).toMatchObject({
+      message: 'Kobo form is already up to date',
+      updated: false,
+    });
   });
 
   it('should successfully refresh when the Kobo form has a new version', async () => {
@@ -140,6 +144,7 @@ describe('Refresh Kobo form', () => {
     expect(response.body).toMatchObject({
       message: 'Kobo form refreshed successfully',
       name: '25042025 Prototype Sprint',
+      updated: true,
     });
 
     // Verify Dutch (nl) was added back from the Kobo form definition

--- a/services/121-service/test/kobo/kobo-refresh-form.test.ts
+++ b/services/121-service/test/kobo/kobo-refresh-form.test.ts
@@ -111,8 +111,9 @@ describe('Refresh Kobo form', () => {
     // Assert
     expect(response.status).toBe(HttpStatus.OK);
     expect(response.body).toMatchObject({
-      message: 'Kobo form refreshed successfully',
+      message: 'Kobo form was already up to date',
       name: '25042025 Prototype Sprint',
+      alreadyUpToDate: true,
     });
 
     // Verify Dutch (nl) was added back from the Kobo form definition

--- a/services/mock-service/src/kobo/kobo-mock-asset-uids.ts
+++ b/services/mock-service/src/kobo/kobo-mock-asset-uids.ts
@@ -9,5 +9,6 @@ export enum KoboMockAssetUids {
   bodyThatTriggersErrors = 'asset-id-body-that-triggers-errors',
   notFound = 'asset-id-not-found',
   happyFlowWithChanges = 'asset-id-happy-flow-with-changes',
+  happyFlowAlwaysNewVersion = 'asset-id-happy-flow-always-new-version',
   withExistingWebhook = 'asset-id-with-existing-webhook',
 }

--- a/services/mock-service/src/kobo/kobo.mock.service.ts
+++ b/services/mock-service/src/kobo/kobo.mock.service.ts
@@ -378,6 +378,18 @@ const getHappyFlowWithChanges = (): KoboAssetDeployment => {
   return withChanges;
 };
 
+const getHappyFlowAlwaysNewVersion = (): KoboAssetDeployment => {
+  const withNewVersion = structuredClone(happyFlowFromDefinition);
+  const newVersionId = `asset-id-happy-flow-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2)}`;
+
+  withNewVersion.version_id = newVersionId;
+  withNewVersion.asset.version_id = newVersionId;
+
+  return withNewVersion;
+};
+
 @Injectable()
 export class KoboMockService {
   public constructor(private readonly httpService: HttpService) {}
@@ -395,6 +407,8 @@ export class KoboMockService {
         return bodyThatTriggersErrors;
       case KoboMockAssetUids.happyFlowWithChanges:
         return getHappyFlowWithChanges();
+      case KoboMockAssetUids.happyFlowAlwaysNewVersion:
+        return getHappyFlowAlwaysNewVersion();
       default: {
         return happyFlowFromDefinition;
       }


### PR DESCRIPTION
[AB#42385](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42385) <!--- Replace this with a reference to a DevOps/backlog-issue -->

Added option to "Refresh link" in the KoboToolbox dropdown menu.

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [ ] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8306.westeurope.3.azurestaticapps.net
