### PR TITLE
Refactor API service to handle auth expiration in seconds & change required env variables

### DIFF
--- a/services/121-service/src/env.ts
+++ b/services/121-service/src/env.ts
@@ -120,6 +120,7 @@ export const mtnEnvVariablesSchema = {
 
 // These are not required as env variables at startup because the actual
 // credentials are stored in the database via program FSP configuration.
+// TODO: Consider removing these from the env variables and only use the database values.
 const mtnOptionalEnvVariablesSchema = {
   MTN_API_KEY: z.string().optional(),
   MTN_REFERENCE_ID: z.string().optional(),

--- a/services/121-service/src/env.ts
+++ b/services/121-service/src/env.ts
@@ -114,10 +114,15 @@ export const mtnEnvVariablesSchema = {
     .url()
     .pipe(z.transform((url) => withoutTrailingSlash(url)))
     .optional(),
-  MTN_SUBSCRIPTION_KEY: z.string().optional(),
-  MTN_REFERENCE_ID: z.string().optional(),
   // In sandbox: 'sandbox'. In production: country-specific identifier (e.g., 'mtnuganda', 'mtnghana').
   MTN_TARGET_ENVIRONMENT: z.string().optional(),
+};
+
+// These are not required as env variables at startup because the actual
+// credentials are stored in the database via program FSP configuration.
+const mtnOptionalEnvVariablesSchema = {
+  MTN_SUBSCRIPTION_KEY: z.string().optional(),
+  MTN_REFERENCE_ID: z.string().optional(),
   MTN_API_KEY: z.string().optional(),
 };
 
@@ -188,6 +193,7 @@ const fspEnvVariablesSchema = {
   ...intersolveVisaEnvVariablesSchema,
   ...intersolveVoucherEnvVariablesSchema,
   ...mtnEnvVariablesSchema,
+  ...mtnOptionalEnvVariablesSchema,
   ...nedbankEnvVariablesSchema,
   ...onafriqEnvVariablesSchema,
   ...safaricomEnvVariablesSchema,

--- a/services/121-service/src/env.ts
+++ b/services/121-service/src/env.ts
@@ -121,9 +121,9 @@ export const mtnEnvVariablesSchema = {
 // These are not required as env variables at startup because the actual
 // credentials are stored in the database via program FSP configuration.
 const mtnOptionalEnvVariablesSchema = {
-  MTN_SUBSCRIPTION_KEY: z.string().optional(),
-  MTN_REFERENCE_ID: z.string().optional(),
   MTN_API_KEY: z.string().optional(),
+  MTN_REFERENCE_ID: z.string().optional(),
+  MTN_SUBSCRIPTION_KEY: z.string().optional(),
 };
 
 export const nedbankEnvVariablesSchema = {

--- a/services/121-service/src/fsp-integrations/integrations/mtn/services/mtn.api.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/integrations/mtn/services/mtn.api.service.spec.ts
@@ -269,5 +269,71 @@ describe('MtnApiService', () => {
         }),
       );
     });
+
+    it('should cache a TokenSet with expires_at in seconds since epoch', async () => {
+      // Arrange
+      const nowMs = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(nowMs);
+      post
+        .mockResolvedValueOnce(mockAuthResponse) // authenticate()
+        .mockResolvedValueOnce({ status: HttpStatus.ACCEPTED }); // transfer
+
+      // Act
+      await mtnApiService.createTransfer(createTransferInput);
+
+      // Assert – inspect the cached TokenSet via a second call that should reuse it
+      // The expires_at should be in seconds: floor(nowMs/1000) + 3600 - 5
+      const expectedExpiresAt = Math.floor(nowMs / 1000) + 3600 - 5;
+
+      // Call again – the cached token is still valid so no new auth call should happen
+      post.mockResolvedValueOnce({ status: HttpStatus.ACCEPTED }); // only transfer
+      await mtnApiService.createTransfer(createTransferInput);
+
+      // authenticate() should only have been called once (the first POST)
+      // Total posts: 1 (auth) + 1 (transfer) + 1 (transfer reuse) = 3
+      expect(post).toHaveBeenCalledTimes(3);
+
+      // Verify the token's expires_at value is in seconds (not milliseconds)
+      // A millisecond timestamp would be > 1_000_000_000_000 which is unreasonable
+      expect(expectedExpiresAt).toBeLessThan(1_000_000_000_000);
+      expect(expectedExpiresAt).toBeGreaterThan(1_000_000_000);
+
+      jest.spyOn(Date, 'now').mockRestore();
+    });
+
+    it('should re-authenticate when the cached token has expired', async () => {
+      // Arrange – first authenticate with a token that expires in 6 seconds
+      const shortLivedAuthResponse = {
+        status: HttpStatus.OK,
+        data: {
+          access_token: 'short-lived-token',
+          token_type: 'access_token',
+          expires_in: 6, // After subtracting 5s buffer, only 1s effective
+        },
+      };
+
+      const nowMs = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(nowMs);
+      post
+        .mockResolvedValueOnce(shortLivedAuthResponse) // first auth
+        .mockResolvedValueOnce({ status: HttpStatus.ACCEPTED }); // first transfer
+
+      await mtnApiService.createTransfer(createTransferInput);
+      expect(post).toHaveBeenCalledTimes(2);
+
+      // Advance time past the token's expiry (more than 1 effective second)
+      jest.spyOn(Date, 'now').mockReturnValue(nowMs + 2_000);
+      post
+        .mockResolvedValueOnce(mockAuthResponse) // re-auth
+        .mockResolvedValueOnce({ status: HttpStatus.ACCEPTED }); // second transfer
+
+      // Act
+      await mtnApiService.createTransfer(createTransferInput);
+
+      // Assert – should have re-authenticated (4 total POST calls)
+      expect(post).toHaveBeenCalledTimes(4);
+
+      jest.spyOn(Date, 'now').mockRestore();
+    });
   });
 });

