### PR TITLE
chore: create fsp config states

### DIFF
--- a/services/121-service/src/migration/1781789936149-add-fsp-configuration-state.ts
+++ b/services/121-service/src/migration/1781789936149-add-fsp-configuration-state.ts
@@ -5,16 +5,13 @@ export class AddFspConfigurationState1781789936149 implements MigrationInterface
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "121-service"."program_fsp_configuration" ADD "fspIntegrationState" character varying`,
+      `ALTER TABLE "121-service"."program_fsp_configuration" ADD "state" character varying`,
     );
     await queryRunner.query(
-      `UPDATE "121-service"."program_fsp_configuration" SET "fspIntegrationState" = 'integrated'`,
+      `UPDATE "121-service"."program_fsp_configuration" SET "state" = 'configured'`,
     );
     await queryRunner.query(
-      `ALTER TABLE "121-service"."program_fsp_configuration" ALTER COLUMN "fspIntegrationState" SET NOT NULL`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "121-service"."program_fsp_configuration" ALTER COLUMN "fspIntegrationState" SET DEFAULT 'not-integrated'`,
+      `ALTER TABLE "121-service"."program_fsp_configuration" ALTER COLUMN "state" SET NOT NULL`,
     );
   }
 

--- a/services/121-service/src/migration/1781789936149-add-fsp-configuration-state.ts
+++ b/services/121-service/src/migration/1781789936149-add-fsp-configuration-state.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddFspConfigurationState1781789936149 implements MigrationInterface {
+  name = 'AddFspConfigurationState1781789936149';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "121-service"."program_fsp_configuration" ADD "fspIntegrationState" character varying`,
+    );
+    await queryRunner.query(
+      `UPDATE "121-service"."program_fsp_configuration" SET "fspIntegrationState" = 'integrated'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "121-service"."program_fsp_configuration" ALTER COLUMN "fspIntegrationState" SET NOT NULL`,
+    );
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    console.log('Do we go down? No, the only way is up');
+  }
+}

--- a/services/121-service/src/migration/1781789936149-add-fsp-configuration-state.ts
+++ b/services/121-service/src/migration/1781789936149-add-fsp-configuration-state.ts
@@ -13,6 +13,9 @@ export class AddFspConfigurationState1781789936149 implements MigrationInterface
     await queryRunner.query(
       `ALTER TABLE "121-service"."program_fsp_configuration" ALTER COLUMN "fspIntegrationState" SET NOT NULL`,
     );
+    await queryRunner.query(
+      `ALTER TABLE "121-service"."program_fsp_configuration" ALTER COLUMN "fspIntegrationState" SET DEFAULT 'not-integrated'`,
+    );
   }
 
   public async down(_queryRunner: QueryRunner): Promise<void> {

--- a/services/121-service/src/program-fsp-configurations/entities/program-fsp-configuration.entity.ts
+++ b/services/121-service/src/program-fsp-configurations/entities/program-fsp-configuration.entity.ts
@@ -12,7 +12,7 @@ import { Base121Entity } from '@121-service/src/base.entity';
 import { Fsps } from '@121-service/src/fsp-integrations/shared/enum/fsp-name.enum';
 import { TransactionEventEntity } from '@121-service/src/payments/transactions/transaction-events/entities/transaction-event.entity';
 import { ProgramFspConfigurationPropertyEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration-property.entity';
-import { FspIntegrationStates } from '@121-service/src/program-fsp-configurations/enum/fsp-integration-states.enum';
+import { FspConfigurationStates } from '@121-service/src/program-fsp-configurations/enum/fsp-configuration-states.enum';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { UILanguageTranslation } from '@121-service/src/shared/types/ui-language-translation.type';
@@ -38,8 +38,8 @@ export class ProgramFspConfigurationEntity extends Base121Entity {
   @Column('json')
   public label: UILanguageTranslation;
 
-  @Column({ type: 'character varying', default: FspIntegrationStates.NotIntegrated })
-  public fspIntegrationState: FspIntegrationStates;
+  @Column({ type: 'character varying' })
+  public state: FspConfigurationStates;
 
   @OneToMany(
     (_type) => ProgramFspConfigurationPropertyEntity,

--- a/services/121-service/src/program-fsp-configurations/entities/program-fsp-configuration.entity.ts
+++ b/services/121-service/src/program-fsp-configurations/entities/program-fsp-configuration.entity.ts
@@ -38,7 +38,7 @@ export class ProgramFspConfigurationEntity extends Base121Entity {
   @Column('json')
   public label: UILanguageTranslation;
 
-  @Column({ type: 'character varying' })
+  @Column({ type: 'character varying', default: FspIntegrationStates.NotIntegrated })
   public fspIntegrationState: FspIntegrationStates;
 
   @OneToMany(

--- a/services/121-service/src/program-fsp-configurations/entities/program-fsp-configuration.entity.ts
+++ b/services/121-service/src/program-fsp-configurations/entities/program-fsp-configuration.entity.ts
@@ -12,6 +12,7 @@ import { Base121Entity } from '@121-service/src/base.entity';
 import { Fsps } from '@121-service/src/fsp-integrations/shared/enum/fsp-name.enum';
 import { TransactionEventEntity } from '@121-service/src/payments/transactions/transaction-events/entities/transaction-event.entity';
 import { ProgramFspConfigurationPropertyEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration-property.entity';
+import { FspIntegrationStates } from '@121-service/src/program-fsp-configurations/enum/fsp-integration-states.enum';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { UILanguageTranslation } from '@121-service/src/shared/types/ui-language-translation.type';
@@ -36,6 +37,9 @@ export class ProgramFspConfigurationEntity extends Base121Entity {
 
   @Column('json')
   public label: UILanguageTranslation;
+
+  @Column({ type: 'character varying' })
+  public fspIntegrationState: FspIntegrationStates;
 
   @OneToMany(
     (_type) => ProgramFspConfigurationPropertyEntity,

--- a/services/121-service/src/program-fsp-configurations/enum/fsp-configuration-states.enum.ts
+++ b/services/121-service/src/program-fsp-configurations/enum/fsp-configuration-states.enum.ts
@@ -1,0 +1,4 @@
+export enum FspConfigurationStates {
+  configured = 'configured',
+  configurationPending = 'configuration-pending',
+}

--- a/services/121-service/src/program-fsp-configurations/enum/fsp-integration-states.enum.ts
+++ b/services/121-service/src/program-fsp-configurations/enum/fsp-integration-states.enum.ts
@@ -1,5 +1,0 @@
-export enum FspIntegrationStates {
-  Integrated = 'integrated',
-  IntegrationPending = 'integration-pending',
-  NotIntegrated = 'not-integrated',
-}

--- a/services/121-service/src/program-fsp-configurations/enum/fsp-integration-states.enum.ts
+++ b/services/121-service/src/program-fsp-configurations/enum/fsp-integration-states.enum.ts
@@ -1,4 +1,5 @@
 export enum FspIntegrationStates {
   Integrated = 'integrated',
   IntegrationPending = 'integration-pending',
+  NotIntegrated = 'not-integrated',
 }

--- a/services/121-service/src/program-fsp-configurations/enum/fsp-integration-states.enum.ts
+++ b/services/121-service/src/program-fsp-configurations/enum/fsp-integration-states.enum.ts
@@ -1,0 +1,4 @@
+export enum FspIntegrationStates {
+  Integrated = 'integrated',
+  IntegrationPending = 'integration-pending',
+}

--- a/services/121-service/src/program-fsp-configurations/mappers/program-fsp-configuration.mapper.spec.ts
+++ b/services/121-service/src/program-fsp-configurations/mappers/program-fsp-configuration.mapper.spec.ts
@@ -5,6 +5,7 @@ import { CreateProgramFspConfigurationDto } from '@121-service/src/program-fsp-c
 import { CreateProgramFspConfigurationPropertyDto } from '@121-service/src/program-fsp-configurations/dtos/create-program-fsp-configuration-property.dto';
 import { ProgramFspConfigurationEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration.entity';
 import { ProgramFspConfigurationPropertyEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration-property.entity';
+import { FspIntegrationStates } from '@121-service/src/program-fsp-configurations/enum/fsp-integration-states.enum';
 import { ProgramFspConfigurationMapper } from '@121-service/src/program-fsp-configurations/mappers/program-fsp-configuration.mapper';
 
 describe('ProgramFspConfigurationMapper', () => {
@@ -104,6 +105,7 @@ describe('ProgramFspConfigurationMapper', () => {
       expect(entity.fspName).toBe(dto.fspName);
       expect(entity.name).toBe(dto.name);
       expect(entity.label).toEqual(dto.label);
+      expect(entity.fspIntegrationState).toBe(FspIntegrationStates.IntegrationPending);
     });
   });
 

--- a/services/121-service/src/program-fsp-configurations/mappers/program-fsp-configuration.mapper.spec.ts
+++ b/services/121-service/src/program-fsp-configurations/mappers/program-fsp-configuration.mapper.spec.ts
@@ -5,7 +5,7 @@ import { CreateProgramFspConfigurationDto } from '@121-service/src/program-fsp-c
 import { CreateProgramFspConfigurationPropertyDto } from '@121-service/src/program-fsp-configurations/dtos/create-program-fsp-configuration-property.dto';
 import { ProgramFspConfigurationEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration.entity';
 import { ProgramFspConfigurationPropertyEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration-property.entity';
-import { FspIntegrationStates } from '@121-service/src/program-fsp-configurations/enum/fsp-integration-states.enum';
+import { FspConfigurationStates } from '@121-service/src/program-fsp-configurations/enum/fsp-configuration-states.enum';
 import { ProgramFspConfigurationMapper } from '@121-service/src/program-fsp-configurations/mappers/program-fsp-configuration.mapper';
 
 describe('ProgramFspConfigurationMapper', () => {
@@ -105,7 +105,7 @@ describe('ProgramFspConfigurationMapper', () => {
       expect(entity.fspName).toBe(dto.fspName);
       expect(entity.name).toBe(dto.name);
       expect(entity.label).toEqual(dto.label);
-      expect(entity.fspIntegrationState).toBe(FspIntegrationStates.IntegrationPending);
+      expect(entity.state).toBe(FspConfigurationStates.configured);
     });
   });
 

--- a/services/121-service/src/program-fsp-configurations/mappers/program-fsp-configuration.mapper.ts
+++ b/services/121-service/src/program-fsp-configurations/mappers/program-fsp-configuration.mapper.ts
@@ -10,6 +10,7 @@ import { ProgramFspConfigurationPropertyResponseDto } from '@121-service/src/pro
 import { ProgramFspConfigurationResponseDto } from '@121-service/src/program-fsp-configurations/dtos/program-fsp-configuration-response.dto';
 import { ProgramFspConfigurationEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration.entity';
 import { ProgramFspConfigurationPropertyEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration-property.entity';
+import { FspIntegrationStates } from '@121-service/src/program-fsp-configurations/enum/fsp-integration-states.enum';
 
 export class ProgramFspConfigurationMapper {
   public static mapEntitiesToDtos(
@@ -52,6 +53,7 @@ export class ProgramFspConfigurationMapper {
     entity.fspName = dto.fspName;
     entity.name = dto.name;
     entity.label = dto.label;
+    entity.fspIntegrationState = FspIntegrationStates.IntegrationPending;
     return entity;
   }
 

--- a/services/121-service/src/program-fsp-configurations/mappers/program-fsp-configuration.mapper.ts
+++ b/services/121-service/src/program-fsp-configurations/mappers/program-fsp-configuration.mapper.ts
@@ -10,7 +10,7 @@ import { ProgramFspConfigurationPropertyResponseDto } from '@121-service/src/pro
 import { ProgramFspConfigurationResponseDto } from '@121-service/src/program-fsp-configurations/dtos/program-fsp-configuration-response.dto';
 import { ProgramFspConfigurationEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration.entity';
 import { ProgramFspConfigurationPropertyEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration-property.entity';
-import { FspIntegrationStates } from '@121-service/src/program-fsp-configurations/enum/fsp-integration-states.enum';
+import { FspConfigurationStates } from '@121-service/src/program-fsp-configurations/enum/fsp-configuration-states.enum';
 
 export class ProgramFspConfigurationMapper {
   public static mapEntitiesToDtos(
@@ -53,7 +53,7 @@ export class ProgramFspConfigurationMapper {
     entity.fspName = dto.fspName;
     entity.name = dto.name;
     entity.label = dto.label;
-    entity.fspIntegrationState = FspIntegrationStates.IntegrationPending;
+    entity.state = FspConfigurationStates.configured;
     return entity;
   }
 

--- a/services/121-service/src/scripts/services/seed-helper.service.ts
+++ b/services/121-service/src/scripts/services/seed-helper.service.ts
@@ -18,7 +18,7 @@ import { MessageTemplateEntity } from '@121-service/src/notifications/message-te
 import { MessageTemplateService } from '@121-service/src/notifications/message-template/message-template.service';
 import { ProgramFspConfigurationEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration.entity';
 import { ProgramFspConfigurationPropertyEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration-property.entity';
-import { FspIntegrationStates } from '@121-service/src/program-fsp-configurations/enum/fsp-integration-states.enum';
+import { FspConfigurationStates } from '@121-service/src/program-fsp-configurations/enum/fsp-configuration-states.enum';
 import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/entities/program-registration-attribute.entity';
@@ -449,7 +449,7 @@ export class SeedHelperService {
       : fspObject.name;
     fspConfigEntity.transactionEvents = [];
     fspConfigEntity.programId = programId;
-    fspConfigEntity.fspIntegrationState = FspIntegrationStates.Integrated;
+    fspConfigEntity.state = FspConfigurationStates.configured;
     return fspConfigEntity;
   }
 

--- a/services/121-service/src/scripts/services/seed-helper.service.ts
+++ b/services/121-service/src/scripts/services/seed-helper.service.ts
@@ -18,6 +18,7 @@ import { MessageTemplateEntity } from '@121-service/src/notifications/message-te
 import { MessageTemplateService } from '@121-service/src/notifications/message-template/message-template.service';
 import { ProgramFspConfigurationEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration.entity';
 import { ProgramFspConfigurationPropertyEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration-property.entity';
+import { FspIntegrationStates } from '@121-service/src/program-fsp-configurations/enum/fsp-integration-states.enum';
 import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/entities/program-registration-attribute.entity';
@@ -448,6 +449,7 @@ export class SeedHelperService {
       : fspObject.name;
     fspConfigEntity.transactionEvents = [];
     fspConfigEntity.programId = programId;
+    fspConfigEntity.fspIntegrationState = FspIntegrationStates.Integrated;
     return fspConfigEntity;
   }
 


### PR DESCRIPTION
[AB#42821](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42821) <!--- Replace this with a reference to a DevOps/backlog-issue -->

- Added fsp configuration states and migration
- Backfill existing rows to "integrated"
- Defaults to "not integrated"
- Sets to "pending" on config creation

**Note**
This can be merged, since having a state doesn't "mean" anything yet.

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
