### PR TITLE
Possible fix for ExportPayments e2e

### DIFF
--- a/e2e/portal/components/ExportData.ts
+++ b/e2e/portal/components/ExportData.ts
@@ -37,7 +37,7 @@ class ExportData extends BasePage {
       await this.page.getByLabel('CSV').click();
     }
 
-    const filePath = await this.downloadFile(this.clickProceedToExport());
+    const filePath = await this.downloadFile(() => this.clickProceedToExport());
     await this.validateExportedFile({
       filePath,
       minRowCount,

--- a/e2e/portal/pages/BasePage.ts
+++ b/e2e/portal/pages/BasePage.ts
@@ -209,16 +209,16 @@ class BasePage {
   /**
    * Downloads a file triggered by a specific action on the page.
    *
-   * @param {Promise<unknown>} triggerDownloadPromise - A promise representing the action that triggers the download
-   * (e.g., a button click). This promise should not be awaited before calling this function.
+   * @param {() => Promise<unknown>} triggerDownload - A callback that triggers the download
+   * (e.g., a button click). The listener is registered before the callback is invoked to avoid
+   * a race condition where the download event fires before the listener is set up.
    * @returns {Promise<string>} - A promise that resolves to the file path where the downloaded file is saved.
    * @throws {Error} - Throws an error if the download event fails or if there are issues saving the file.
    */
-  async downloadFile(triggerDownloadPromise: Promise<unknown>) {
-    const [download] = await Promise.all([
-      this.page.waitForEvent('download'),
-      triggerDownloadPromise,
-    ]);
+  async downloadFile(triggerDownload: () => Promise<unknown>) {
+    const downloadPromise = this.page.waitForEvent('download');
+    await triggerDownload();
+    const download = await downloadPromise;
 
     const downloadDir = path.join(process.cwd(), 'downloads');
     if (!fs.existsSync(downloadDir)) fs.mkdirSync(downloadDir);

--- a/e2e/portal/pages/ProgramMonitoringPage.ts
+++ b/e2e/portal/pages/ProgramMonitoringPage.ts
@@ -210,7 +210,7 @@ class ProgramMonitoring extends BasePage {
       .getByRole('row', { name: fileName })
       .locator('button')
       .click();
-    const filePath = await this.downloadFile(this.downloadOption.click());
+    const filePath = await this.downloadFile(() => this.downloadOption.click());
     const fileBuffer = await fs.readFile(filePath);
     expect(fileBuffer).toMatchSnapshot(snapshotName);
   }

--- a/e2e/portal/pages/RegistrationsPage.ts
+++ b/e2e/portal/pages/RegistrationsPage.ts
@@ -351,7 +351,9 @@ class RegistrationsPage extends BasePage {
     for (const column of columns) {
       await this.page.getByRole('option', { name: column }).click();
     }
-    const filePath = await this.downloadFile(this.exportCSVButton.click());
+    const filePath = await this.downloadFile(() =>
+      this.exportCSVButton.click(),
+    );
     await this.validateToastMessageAndClose('Exporting');
     await this.validateExportedFile({
       filePath,
@@ -400,7 +402,7 @@ class RegistrationsPage extends BasePage {
   async assertImportTemplateForPvProgram() {
     await this.clickAndSelectImportOption('Import new registrations');
 
-    const filePath = await this.downloadFile(
+    const filePath = await this.downloadFile(() =>
       this.downloadTemplateButton.click(),
     );
 


### PR DESCRIPTION
[AB#42612](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42612)

Related: [AB#38806](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/38806)

## Claude respons

**Root cause:** `this.downloadFile(this.clickProceedToExport())` — calling `this.clickProceedToExport()` *before* passing it to `downloadFile` means the click is dispatched to the browser immediately. By the time `downloadFile` calls `page.waitForEvent('download')` inside `Promise.all`, the download event may have already fired (especially on fast servers), causing the listener to miss it.

**Fix:** Changed `downloadFile` to accept a **callback** (`() => Promise<unknown>`) instead of an already-started promise. The listener is now registered *before* the callback executes, eliminating the race:

```ts
// Before (racy):
const [download] = await Promise.all([
  this.page.waitForEvent('download'),
  triggerDownloadPromise,   // already in-flight!
]);

// After (correct Playwright pattern):
const downloadPromise = this.page.waitForEvent('download');
await triggerDownload();    // click happens AFTER listener is set up
const download = await downloadPromise;
```

All four callers (ExportData.ts, RegistrationsPage.ts ×2, ProgramMonitoringPage.ts) were updated to pass arrow function callbacks.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] I have made sure that all automated checks pass before requesting a review

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
