### PR TITLE
Eslint rule never throw 500 http exception

### DIFF
--- a/services/121-service/eslint-custom-rules/no-internal-server-error-http-exception.mjs
+++ b/services/121-service/eslint-custom-rules/no-internal-server-error-http-exception.mjs
@@ -25,6 +25,20 @@ export default {
     },
   },
   create(context) {
+    function getClassName(node) {
+      if (node.type === 'Identifier') {
+        return node.name;
+      }
+      if (
+        node.type === 'MemberExpression' &&
+        !node.computed &&
+        node.property.type === 'Identifier'
+      ) {
+        return node.property.name;
+      }
+      return null;
+    }
+
     function isInternalServerErrorStatus(node) {
       if (!node) {
         return false;
@@ -35,10 +49,9 @@ export default {
       if (
         node.type === 'MemberExpression' &&
         !node.computed &&
-        node.object.type === 'Identifier' &&
-        node.object.name === 'HttpStatus' &&
         node.property.type === 'Identifier' &&
-        node.property.name === 'INTERNAL_SERVER_ERROR'
+        node.property.name === 'INTERNAL_SERVER_ERROR' &&
+        getClassName(node.object) === 'HttpStatus'
       ) {
         return true;
       }
@@ -51,12 +64,12 @@ export default {
         if (!argument || argument.type !== 'NewExpression') {
           return;
         }
-        const callee = argument.callee;
-        if (callee.type !== 'Identifier') {
+        const className = getClassName(argument.callee);
+        if (!className) {
           return;
         }
 
-        if (callee.name === 'InternalServerErrorException') {
+        if (className === 'InternalServerErrorException') {
           context.report({
             node: argument,
             messageId: 'noInternalServerErrorException',
@@ -65,7 +78,7 @@ export default {
         }
 
         if (
-          callee.name === 'HttpException' &&
+          className === 'HttpException' &&
           isInternalServerErrorStatus(argument.arguments[1])
         ) {
           context.report({

--- a/services/121-service/eslint-custom-rules/no-internal-server-error-http-exception.mjs
+++ b/services/121-service/eslint-custom-rules/no-internal-server-error-http-exception.mjs
@@ -1,0 +1,79 @@
+/**
+ * Disallow throwing `HttpException` with status 500 / `HttpStatus.INTERNAL_SERVER_ERROR`,
+ * and `InternalServerErrorException`.
+ *
+ * Throwing one of these turns an unexpected failure into a "handled" HTTP response,
+ * which suppresses the stacktrace in our logs. Throwing a regular `Error` instead lets
+ * Nest's default exception filter log it with a full stacktrace, so we can actually
+ * diagnose the problem in production.
+ */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow throwing HttpException with status 500 or InternalServerErrorException; throw a regular Error instead so the stacktrace is logged.',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      noHttpException500:
+        'Do not throw HttpException with status 500. Throw a regular Error instead, so the stacktrace is logged.',
+      noInternalServerErrorException:
+        'Do not throw InternalServerErrorException. Throw a regular Error instead, so the stacktrace is logged.',
+    },
+  },
+  create(context) {
+    function isInternalServerErrorStatus(node) {
+      if (!node) {
+        return false;
+      }
+      if (node.type === 'Literal' && node.value === 500) {
+        return true;
+      }
+      if (
+        node.type === 'MemberExpression' &&
+        !node.computed &&
+        node.object.type === 'Identifier' &&
+        node.object.name === 'HttpStatus' &&
+        node.property.type === 'Identifier' &&
+        node.property.name === 'INTERNAL_SERVER_ERROR'
+      ) {
+        return true;
+      }
+      return false;
+    }
+
+    return {
+      ThrowStatement(node) {
+        const argument = node.argument;
+        if (!argument || argument.type !== 'NewExpression') {
+          return;
+        }
+        const callee = argument.callee;
+        if (callee.type !== 'Identifier') {
+          return;
+        }
+
+        if (callee.name === 'InternalServerErrorException') {
+          context.report({
+            node: argument,
+            messageId: 'noInternalServerErrorException',
+          });
+          return;
+        }
+
+        if (
+          callee.name === 'HttpException' &&
+          isInternalServerErrorStatus(argument.arguments[1])
+        ) {
+          context.report({
+            node: argument,
+            messageId: 'noHttpException500',
+          });
+        }
+      },
+    };
+  },
+};

--- a/services/121-service/eslint.config.mjs
+++ b/services/121-service/eslint.config.mjs
@@ -5,6 +5,7 @@ import eslintPluginNoRelativePaths from 'eslint-plugin-no-relative-import-paths'
 import tsEslint from 'typescript-eslint';
 
 import controllerAuthenticatedUser from './eslint-custom-rules/controller-authenticated-user.mjs';
+import noInternalServerErrorHttpException from './eslint-custom-rules/no-internal-server-error-http-exception.mjs';
 import noMethodApiTags from './eslint-custom-rules/no-method-api-tags.mjs';
 import typeormCascadeOndelete from './eslint-custom-rules/typeorm-cascade-ondelete.mjs';
 
@@ -14,6 +15,8 @@ const customRulesPlugin = {
     'typeorm-cascade-ondelete': typeormCascadeOndelete,
     'no-method-api-tags': noMethodApiTags,
     'controller-authenticated-user': controllerAuthenticatedUser,
+    'no-internal-server-error-http-exception':
+      noInternalServerErrorHttpException,
   },
 };
 
@@ -107,6 +110,17 @@ export default defineConfig(
     },
     rules: {
       'custom-rules/typeorm-cascade-ondelete': 'error',
+    },
+  },
+  {
+    name: 'Source files - no 500 HttpException',
+    files: ['src/**/*.ts'],
+    ignores: ['**/*.spec.ts', '**/*.test.ts'],
+    plugins: {
+      'custom-rules': customRulesPlugin,
+    },
+    rules: {
+      'custom-rules/no-internal-server-error-http-exception': 'error',
     },
   },
   {

--- a/services/121-service/src/fsp-integrations/account-management/intersolve-visa/intersolve-visa-account-management.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/account-management/intersolve-visa/intersolve-visa-account-management.service.spec.ts
@@ -517,14 +517,15 @@ describe('IntersolveVisaAccountManagementService', () => {
     });
 
     it('throws when persisting the order record fails', async () => {
-      cardOrderRepository.save.mockRejectedValue(new Error('db down'));
+      const dbError = new Error('db down');
+      cardOrderRepository.save.mockRejectedValue(dbError);
 
       await expect(
         service.createVisaCardOrder(buildOrderInput()),
       ).rejects.toMatchObject({
         message:
           'Cards were ordered, but saving the batch record failed. Please contact support for reconciliation.',
-        status: HttpStatus.INTERNAL_SERVER_ERROR,
+        cause: dbError,
       });
     });
 

--- a/services/121-service/src/fsp-integrations/account-management/intersolve-visa/intersolve-visa-account-management.service.ts
+++ b/services/121-service/src/fsp-integrations/account-management/intersolve-visa/intersolve-visa-account-management.service.ts
@@ -28,7 +28,6 @@ import { RegistrationsService } from '@121-service/src/registration/services/reg
 
 @Injectable()
 export class IntersolveVisaAccountManagementService {
-
   public constructor(
     private readonly intersolveVisaService: IntersolveVisaService,
     private readonly programFspConfigurationRepository: ProgramFspConfigurationRepository,
@@ -605,9 +604,8 @@ export class IntersolveVisaAccountManagementService {
     try {
       await this.cardOrderRepository.save(order);
     } catch (error) {
-      throw new HttpException(
+      throw new Error(
         'Cards were ordered, but saving the batch record failed. Please contact support for reconciliation.',
-        HttpStatus.INTERNAL_SERVER_ERROR,
         { cause: error },
       );
     }

--- a/services/121-service/src/fsp-integrations/reconciliation/safaricom/safaricom-reconciliation.service.ts
+++ b/services/121-service/src/fsp-integrations/reconciliation/safaricom/safaricom-reconciliation.service.ts
@@ -1,9 +1,4 @@
-import {
-  Inject,
-  Injectable,
-  InternalServerErrorException,
-  NotFoundException,
-} from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { Redis } from 'ioredis';
 
 import { SafaricomTransferScopedRepository } from '@121-service/src/fsp-integrations/integrations/safaricom/repositories/safaricom-transfer.scoped.repository';
@@ -135,7 +130,7 @@ export class SafaricomReconciliationService {
     } catch (error) {
       // This should never happen. This way, if it happens, we receive an alert
       if (error instanceof NotFoundException) {
-        throw new InternalServerErrorException(error.message);
+        throw new Error(error.message);
       }
 
       throw error;

--- a/services/121-service/src/programs/programs.service.ts
+++ b/services/121-service/src/programs/programs.service.ts
@@ -257,16 +257,7 @@ export class ProgramService {
       program[key] = updateProgramDto[key];
     }
 
-    let savedProgram: ProgramEntity;
-    try {
-      savedProgram = await this.programRepository.save(program);
-    } catch (err) {
-      console.log('Error updating program ', err);
-      throw new HttpException(
-        'Error updating program',
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+    const savedProgram = await this.programRepository.save(program);
 
     const programDto: ProgramReturnDto =
       this.fillProgramReturnDto(savedProgram);

--- a/services/121-service/src/validation-options/validation-pipe-options.const.ts
+++ b/services/121-service/src/validation-options/validation-pipe-options.const.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, HttpException, HttpStatus } from '@nestjs/common';
+import { BadRequestException } from '@nestjs/common';
 
 export const ValidationPipeOptions = {
   whitelist: true,
@@ -7,8 +7,7 @@ export const ValidationPipeOptions = {
   exceptionFactory: (errors) => {
     for (const e of errors) {
       if (e.constraints && e.constraints['unknownValue']) {
-        console.log('e: ', e);
-        throw new HttpException(e, HttpStatus.INTERNAL_SERVER_ERROR);
+        throw new Error(`Unknown validation value: ${JSON.stringify(e)}`);
       }
     }
     throw new BadRequestException(errors);


### PR DESCRIPTION
[AB#42833](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42833) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Custom ESLint rule to prevent throwing HttpException with status 500.

Why?
-  Prevent keeping unexpected failures “unhandled” so NestJS logs full stacktraces.
- HttpException do not trigger the automated internal server error alerts we setup

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
