### PR TITLE
Adding text wrap on select to stop it from breaking

### DIFF
--- a/interfaces/portal/src/styles.css
+++ b/interfaces/portal/src/styles.css
@@ -344,12 +344,20 @@ svg-icon svg {
     }
   }
 
+  /* Prevent contents being cut off, always wrap and align checkboxes to the top */
+
+  .p-select {
+    .p-select-option {
+      @apply items-start text-wrap;
+    }
+  }
+
   .p-multiselect {
-    /* Prevent contents being cut off, always wrap and align checkboxes to the top */
     .p-multiselect-option {
       @apply items-start text-wrap;
     }
   }
+
   /* To be able to remove this rule we need to be able to mark all form fields as "dirty" instead of "touched" on form submit
      Waiting for this to be merged & released in angular: https://github.com/angular/angular/pull/58663#issuecomment-2476844180 */
   .p-inputwrapper,

--- a/interfaces/portal/src/styles.css
+++ b/interfaces/portal/src/styles.css
@@ -344,13 +344,15 @@ svg-icon svg {
     }
   }
 
-  /* Prevent contents being cut off, always wrap and align checkboxes to the top */
+  /* Prevent contents being cut off */
 
   .p-select {
     .p-select-option {
       @apply items-start text-wrap;
     }
   }
+
+  /* Prevent contents being cut off, always wrap and align checkboxes to the top */
 
   .p-multiselect {
     .p-multiselect-option {


### PR DESCRIPTION
[AB#42758](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42758)

Parent [AB#42089](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42089)

## Describe your changes

Added text wrap on select option to stop it from breaking

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8348.westeurope.3.azurestaticapps.net
