### PR TITLE
Add new permissions to manage FSP-configuration(s)

### DIFF
--- a/interfaces/portal/src/app/app.routes.ts
+++ b/interfaces/portal/src/app/app.routes.ts
@@ -239,7 +239,12 @@ export const routes: Routes = [
                 (x) => x.ProgramSettingsFspsPageComponent,
               ),
             canActivate: [
-              authCapabilitiesGuard((authService) => authService.isAdmin),
+              programPermissionsGuard({
+                permission: PermissionEnum.ProgramFspConfigCREATE,
+              }),
+              programPermissionsGuard({
+                permission: PermissionEnum.ProgramFspConfigUPDATE,
+              }),
             ],
           },
           {

--- a/interfaces/portal/src/app/app.routes.ts
+++ b/interfaces/portal/src/app/app.routes.ts
@@ -1,3 +1,4 @@
+import { inject } from '@angular/core';
 import { Routes } from '@angular/router';
 
 import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
@@ -7,6 +8,7 @@ import { authCapabilitiesGuard } from '~/guards/auth-capabilities.guard';
 import { foundResourceGuard } from '~/guards/found-resource.guard';
 import { pendingChangesGuard } from '~/guards/pending-changes.guard';
 import { programPermissionsGuard } from '~/guards/program-permissions-guard';
+import { AuthService } from '~/services/auth.service';
 
 export enum AppRoutes {
   authCallback = 'auth-callback',
@@ -239,12 +241,16 @@ export const routes: Routes = [
                 (x) => x.ProgramSettingsFspsPageComponent,
               ),
             canActivate: [
-              programPermissionsGuard({
-                permission: PermissionEnum.ProgramFspConfigCREATE,
-              }),
-              programPermissionsGuard({
-                permission: PermissionEnum.ProgramFspConfigUPDATE,
-              }),
+              (route) => {
+                const authService = inject(AuthService);
+                return authService.hasSomePermission({
+                  programId: Number(route.parent?.params.programId),
+                  optionalPermissions: [
+                    PermissionEnum.ProgramFspConfigCREATE,
+                    PermissionEnum.ProgramFspConfigUPDATE,
+                  ],
+                });
+              },
             ],
           },
           {

--- a/interfaces/portal/src/app/components/page-layout-program-settings/page-layout-program-settings.component.ts
+++ b/interfaces/portal/src/app/components/page-layout-program-settings/page-layout-program-settings.component.ts
@@ -62,7 +62,13 @@ export class PageLayoutProgramSettingsComponent {
         AppRoutes.programSettings,
         AppRoutes.programSettingsFsps,
       ],
-      visible: this.authService.isAdmin,
+      visible: this.authService.hasSomePermission({
+        programId: this.programId(),
+        optionalPermissions: [
+          PermissionEnum.ProgramFspConfigCREATE,
+          PermissionEnum.ProgramFspConfigUPDATE,
+        ],
+      }),
     },
     {
       label: $localize`Registration data`,

--- a/interfaces/portal/src/app/pages/program-settings-fsps/components/fsp-configuration-list/fsp-configuration-list.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-fsps/components/fsp-configuration-list/fsp-configuration-list.component.html
@@ -60,7 +60,7 @@
           </div>
         }
       </div>
-    } @else {
+    } @else if (canAddFsp()) {
       <p-button
         label="Add another FSP"
         i18n-label

--- a/interfaces/portal/src/app/pages/program-settings-fsps/components/fsp-configuration-list/fsp-configuration-list.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-fsps/components/fsp-configuration-list/fsp-configuration-list.component.ts
@@ -14,6 +14,7 @@ import { CardModule } from 'primeng/card';
 
 import { FSP_SETTINGS } from '@121-service/src/fsp-integrations/settings/fsp-settings.const';
 import { Fsps } from '@121-service/src/fsp-integrations/shared/enum/fsp-name.enum';
+import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 
 import { CardWithLinkComponent } from '~/components/card-with-link/card-with-link.component';
 import { SkeletonInlineComponent } from '~/components/skeleton-inline/skeleton-inline.component';
@@ -22,6 +23,7 @@ import { FSP_IMAGE_URLS } from '~/domains/fsp-configuration/fsp-configuration.he
 import { FspConfiguration } from '~/domains/fsp-configuration/fsp-configuration.model';
 import { FspConfigurationCardComponent } from '~/pages/program-settings-fsps/components/fsp-configuration-card/fsp-configuration-card.component';
 import { TranslatableStringPipe } from '~/pipes/translatable-string.pipe';
+import { AuthService } from '~/services/auth.service';
 
 @Component({
   selector: 'app-fsp-configuration-list',
@@ -38,6 +40,7 @@ import { TranslatableStringPipe } from '~/pipes/translatable-string.pipe';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FspConfigurationListComponent {
+  readonly authService = inject(AuthService);
   readonly programId = input.required<string>();
   readonly forceShowNewFspList = model.required<boolean>();
   readonly addFspConfiguration = output<Fsps>();
@@ -65,5 +68,12 @@ export class FspConfigurationListComponent {
     return this.fspConfigurations
       .data()
       ?.every((fspConfiguration) => fspConfiguration.fspName !== name);
+  }
+
+  canAddFsp() {
+    return this.authService.hasPermission({
+      programId: this.programId(),
+      requiredPermission: PermissionEnum.ProgramFspConfigCREATE,
+    });
   }
 }

--- a/services/121-service/src/fsp-integrations/integrations/commercial-bank-ethiopia/services/commercial-bank-ethiopia.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/commercial-bank-ethiopia/services/commercial-bank-ethiopia.service.ts
@@ -107,10 +107,10 @@ export class CommercialBankEthiopiaService {
         fspName: Fsps.commercialBankEthiopia,
       });
 
-    // For now we only support one CBE FSP configuration per program
+    // For now we only support one CBE FSP-configuration per program
     if (configs.length !== 1) {
       throw new HttpException(
-        `Expected exactly one program Fsp configuration for program ${programId} and Fsp ${Fsps.commercialBankEthiopia}`,
+        `Expected exactly one program FSP-configuration for program ${programId} and Fsp ${Fsps.commercialBankEthiopia}`,
         HttpStatus.NOT_FOUND,
       );
     }
@@ -122,7 +122,7 @@ export class CommercialBankEthiopiaService {
 
     if (credentials.password == null || credentials.username == null) {
       throw new HttpException(
-        `Missing username or password for program ${programId} Fsp configuration.`,
+        `Missing username or password for program ${programId} FSP-configuration.`,
         HttpStatus.NOT_FOUND,
       );
     }

--- a/services/121-service/src/fsp-integrations/integrations/excel/excel.module.ts
+++ b/services/121-service/src/fsp-integrations/integrations/excel/excel.module.ts
@@ -23,7 +23,7 @@ import { FileImportService } from '@121-service/src/utils/file-import/file-impor
     ExcelService,
     LookupService,
     FileImportService,
-    // TODO: Refactor this to not make excel module dependent on program Fsp configuration
+    // TODO: Refactor this to not make excel module dependent on program FSP-configuration
     ProgramFspConfigurationRepository,
   ],
   controllers: [],

--- a/services/121-service/src/guards/authenticated-user.decorator.ts
+++ b/services/121-service/src/guards/authenticated-user.decorator.ts
@@ -29,7 +29,7 @@ export const AuthenticatedUser = (parameters?: AuthenticatedUserParameters) => {
     }),
     ApiResponse({
       status: HttpStatus.FORBIDDEN,
-      description: `User does not have the right permission to access this endpoint. \n (${permissionsDescription})`,
+      description: `User does not have the required permission(s) to access this endpoint. \n (${permissionsDescription})`,
     }),
     ApiResponse({
       status: HttpStatus.UNAUTHORIZED,

--- a/services/121-service/src/program-fsp-configurations/program-fsp-configurations.controller.ts
+++ b/services/121-service/src/program-fsp-configurations/program-fsp-configurations.controller.ts
@@ -295,7 +295,7 @@ export class ProgramFspConfigurationsController {
     });
   }
 
-  @AuthenticatedUser({ isAdmin: true })
+  @AuthenticatedUser({ permissions: [PermissionEnum.ProgramFspConfigUPDATE] })
   @ApiOperation({
     summary: `Update a single property for an FSP-configuration. See \`/api/fsps\` for allowed properties per FSP.`,
   })
@@ -341,7 +341,7 @@ export class ProgramFspConfigurationsController {
     });
   }
 
