### PR TITLE
chore: e2e tests for refreshing Kobo integration

### DIFF
--- a/e2e/portal/pages/RegistrationDataPage.ts
+++ b/e2e/portal/pages/RegistrationDataPage.ts
@@ -135,6 +135,15 @@ class RegistrationDataPage extends BasePage {
     await this.page.getByText('Import existing reg.').click();
   }
 
+  async refreshKoboIntegration() {
+    const ellipsisMenuButton = this.koboCard.getByTestId(
+      'ellipsis-menu-button',
+    );
+
+    await ellipsisMenuButton.click();
+    await this.page.getByText('Refresh link').click();
+  }
+
   async validateErrorTable() {
     const fileDialogErrorTable = new TableComponent(
       this.page,

--- a/e2e/portal/tests/ProgramSettings/RegistrationData/RefreshKoboIntegration.spec.ts
+++ b/e2e/portal/tests/ProgramSettings/RegistrationData/RefreshKoboIntegration.spec.ts
@@ -1,0 +1,107 @@
+import { env } from '@121-service/src/env';
+import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
+import {
+  programIdSafaricom,
+  registrationsSafaricom,
+} from '@121-service/test/registrations/pagination/pagination-data';
+
+import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
+
+const koboIntegrationBase = {
+  apiKey: 'mock-token',
+};
+
+const alreadyUpToDateUrl = `${env.MOCK_SERVICE_URL}/api/kobo/#/forms/success-asset/summary`;
+const alwaysNewVersionUrl = `${env.MOCK_SERVICE_URL}/api/kobo/#/forms/asset-id-happy-flow-always-new-version/summary`;
+
+test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
+  await resetDBAndSeedRegistrations({
+    seedScript: SeedScript.safaricomProgram,
+    registrations: registrationsSafaricom,
+    programId: programIdSafaricom,
+    navigateToPage: `/program/${programIdSafaricom}/settings/registration-data`,
+  });
+});
+
+test('Refresh Kobo integration - happy flow (integration updated)', async ({
+  registrationDataPage,
+}) => {
+  await test.step('Add Kobo integration with always-new-version asset', async () => {
+    await registrationDataPage.addKoboIntegration({
+      url: alwaysNewVersionUrl,
+      apiKey: koboIntegrationBase.apiKey,
+    });
+    await registrationDataPage.koboSuccessfullyLinkedDialog({
+      closeDialog: true,
+    });
+  });
+
+  await test.step('Click "Refresh link" from the ellipsis menu', async () => {
+    await registrationDataPage.refreshKoboIntegration();
+  });
+
+  await test.step('Validate success toast: integration updated', async () => {
+    await registrationDataPage.validateToastMessageAndClose(
+      'Integration updated successfully.',
+    );
+  });
+});
+
+test('Refresh Kobo integration - already up to date', async ({
+  registrationDataPage,
+}) => {
+  await test.step('Add Kobo integration with static-version asset', async () => {
+    await registrationDataPage.addKoboIntegration({
+      url: alreadyUpToDateUrl,
+      apiKey: koboIntegrationBase.apiKey,
+    });
+    await registrationDataPage.koboSuccessfullyLinkedDialog({
+      closeDialog: true,
+    });
+  });
+
+  await test.step('Click "Refresh link" from the ellipsis menu', async () => {
+    await registrationDataPage.refreshKoboIntegration();
+  });
+
+  await test.step('Validate info toast: already up to date', async () => {
+    await registrationDataPage.validateToastMessageAndClose(
+      'Integration is already up to date.',
+    );
+  });
+});
+
+test('Refresh Kobo integration - unsuccessful', async ({
+  registrationDataPage,
+  page,
+}) => {
+  await test.step('Add Kobo integration', async () => {
+    await registrationDataPage.addKoboIntegration({
+      url: alreadyUpToDateUrl,
+      apiKey: koboIntegrationBase.apiKey,
+    });
+    await registrationDataPage.koboSuccessfullyLinkedDialog({
+      closeDialog: true,
+    });
+  });
+
+  await test.step('Intercept PATCH /kobo to simulate a server error', async () => {
+    await page.route(`**/api/programs/*/kobo`, async (route) => {
+      if (route.request().method() === 'PATCH') {
+        await route.fulfill({ status: 500 });
+        return;
+      }
+      await route.continue();
+    });
+  });
+
+  await test.step('Click "Refresh link" from the ellipsis menu', async () => {
+    await registrationDataPage.refreshKoboIntegration();
+  });
+
+  await test.step('Validate error toast: update unsuccessful', async () => {
+    await registrationDataPage.validateToastMessageAndClose(
+      'Integration update unsuccessful. Please try again.',
+    );
+  });
+});


### PR DESCRIPTION
[AB#42515](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42515) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Added an e2e test for refreshing Kobo integrations.

The third (unsuccessful) test intercepts any outgoing HTTP PATCH request to a URL matching `**/api/programs/*/kobo` and short-circuits it. Instead of the request reaching the real server, Playwright immediately returns a 500 response to the browser. 

The first two do it differently because they're controlling behavior from a different layer. They use different Kobo asset URLs (`alwaysNewVersionUrl` vs `alreadyUpToDateUrl`) to steer the mock Kobo service into returning different responses. The 121-service PATCH endpoint runs for real and produces the correct toast based on what the Kobo API says.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