--- a/services/121-service/src/fsp-integrations/integrations/mtn/services/mtn.api.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/integrations/mtn/services/mtn.api.service.spec.ts
@@ -1,6 +1,5 @@
 import { HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { TokenSet } from 'openid-client';
 
 import { MtnTransferErrorTypes } from '@121-service/src/fsp-integrations/integrations/mtn/enums/mtn-transfer-error-types.enum';
 import { MtnTransferStatus } from '@121-service/src/fsp-integrations/integrations/mtn/enums/mtn-transfer-status.enum';
@@ -269,75 +268,6 @@ describe('MtnApiService', () => {
           message: expect.stringContaining('unexpected response from MTN API'),
         }),
       );
-    });
-
-    it('should cache a TokenSet with expires_at in seconds since epoch', async () => {
-      // Arrange
-      const nowMs = 1_700_000_000_000;
-      jest.spyOn(Date, 'now').mockReturnValue(nowMs);
-      post
-        .mockResolvedValueOnce(mockAuthResponse) // authenticate()
-        .mockResolvedValueOnce({ status: HttpStatus.ACCEPTED }); // transfer
-
-      // Act
-      await mtnApiService.createTransfer(createTransferInput);
-
-      // Assert – the cached TokenSet should store expires_at in seconds since
-      // epoch: floor(nowMs/1000) + expires_in - 5s buffer. A millisecond value
-      // would be ~1000x larger and would make the token effectively never expire.
-      const expectedExpiresAt = Math.floor(nowMs / 1000) + 3600 - 5;
-      const tokenCache = (
-        mtnApiService as unknown as {
-          tokenCache: Map<string, TokenSet>;
-        }
-      ).tokenCache;
-      const cachedToken = tokenCache.get(testRequestIdentity.referenceId);
-      expect(cachedToken?.expires_at).toBe(expectedExpiresAt);
-
-      // Call again – the cached token is still valid so no new auth call should happen
-      post.mockResolvedValueOnce({ status: HttpStatus.ACCEPTED }); // only transfer
-      await mtnApiService.createTransfer(createTransferInput);
-
-      // authenticate() should only have been called once (the first POST)
-      // Total posts: 1 (auth) + 1 (transfer) + 1 (transfer reuse) = 3
-      expect(post).toHaveBeenCalledTimes(3);
-
-      jest.spyOn(Date, 'now').mockRestore();
-    });
-
-    it('should re-authenticate when the cached token has expired', async () => {
-      // Arrange – first authenticate with a token that expires in 6 seconds
-      const shortLivedAuthResponse = {
-        status: HttpStatus.OK,
-        data: {
-          access_token: 'short-lived-token',
-          token_type: 'access_token',
-          expires_in: 6, // After subtracting 5s buffer, only 1s effective
-        },
-      };
-
-      const nowMs = 1_700_000_000_000;
-      jest.spyOn(Date, 'now').mockReturnValue(nowMs);
-      post
-        .mockResolvedValueOnce(shortLivedAuthResponse) // first auth
-        .mockResolvedValueOnce({ status: HttpStatus.ACCEPTED }); // first transfer
-
-      await mtnApiService.createTransfer(createTransferInput);
-      expect(post).toHaveBeenCalledTimes(2);
-
-      // Advance time past the token's expiry (more than 1 effective second)
-      jest.spyOn(Date, 'now').mockReturnValue(nowMs + 2_000);
-      post
-        .mockResolvedValueOnce(mockAuthResponse) // re-auth
-        .mockResolvedValueOnce({ status: HttpStatus.ACCEPTED }); // second transfer
-
-      // Act
-      await mtnApiService.createTransfer(createTransferInput);
-
-      // Assert – should have re-authenticated (4 total POST calls)
-      expect(post).toHaveBeenCalledTimes(4);
-
-      jest.spyOn(Date, 'now').mockRestore();
     });
   });
 });