-  @AuthenticatedUser({ isAdmin: true })
+  @AuthenticatedUser({ permissions: [PermissionEnum.ProgramFspConfigDELETE] })
   @ApiOperation({
     summary: `Delete a single FSP-configuration property. See \`/api/fsps\` for required properties per FSP.`,
   })

--- a/services/121-service/src/program-fsp-configurations/program-fsp-configurations.controller.ts
+++ b/services/121-service/src/program-fsp-configurations/program-fsp-configurations.controller.ts
@@ -38,7 +38,9 @@ export class ProgramFspConfigurationsController {
     private readonly programFspConfigurationsService: ProgramFspConfigurationsService,
   ) {}
 
-  @AuthenticatedUser({ isAdmin: true })
+  @AuthenticatedUser({
+    permissions: [PermissionEnum.ProgramFspConfigREAD],
+  })
   @ApiOperation({
     summary: 'Get all FSP-configurations for a Program.',
   })
@@ -59,7 +61,9 @@ export class ProgramFspConfigurationsController {
     return this.programFspConfigurationsService.getByProgramId(programId);
   }
 
-  @AuthenticatedUser({ isAdmin: true })
+  @AuthenticatedUser({
+    permissions: [PermissionEnum.ProgramFspConfigCREATE],
+  })
   @ApiOperation({
     summary: `
       Create an FSP-configuration for a Program.
@@ -96,7 +100,9 @@ export class ProgramFspConfigurationsController {
     );
   }
 
-  @AuthenticatedUser({ isAdmin: true })
+  @AuthenticatedUser({
+    permissions: [PermissionEnum.ProgramFspConfigUPDATE],
+  })
   @ApiOperation({
     summary: `
       Update an FSP-configuration for a Program. Can only update the label and properties.
@@ -139,7 +145,9 @@ export class ProgramFspConfigurationsController {
     );
   }
 
-  @AuthenticatedUser({ isAdmin: true })
+  @AuthenticatedUser({
+    permissions: [PermissionEnum.ProgramFspConfigDELETE],
+  })
   @ApiOperation({
     summary:
       'Delete an FSP-configuration. FSP-configurations cannot be deleted if they are associated with any transaction(s).',
@@ -173,7 +181,9 @@ export class ProgramFspConfigurationsController {
     await this.programFspConfigurationsService.delete(programId, name);
   }
 
-  @AuthenticatedUser({ isAdmin: true })
+  @AuthenticatedUser({
+    permissions: [PermissionEnum.ProgramFspConfigREAD],
+  })
   @ApiOperation({
     summary: 'Retrieve visible properties for FSP-configuration.',
   })
@@ -203,7 +213,12 @@ export class ProgramFspConfigurationsController {
     );
   }
 
-  @AuthenticatedUser({ permissions: [PermissionEnum.ProgramREAD] })
+  @AuthenticatedUser({
+    permissions: [
+      PermissionEnum.ProgramREAD,
+      PermissionEnum.ProgramFspConfigREAD,
+    ],
+  })
   @ApiOperation({
     summary:
       'Retrieve allowlisted public properties for FSP-configuration. Only returns properties that are safe to expose to non-admin users based on the Program FSP-configuration Property type.',
@@ -234,7 +249,7 @@ export class ProgramFspConfigurationsController {
     );
   }
 
-  @AuthenticatedUser({ isAdmin: true })
+  @AuthenticatedUser({ permissions: [PermissionEnum.ProgramFspConfigUPDATE] })
   @ApiOperation({
     summary: `Create properties for an FSP-configuration. See \`/api/fsps\` for allowed properties per FSP.`,
   })

--- a/services/121-service/src/program-fsp-configurations/program-fsp-configurations.controller.ts
+++ b/services/121-service/src/program-fsp-configurations/program-fsp-configurations.controller.ts
@@ -17,7 +17,6 @@ import {
 import { ApiBody, ApiTags } from '@nestjs/swagger';
 import { ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
 
-import { EXTERNAL_API } from '@121-service/src/config';
 import { FspConfigurationProperties } from '@121-service/src/fsp-integrations/shared/enum/fsp-configuration-properties.enum';
 import { AuthenticatedUser } from '@121-service/src/guards/authenticated-user.decorator';
 import { AuthenticatedUserGuard } from '@121-service/src/guards/authenticated-user.guard';
@@ -41,12 +40,12 @@ export class ProgramFspConfigurationsController {
 
   @AuthenticatedUser({ isAdmin: true })
   @ApiOperation({
-    summary: 'Get all Fsp Configurations for a Program.',
+    summary: 'Get all FSP-configurations for a Program.',
   })
   @ApiParam({ name: 'programId', required: true, type: 'integer' })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Return Fsp Configurations by Program Id.',
+    description: 'Returns all FSP-configurations for the given Program Id.',
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
@@ -62,13 +61,15 @@ export class ProgramFspConfigurationsController {
 
   @AuthenticatedUser({ isAdmin: true })
   @ApiOperation({
-    summary:
-      'Create a Fsp Configuration for a Program. You can also add properties in this API call or you can add them later using /programs/{programId}/fsp-configurations/{name}/properties',
+    summary: `
+      Create an FSP-configuration for a Program.
+      You can add properties in this API call or add them later using: \`/api/programs/{programId}/fsp-configurations/{name}/properties\`
+      `,
   })
   @ApiParam({ name: 'programId', required: true, type: 'integer' })
   @ApiResponse({
     status: HttpStatus.CREATED,
-    description: 'The Fsp Configuration has been successfully created.',
+    description: 'FSP-configuration has been successfully created.',
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
@@ -80,7 +81,7 @@ export class ProgramFspConfigurationsController {
   })
   @ApiResponse({
     status: HttpStatus.CONFLICT,
-    description: 'Program Fsp Configuration with same name already exists',
+    description: 'FSP-configuration with the same name already exists',
   })
   @Post(':programId/fsp-configurations')
   public async create(
@@ -97,8 +98,12 @@ export class ProgramFspConfigurationsController {
 
   @AuthenticatedUser({ isAdmin: true })
   @ApiOperation({
-    summary:
-      'Update a Fsp Configuration for a Program. Can only update the label and properties. Posting an array with properties or an empty array of properties will delete all existing properties and create new ones. If you want to add properties it is therefore recommended to use this endpoint: /programs/{programId}/fsp-configurations/{name}/properties. Example of how to format properties can also be found there',
+    summary: `
+      Update an FSP-configuration for a Program. Can only update the label and properties.
+      Posting any (empty) array with properties will delete all _existing_ properties and create _new_ ones.
+      If you only want to _add_ properties it is therefore recommended to use the endpoint: \`/api/programs/{programId}/fsp-configurations/{name}/properties\`.
+      Example of how to format properties can also be found there.
+      `,
   })
   @ApiParam({ name: 'programId', required: true, type: 'integer' })
   @ApiParam({
@@ -108,7 +113,7 @@ export class ProgramFspConfigurationsController {
   })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'The Fsp Configuration has been successfully updated.',
+    description: 'FSP-configuration has been successfully updated.',
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
@@ -137,17 +142,17 @@ export class ProgramFspConfigurationsController {
   @AuthenticatedUser({ isAdmin: true })
   @ApiOperation({
     summary:
-      'Delete a Fsp Configuration for a Program. Program Fsp Configurations cannot be deleted if they are associated with any transactions.',
+      'Delete an FSP-configuration. FSP-configurations cannot be deleted if they are associated with any transaction(s).',
   })
   @ApiParam({ name: 'programId', required: true, type: 'integer' })
   @HttpCode(204)
   @ApiResponse({
     status: HttpStatus.NO_CONTENT,
-    description: 'The Fsp Configuration has been successfully deleted.',
+    description: 'FSP-configuration has been successfully deleted.',
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Program does not exist or Fsp Configuration does not exist',
+    description: 'Program or FSP-configuration does not exist',
   })
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
@@ -156,7 +161,7 @@ export class ProgramFspConfigurationsController {
   @ApiResponse({
     status: HttpStatus.CONFLICT,
     description:
-      'Program Fsp Configuration is associated with transactions, so cannot be deleted',
+      'FSP-configuration is associated with transaction(s), so cannot be deleted',
   })
   @Delete(':programId/fsp-configurations/:name')
   public async delete(
@@ -170,7 +175,7 @@ export class ProgramFspConfigurationsController {
 
   @AuthenticatedUser({ isAdmin: true })
   @ApiOperation({
-    summary: 'Retrieve visible properties for Fsp Configuration.',
+    summary: 'Retrieve visible properties for FSP-configuration.',
   })
   @ApiParam({ name: 'programId', required: true, type: 'integer' })
   @ApiParam({
@@ -181,11 +186,11 @@ export class ProgramFspConfigurationsController {
   @ApiResponse({
     status: HttpStatus.OK,
     description:
-      'The Fsp Configuration properties have been successfully retrieved.',
+      'FSP-configuration properties have been successfully retrieved.',
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Program does not exist or Fsp Configuration does not exist',
+    description: 'Program or FSP-configuration does not exist',
   })
   @Get(':programId/fsp-configurations/:name/properties')
   public async getFspConfigurationProperties(
@@ -201,7 +206,7 @@ export class ProgramFspConfigurationsController {
   @AuthenticatedUser({ permissions: [PermissionEnum.ProgramREAD] })
   @ApiOperation({
     summary:
-      'Retrieve allowlisted public properties for Fsp Configuration. Only returns properties that are safe to expose to non-admin users based on the Program Fsp Configuration Property type.',
+      'Retrieve allowlisted public properties for FSP-configuration. Only returns properties that are safe to expose to non-admin users based on the Program FSP-configuration Property type.',
   })
   @ApiParam({ name: 'programId', required: true, type: 'integer' })
   @ApiParam({
@@ -212,11 +217,11 @@ export class ProgramFspConfigurationsController {
   @ApiResponse({
     status: HttpStatus.OK,
     description:
-      'The Fsp Configuration properties have been successfully retrieved.',
+      'FSP-configuration properties have been successfully retrieved.',
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Program does not exist or Fsp Configuration does not exist',
+    description: 'Program or FSP-configuration does not exist',
   })
   @Get(':programId/fsp-configurations/:name/properties/public')
   public async getPublicFspConfigurationProperties(
@@ -231,7 +236,7 @@ export class ProgramFspConfigurationsController {
 
   @AuthenticatedUser({ isAdmin: true })
   @ApiOperation({
-    summary: `Create properties for a Program FSP Configuration. See ${EXTERNAL_API.rootApi}/fsps for allowed properties per FSP.`,
+    summary: `Create properties for an FSP-configuration. See \`/api/fsps\` for allowed properties per FSP.`,
   })
   @ApiParam({ name: 'programId', required: true, type: 'integer' })
   @ApiParam({
@@ -241,8 +246,7 @@ export class ProgramFspConfigurationsController {
   })
   @ApiResponse({
     status: HttpStatus.CREATED,
-    description:
-      'The Fsp Configuration properties have been successfully created.',
+    description: 'FSP-configuration properties have been successfully created.',
   })
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
@@ -250,7 +254,7 @@ export class ProgramFspConfigurationsController {
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Program does not exist or Fsp Configuration does not exist',
+    description: 'Program or FSP-configuration does not exist',
   })
   @ApiBody({
     isArray: true,
@@ -278,7 +282,7 @@ export class ProgramFspConfigurationsController {
 
   @AuthenticatedUser({ isAdmin: true })
   @ApiOperation({
-    summary: `Update a single property for a Program FSP Configuration.. See ${EXTERNAL_API.rootApi}/fsps for allowed properties per FSP.`,
+    summary: `Update a single property for an FSP-configuration. See \`/api/fsps\` for allowed properties per FSP.`,
   })
   @ApiParam({ name: 'programId', required: true, type: 'integer' })
   @ApiParam({
@@ -293,8 +297,7 @@ export class ProgramFspConfigurationsController {
   })
   @ApiResponse({
     status: HttpStatus.CREATED,
-    description:
-      'The Fsp Configuration property has been successfully updated.',
+    description: 'FSP-configuration property has been successfully updated.',
   })
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
@@ -302,8 +305,7 @@ export class ProgramFspConfigurationsController {
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description:
-      'Program does not exist or Fsp Configuration or property does not exist',
+    description: 'Program, FSP-configuration or property does not exist',
   })
   @Patch(':programId/fsp-configurations/:name/properties/:propertyName')
   public async updateProperty(
@@ -326,7 +328,7 @@ export class ProgramFspConfigurationsController {
 
   @AuthenticatedUser({ isAdmin: true })
   @ApiOperation({
-    summary: `Delete a single Program FSP Configuration property. See ${EXTERNAL_API.rootApi}/fsps for required properties per FSP.`,
+    summary: `Delete a single FSP-configuration property. See \`/api/fsps\` for required properties per FSP.`,
   })
   @ApiParam({ name: 'programId', required: true, type: 'integer' })
   @ApiParam({
@@ -342,7 +344,7 @@ export class ProgramFspConfigurationsController {
   @HttpCode(204)
   @ApiResponse({
     status: HttpStatus.NO_CONTENT,
-    description: 'The Fsp Configuration property is successfully deleted.',
+    description: 'FSP-configuration property is successfully deleted.',
   })
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
@@ -350,8 +352,7 @@ export class ProgramFspConfigurationsController {
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description:
-      'Program does not exist or Fsp Configuration or property does not exist',
+    description: 'Program, FSP-configuration or property does not exist',
   })
   @Delete(':programId/fsp-configurations/:name/properties/:propertyName')
   public async deleteProperty(

--- a/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.spec.ts
+++ b/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.spec.ts
@@ -418,7 +418,7 @@ describe('ProgramFspConfigurationsService', () => {
         }),
       ).rejects.toThrow(
         new HttpException(
-          `Program Fsp configuration with name ${
+          `Program FSP-configuration with name ${
             nonExistingConfigName
           } not found`,
           HttpStatus.NOT_FOUND,
@@ -490,7 +490,7 @@ describe('ProgramFspConfigurationsService', () => {
         }),
       ).rejects.toThrow(
         new HttpException(
-          `Program Fsp configuration property with name ${propertyName} not found`,
+          `Program FSP-configuration property with name ${propertyName} not found`,
           HttpStatus.NOT_FOUND,
         ),
       );

--- a/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.spec.ts
+++ b/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.spec.ts
@@ -235,7 +235,7 @@ describe('ProgramFspConfigurationsService', () => {
         service.create(programId, duplivateNameCreateDto),
       ).rejects.toThrow(
         new HttpException(
-          `Program Fsp with name ${duplivateNameCreateDto.name} already exists`,
+          `Program FSP-configuration with name ${duplivateNameCreateDto.name} already exists`,
           HttpStatus.CONFLICT,
         ),
       );

--- a/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.ts
+++ b/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.ts
@@ -82,7 +82,7 @@ export class ProgramFspConfigurationsService {
 
     if (existingConfig) {
       throw new HttpException(
-        `Program Fsp with name ${programFspConfigurationDto.name} already exists`,
+        `Program FSP-configuration with name ${programFspConfigurationDto.name} already exists`,
         HttpStatus.CONFLICT,
       );
     }

--- a/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.ts
+++ b/services/121-service/src/program-fsp-configurations/program-fsp-configurations.service.ts
@@ -231,7 +231,7 @@ export class ProgramFspConfigurationsService {
         (r) => r.referenceId,
       );
       throw new HttpException(
-        `Cannot delete program Fsp configuration ${name} because it is still in use by registrations with referenceIds: ${registrationReferenceIds.join(
+        `Cannot delete program FSP-configuration ${name} because it is still in use by registrations with referenceIds: ${registrationReferenceIds.join(
           ', ',
         )}`,
         HttpStatus.CONFLICT,
@@ -497,7 +497,7 @@ export class ProgramFspConfigurationsService {
     });
     if (!config) {
       throw new HttpException(
-        `Program Fsp configuration with name ${name} not found`,
+        `Program FSP-configuration with name ${name} not found`,
         HttpStatus.NOT_FOUND,
       );
     }
@@ -517,7 +517,7 @@ export class ProgramFspConfigurationsService {
       });
     if (!property) {
       throw new HttpException(
-        `Program Fsp configuration property with name ${propertyName} not found`,
+        `Program FSP-configuration property with name ${propertyName} not found`,
         HttpStatus.NOT_FOUND,
       );
     }

--- a/services/121-service/src/programs/programs.service.ts
+++ b/services/121-service/src/programs/programs.service.ts
@@ -354,7 +354,7 @@ export class ProgramService {
       });
     if (!programFspConfigurations) {
       throw new HttpException(
-        'Fsp configurations not found',
+        'FSP-configurations not found',
         HttpStatus.NOT_FOUND,
       );
     }

--- a/services/121-service/src/registration/controllers/registrations.controller.ts
+++ b/services/121-service/src/registration/controllers/registrations.controller.ts
@@ -407,7 +407,7 @@ export class RegistrationsController {
         GenericRegistrationAttributes.programFspConfigurationName
       ) {
         if (!hasUpdateFspConfigPermission) {
-          const errors = `User does not have permission to update chosen program Fsp configuration`;
+          const errors = `User does not have permission to update chosen program FSP-configuration`;
           throw new HttpException({ errors }, HttpStatus.FORBIDDEN);
         }
       } else {

--- a/services/121-service/src/user/enum/permission.enum.ts
+++ b/services/121-service/src/user/enum/permission.enum.ts
@@ -31,6 +31,11 @@ export enum PermissionEnum {
   ProgramAttachmentsUPDATE = 'program:attachments.update',
   ProgramAttachmentsDELETE = 'program:attachments.delete',
 
+  ProgramFspConfigREAD = 'program:fsp-config.read',
+  ProgramFspConfigCREATE = 'program:fsp-config.create',
+  ProgramFspConfigUPDATE = 'program:fsp-config.update',
+  ProgramFspConfigDELETE = 'program:fsp-config.delete',
+
   ProgramMetricsREAD = 'program:metrics.read',
 
   // Program Registration Attributes

--- a/services/121-service/test/middlewares/program-exists.interceptor.test.ts
+++ b/services/121-service/test/middlewares/program-exists.interceptor.test.ts
@@ -26,6 +26,6 @@ describe('Program exist interceptor', () => {
     });
 
     // Assert
-    expect(result.statusCode).toBe(HttpStatus.FORBIDDEN); // As the users does not have any permissions on the non-existing program, the request fails before the program has even been looked up.
+    expect(result.statusCode).toBe(HttpStatus.FORBIDDEN); // As the user will not have any permissions on the non-existing program, the request fails before the program has even been looked up.
   });
 });

--- a/services/121-service/test/middlewares/program-exists.interceptor.test.ts
+++ b/services/121-service/test/middlewares/program-exists.interceptor.test.ts
@@ -26,8 +26,6 @@ describe('Program exist interceptor', () => {
     });
 
     // Assert
-    expect(result.statusCode).toBe(HttpStatus.NOT_FOUND);
-    expect(result.body?.message).toContain('Program');
-    expect(result.body?.message).toContain(String(nonExistingProgramId));
+    expect(result.statusCode).toBe(HttpStatus.FORBIDDEN); // As the users does not have any permissions on the non-existing program, the request fails before the program has even been looked up.
   });
 });

--- a/services/121-service/test/program/__snapshots__/manage-program-fsp-configuration.test.ts.snap
+++ b/services/121-service/test/program/__snapshots__/manage-program-fsp-configuration.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Manage Fsp configurations should not delete existing program Fsp configuration because of active registrations with that config 1`] = `
+exports[`Manage FSP-configurations should not delete existing program FSP-configuration because of active registrations with that config 1`] = `
 {
-  "message": "Cannot delete program Fsp configuration Intersolve-voucher-whatsapp because it is still in use by registrations with referenceIds: 54e62864557597e034",
+  "message": "Cannot delete program FSP-configuration Intersolve-voucher-whatsapp because it is still in use by registrations with referenceIds: 54e62864557597e034",
   "statusCode": 409,
 }
 `;

--- a/services/121-service/test/program/manage-program-fsp-configuration.test.ts
+++ b/services/121-service/test/program/manage-program-fsp-configuration.test.ts
@@ -85,7 +85,7 @@ const createProgramFspConfigurationDtoSafaricom: CreateProgramFspConfigurationDt
     properties: [],
   };
 
-describe('Manage Fsp configurations', () => {
+describe('Manage FSP-configurations', () => {
   let accessToken: string;
 
   beforeEach(async () => {
@@ -93,7 +93,7 @@ describe('Manage Fsp configurations', () => {
     accessToken = await getAccessToken();
   });
 
-  it('should add program Fsp configuration to an existing program', async () => {
+  it('should add program FSP-configuration to an existing program', async () => {
     // Act
     const result = await postProgramFspConfiguration({
       programId: programIdVisa,
@@ -137,7 +137,7 @@ describe('Manage Fsp configurations', () => {
     expect(getResultConfig).toEqual(result.body);
   });
 
-  it('should add missing required program registration attributes when adding a program Fsp configuration', async () => {
+  it('should add missing required program registration attributes when adding a program FSP-configuration', async () => {
     // Arrange
     const program = await getProgram(programIdVisa, accessToken);
     const programRegistrationAttributes =
@@ -179,7 +179,7 @@ describe('Manage Fsp configurations', () => {
     ).toEqual(originalPhoneNumberProgramRegistrationAttribute);
   });
 
-  it('should patch existing program Fsp configuration', async () => {
+  it('should patch existing program FSP-configuration', async () => {
     // Act
     const updateProgramFspConfigurationDto: UpdateProgramFspConfigurationDto = {
       label: {
@@ -238,7 +238,7 @@ describe('Manage Fsp configurations', () => {
     expect(getResultConfig).toEqual(result.body);
   });
 
-  it('should delete existing program Fsp configuration', async () => {
+  it('should delete existing program FSP-configuration', async () => {
     // Act
     const name = seededFspConfigVoucher.fsp;
     const result = await deleteProgramFspConfiguration({
@@ -258,7 +258,7 @@ describe('Manage Fsp configurations', () => {
     expect(getResultConfig).toBeUndefined();
   });
 
-  it('should not delete existing program Fsp configuration because of active registrations with that config', async () => {
+  it('should not delete existing program FSP-configuration because of active registrations with that config', async () => {
     // Prepare
     await seedPaidRegistrations({
       registrations: [registrationOCW5],
@@ -287,7 +287,7 @@ describe('Manage Fsp configurations', () => {
   });
 
   // Checking this exception in api test because it's hard to unit test the more complex transaction querybuilder part
-  it('deleting program Fsp configuration with existing transactions should set programFspConfigurationId of transactions to null', async () => {
+  it('deleting program FSP-configuration with existing transactions should set programFspConfigurationId of transactions to null', async () => {
     // Prepare
     await seedPaidRegistrations({
       registrations: [registrationOCW5],
@@ -342,7 +342,7 @@ describe('Manage Fsp configurations', () => {
     expect(transactions[0].programFspConfigurationName).toBe(null);
   });
 
-  it('should add program Fsp configuration properties to an existing program Fsp configuration', async () => {
+  it('should add program FSP-configuration properties to an existing program FSP-configuration', async () => {
     // Prepare
     const createProgramFspConfigurationDtoNoProperties = {
       ...createProgramFspConfigurationDtoIntersolveVoucher,
@@ -390,7 +390,7 @@ describe('Manage Fsp configurations', () => {
     expect(getResultConfig?.properties.sort()).toEqual(result.body.sort());
   });
 
-  it('should patch a property of an existing program Fsp configuration', async () => {
+  it('should patch a property of an existing program FSP-configuration', async () => {
     // Prepare
     const updatedPropertyDto: UpdateProgramFspConfigurationPropertyDto = {
       value: 'user1234',
@@ -437,7 +437,7 @@ describe('Manage Fsp configurations', () => {
     );
   });
 
-  it('should delete a property of an existing program Fsp configuration', async () => {
+  it('should delete a property of an existing program FSP-configuration', async () => {
     // Act
     const deleteResult = await deleteProgramFspConfigurationProperty({
       programId: programIdVisa,
@@ -466,7 +466,7 @@ describe('Manage Fsp configurations', () => {
     );
   });
 
-  it('Should return all visible properties of a program Fsp configuration', async () => {
+  it('Should return all visible properties of a program FSP-configuration', async () => {
     // Arrange
     const enumValues = Object.values(FspConfigurationProperties);
     // Act
@@ -490,7 +490,7 @@ describe('Manage Fsp configurations', () => {
     });
   });
 
-  it('Returns masked values for hidden properties of a program Fsp configuration', async () => {
+  it('Returns masked values for hidden properties of a program FSP-configuration', async () => {
     // Act
     const getHiddenProperties = await getProgramFspConfigurationProperties({
       programId: programIdVisa,
@@ -513,7 +513,7 @@ describe('Manage Fsp configurations', () => {
     });
   });
 
-  it('Should return allowlisted public properties of a program Fsp configuration for users with program.read permission', async () => {
+  it('Should return allowlisted public properties of a program FSP-configuration for users with program.read permission', async () => {
     // Arrange
     const programReadAccessToken = await createAccessTokenWithPermissions({
       permissions: [PermissionEnum.ProgramREAD],


### PR DESCRIPTION
[AB#42714](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42714)

## Describe your changes

Sidenote; It is: "a<i><b><ins>n</ins></b></i> FSP-configuration", from "an ef es pee".

See: https://www.merriam-webster.com/grammar/is-it-a-or-an#:~:text=It%27s%20About%20the%20Sound


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not change the UI/UX significantly
- [x] I have updated tests for my changes
- [x] I have made sure that all automated checks pass before requesting a review
- [ ] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [ ] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8332.westeurope.3.azurestaticapps.net
