### PR TITLE
Use more secure way to generate random-strings for test IDs and mock webhook UIDs

### DIFF
--- a/services/121-service/test/helpers/utility.helper.ts
+++ b/services/121-service/test/helpers/utility.helper.ts
@@ -17,7 +17,8 @@ import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 import { DefaultUserRole } from '@121-service/src/user/enum/user-role.enum';
 
 export function generateUniqueTestId(): string {
-  return `${Date.now()}_${randomUUID()}`;
+  const timestamp = Date.now();
+  return `${timestamp}_${randomUUID().slice(0, 8)}`;
 }
 
 export function getHostname(): string {

--- a/services/121-service/test/helpers/utility.helper.ts
+++ b/services/121-service/test/helpers/utility.helper.ts
@@ -1,5 +1,5 @@
 import { HttpStatus } from '@nestjs/common';
-import { randomBytes } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import * as request from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
@@ -16,14 +16,8 @@ import { UserRoleResponseDTO } from '@121-service/src/user/dto/userrole-response
 import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 import { DefaultUserRole } from '@121-service/src/user/enum/user-role.enum';
 
-const uniqueTestIdSuffixLength = 8;
-
 export function generateUniqueTestId(): string {
-  const timestamp = Date.now();
-  const randomSuffix = randomBytes(Math.ceil(uniqueTestIdSuffixLength / 2))
-    .toString('hex')
-    .slice(0, uniqueTestIdSuffixLength);
-  return `${timestamp}_${randomSuffix}`;
+  return `${Date.now()}_${randomUUID()}`;
 }
 
 export function getHostname(): string {

--- a/services/121-service/test/helpers/utility.helper.ts
+++ b/services/121-service/test/helpers/utility.helper.ts
@@ -1,7 +1,7 @@
 import { HttpStatus } from '@nestjs/common';
+import { randomBytes } from 'node:crypto';
 import * as request from 'supertest';
 import TestAgent from 'supertest/lib/agent';
-import { randomBytes } from 'crypto';
 
 import { env } from '@121-service/src/env';
 import { ApproverSeedMode } from '@121-service/src/scripts/enum/approval-seed-mode.enum';

--- a/services/121-service/test/helpers/utility.helper.ts
+++ b/services/121-service/test/helpers/utility.helper.ts
@@ -1,6 +1,7 @@
 import { HttpStatus } from '@nestjs/common';
 import * as request from 'supertest';
 import TestAgent from 'supertest/lib/agent';
+import { randomBytes } from 'crypto';
 
 import { env } from '@121-service/src/env';
 import { ApproverSeedMode } from '@121-service/src/scripts/enum/approval-seed-mode.enum';
@@ -17,7 +18,7 @@ import { DefaultUserRole } from '@121-service/src/user/enum/user-role.enum';
 
 export function generateUniqueTestId(): string {
   const timestamp = Date.now();
-  const randomSuffix = Math.random().toString(36).substring(7);
+  const randomSuffix = randomBytes(8).toString('hex');
   return `${timestamp}_${randomSuffix}`;
 }
 

--- a/services/121-service/test/helpers/utility.helper.ts
+++ b/services/121-service/test/helpers/utility.helper.ts
@@ -16,9 +16,13 @@ import { UserRoleResponseDTO } from '@121-service/src/user/dto/userrole-response
 import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 import { DefaultUserRole } from '@121-service/src/user/enum/user-role.enum';
 
+const uniqueTestIdSuffixLength = 8;
+
 export function generateUniqueTestId(): string {
   const timestamp = Date.now();
-  const randomSuffix = randomBytes(8).toString('hex');
+  const randomSuffix = randomBytes(Math.ceil(uniqueTestIdSuffixLength / 2))
+    .toString('hex')
+    .slice(0, uniqueTestIdSuffixLength);
   return `${timestamp}_${randomSuffix}`;
 }
 

--- a/services/mock-service/src/kobo/kobo.mock.service.ts
+++ b/services/mock-service/src/kobo/kobo.mock.service.ts
@@ -1,6 +1,6 @@
 import { HttpService } from '@nestjs/axios';
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
-import { randomBytes } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import { lastValueFrom } from 'rxjs';
 import { joinURL } from 'ufo';
 
@@ -49,8 +49,6 @@ export interface KoboAssetDeployment {
   asset: KoboAsset;
   version_id: string;
 }
-
-const webhookUidSuffixLength = 13;
 
 const bodyThatTriggersErrors: KoboAssetDeployment = {
   version_id: KoboMockAssetUids.bodyThatTriggersErrors,
@@ -462,13 +460,9 @@ export class KoboMockService {
     active: boolean;
     subset_fields: string[];
   } {
-    const randomSuffix = randomBytes(Math.ceil(webhookUidSuffixLength / 2))
-      .toString('hex')
-      .slice(0, webhookUidSuffixLength);
-
     // Mock implementation - return the created webhook with a generated uid
     return {
-      uid: `hook_${randomSuffix}`,
+      uid: `hook_${randomUUID()}`,
       ...body,
     };
   }

--- a/services/mock-service/src/kobo/kobo.mock.service.ts
+++ b/services/mock-service/src/kobo/kobo.mock.service.ts
@@ -1,5 +1,6 @@
 import { HttpService } from '@nestjs/axios';
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { randomBytes } from 'node:crypto';
 import { lastValueFrom } from 'rxjs';
 import { joinURL } from 'ufo';
 
@@ -459,9 +460,13 @@ export class KoboMockService {
     active: boolean;
     subset_fields: string[];
   } {
+    const randomSuffix = Array.from(randomBytes(13), (byte) =>
+      (byte % 36).toString(36),
+    ).join('');
+
     // Mock implementation - return the created webhook with a generated uid
     return {
-      uid: 'hook_' + Math.random().toString(36).substring(2, 15),
+      uid: `hook_${randomSuffix}`,
       ...body,
     };
   }

--- a/services/mock-service/src/kobo/kobo.mock.service.ts
+++ b/services/mock-service/src/kobo/kobo.mock.service.ts
@@ -1,6 +1,6 @@
 import { HttpService } from '@nestjs/axios';
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
-import { randomInt } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
 import { lastValueFrom } from 'rxjs';
 import { joinURL } from 'ufo';
 
@@ -462,10 +462,9 @@ export class KoboMockService {
     active: boolean;
     subset_fields: string[];
   } {
-    const randomSuffix = Array.from(
-      { length: webhookUidSuffixLength },
-      () => randomInt(0, 36).toString(36),
-    ).join('');
+    const randomSuffix = randomBytes(Math.ceil(webhookUidSuffixLength / 2))
+      .toString('hex')
+      .slice(0, webhookUidSuffixLength);
 
     // Mock implementation - return the created webhook with a generated uid
     return {

--- a/services/mock-service/src/kobo/kobo.mock.service.ts
+++ b/services/mock-service/src/kobo/kobo.mock.service.ts
@@ -1,6 +1,6 @@
 import { HttpService } from '@nestjs/axios';
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
-import { randomBytes } from 'node:crypto';
+import { randomInt } from 'node:crypto';
 import { lastValueFrom } from 'rxjs';
 import { joinURL } from 'ufo';
 
@@ -49,6 +49,8 @@ export interface KoboAssetDeployment {
   asset: KoboAsset;
   version_id: string;
 }
+
+const webhookUidSuffixLength = 13;
 
 const bodyThatTriggersErrors: KoboAssetDeployment = {
   version_id: KoboMockAssetUids.bodyThatTriggersErrors,
@@ -460,8 +462,9 @@ export class KoboMockService {
     active: boolean;
     subset_fields: string[];
   } {
-    const randomSuffix = Array.from(randomBytes(13), (byte) =>
-      (byte % 36).toString(36),
+    const randomSuffix = Array.from(
+      { length: webhookUidSuffixLength },
+      () => randomInt(0, 36).toString(36),
     ).join('');
 
     // Mock implementation - return the created webhook with a generated uid


### PR DESCRIPTION
<a href="https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42661">[AB#42661](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42661)</a>

## Describe your changes

Replaces insecure `Math.random()` usage in both the 121-service test helper and the mock-service Kobo webhook UID generator with `randomUUID()` from `node:crypto`. Both solutions now use the same pattern for consistency.

- **121-service test ID randomness**
  - `generateUniqueTestId()` now uses `randomUUID()` from `node:crypto`.
  - ID shape: `${timestamp}_${randomUUID()}`.

- **Mock-service webhook UID randomness**
  - Replaced `Math.random().toString(36).substring(2, 15)` with `randomUUID()` from `node:crypto`.
  - Preserves `hook_` prefix: `hook_${randomUUID()}`.

- **Code scanning coverage**
  - Addresses:
    - https://github.com/global-121/121-platform/security/code-scanning/71
    - https://github.com/global-121/121-platform/security/code-scanning/66

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->