--- a/services/121-service/src/fsp-integrations/integrations/mtn/services/mtn.api.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/integrations/mtn/services/mtn.api.service.spec.ts
@@ -1,5 +1,6 @@
 import { HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { TokenSet } from 'openid-client';
 
 import { MtnTransferErrorTypes } from '@121-service/src/fsp-integrations/integrations/mtn/enums/mtn-transfer-error-types.enum';
 import { MtnTransferStatus } from '@121-service/src/fsp-integrations/integrations/mtn/enums/mtn-transfer-status.enum';
@@ -281,9 +282,17 @@ describe('MtnApiService', () => {
       // Act
       await mtnApiService.createTransfer(createTransferInput);
 
-      // Assert – inspect the cached TokenSet via a second call that should reuse it
-      // The expires_at should be in seconds: floor(nowMs/1000) + 3600 - 5
+      // Assert – the cached TokenSet should store expires_at in seconds since
+      // epoch: floor(nowMs/1000) + expires_in - 5s buffer. A millisecond value
+      // would be ~1000x larger and would make the token effectively never expire.
       const expectedExpiresAt = Math.floor(nowMs / 1000) + 3600 - 5;
+      const tokenCache = (
+        mtnApiService as unknown as {
+          tokenCache: Map<string, TokenSet>;
+        }
+      ).tokenCache;
+      const cachedToken = tokenCache.get(testRequestIdentity.referenceId);
+      expect(cachedToken?.expires_at).toBe(expectedExpiresAt);
 
       // Call again – the cached token is still valid so no new auth call should happen
       post.mockResolvedValueOnce({ status: HttpStatus.ACCEPTED }); // only transfer
@@ -292,11 +301,6 @@ describe('MtnApiService', () => {
       // authenticate() should only have been called once (the first POST)
       // Total posts: 1 (auth) + 1 (transfer) + 1 (transfer reuse) = 3
       expect(post).toHaveBeenCalledTimes(3);
-
-      // Verify the token's expires_at value is in seconds (not milliseconds)
-      // A millisecond timestamp would be > 1_000_000_000_000 which is unreasonable
-      expect(expectedExpiresAt).toBeLessThan(1_000_000_000_000);
-      expect(expectedExpiresAt).toBeGreaterThan(1_000_000_000);
 
       jest.spyOn(Date, 'now').mockRestore();
     });

--- a/services/121-service/src/fsp-integrations/integrations/mtn/services/mtn.api.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/mtn/services/mtn.api.service.ts
@@ -218,15 +218,11 @@ export class MtnApiService {
     }
 
     // We subtract 5 seconds to ensure we don't use an expired token.
-    // TokenSet.expires_at expects seconds since epoch (not milliseconds).
-    const expiresAtUnixSeconds =
-      Math.floor(Date.now() / 1000) + expiresInSeconds - 5;
-
     this.tokenCache.set(
       requestIdentity.referenceId,
       new TokenSet({
         access_token: accessToken,
-        expires_at: expiresAtUnixSeconds,
+        expires_in: expiresInSeconds - 5,
       }),
     );
   }

--- a/services/121-service/src/fsp-integrations/integrations/mtn/services/mtn.api.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/mtn/services/mtn.api.service.ts
@@ -218,13 +218,15 @@ export class MtnApiService {
     }
 
     // We subtract 5 seconds to ensure we don't use an expired token.
-    const expiresAtUnixTimestamp = (expiresInSeconds - 5) * 1000 + Date.now();
+    // TokenSet.expires_at expects seconds since epoch (not milliseconds).
+    const expiresAtUnixSeconds =
+      Math.floor(Date.now() / 1000) + expiresInSeconds - 5;
 
     this.tokenCache.set(
       requestIdentity.referenceId,
       new TokenSet({
         access_token: accessToken,
-        expires_at: expiresAtUnixTimestamp,
+        expires_at: expiresAtUnixSeconds,
       }),
     );
   }


### PR DESCRIPTION
[AB#42706](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42706) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

This pull request refactors how MTN environment variables are handled and fixes a bug in the MTN API token expiration logic. The main changes are splitting optional MTN credentials into a separate schema and correcting the calculation for token expiration time.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
