### PR TITLE
Adding kobo error dialog for refresh errors response

### DIFF
--- a/e2e/portal/pages/RegistrationDataPage.ts
+++ b/e2e/portal/pages/RegistrationDataPage.ts
@@ -269,9 +269,7 @@ class RegistrationDataPage extends BasePage {
 
   async validateErrorDialogIsShown() {
     const koboIntegrationDialog = new DialogComponent(
-      this.page
-        .getByTestId('kobo-integration-error-dialog')
-        .locator('.p-dialog'),
+      this.page.getByTestId('kobo-error-dialog').locator('.p-dialog'),
     );
     await koboIntegrationDialog.waitForVisible();
   }

--- a/e2e/portal/tests/ProgramSettings/RegistrationData/RefreshKoboIntegration.spec.ts
+++ b/e2e/portal/tests/ProgramSettings/RegistrationData/RefreshKoboIntegration.spec.ts
@@ -105,3 +105,75 @@ test('Refresh Kobo integration - unsuccessful', async ({
     );
   });
 });
+
+test('Refresh Kobo integration - unsuccessful with error payload', async ({
+  registrationDataPage,
+  page,
+}) => {
+  await test.step('Add Kobo integration with always-new-version asset', async () => {
+    await registrationDataPage.addKoboIntegration({
+      url: alwaysNewVersionUrl,
+      apiKey: koboIntegrationBase.apiKey,
+    });
+    await registrationDataPage.koboSuccessfullyLinkedDialog({
+      closeDialog: true,
+    });
+  });
+
+  await test.step('Intercept PATCH /kobo to simulate a validation error response', async () => {
+    await page.route(`**/api/programs/*/kobo`, async (route) => {
+      if (route.request().method() === 'PATCH') {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify(koboRefreshErrorPayload),
+        });
+        return;
+      }
+      await route.continue();
+    });
+  });
+
+  await test.step('Click "Refresh link" from the ellipsis menu', async () => {
+    await registrationDataPage.refreshKoboIntegration();
+  });
+
+  await test.step('Validate error dialog for Kobo integration failure', async () => {
+    await registrationDataPage.validateToastMessage(
+      'Integration update unsuccessful. Please try again.',
+    );
+
+    await registrationDataPage.validateErrorDialogIsShown();
+
+    await registrationDataPage.validateMissingFields({
+      missingFields: ['phoneNumber'],
+    });
+
+    await registrationDataPage.validateKoboConfigurationErrorsTable({
+      configurationErrorsTableColumns: ['Field', 'Error', 'Solution'],
+      configurationErrors: [
+        'fullName',
+        "Attribute 'fullName' is missing",
+        'Add the missing attribute to the Kobo form',
+      ],
+    });
+  });
+});
+
+const koboRefreshErrorPayload = {
+  message: 'Kobo form definition validation failed',
+  errors: [
+    {
+      type: 'missingField',
+      attributeName: 'phoneNumber',
+      error: "Attribute 'phoneNumber' is missing",
+      solution: "Add 'phoneNumber' to the Kobo form",
+    },
+    {
+      type: 'missingFullnameAttributes',
+      attributeName: 'fullName',
+      error: "Attribute 'fullName' is missing",
+      solution: 'Add the missing attribute to the Kobo form',
+    },
+  ],
+};

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-configuration-dialog/kobo-configuration-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-configuration-dialog/kobo-configuration-dialog.component.html
@@ -128,7 +128,7 @@
 />
 
 <app-kobo-error-dialog
-  #koboIntegrationErrorDialog
+  #koboErrorDialog
   [errors]="koboIntegrationErrors()"
   (tryAgain)="koboConfigurationDialog.show()"
 />

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-configuration-dialog/kobo-configuration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-configuration-dialog/kobo-configuration-dialog.component.ts
@@ -51,6 +51,7 @@ import { generateFieldErrors } from '~/utils/form-validation';
 })
 export class KoboConfigurationDialogComponent {
   readonly programId = input.required<number | string>();
+  readonly isKoboIntegrated = input<boolean>();
   readonly koboIntegrationErrors = signal<KoboValidationError[]>([]);
 
   private readonly koboApiService = inject(KoboApiService);
@@ -63,9 +64,8 @@ export class KoboConfigurationDialogComponent {
     'koboConfigurationDialog',
   );
 
-  readonly koboErrorDialog = viewChild.required<KoboErrorDialogComponent>(
-    'koboIntegrationErrorDialog',
-  );
+  readonly koboErrorDialog =
+    viewChild.required<KoboErrorDialogComponent>('koboErrorDialog');
 
   readonly linkKoboDialog =
     viewChild.required<FormDialogComponent>('linkKoboDialog');

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-configuration-dialog/kobo-configuration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-configuration-dialog/kobo-configuration-dialog.component.ts
@@ -51,7 +51,6 @@ import { generateFieldErrors } from '~/utils/form-validation';
 })
 export class KoboConfigurationDialogComponent {
   readonly programId = input.required<number | string>();
-  readonly isKoboIntegrated = input<boolean>();
   readonly koboIntegrationErrors = signal<KoboValidationError[]>([]);
 
   private readonly koboApiService = inject(KoboApiService);

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-error-dialog/kobo-error-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-error-dialog/kobo-error-dialog.component.html
@@ -3,18 +3,17 @@
   [closeOnEscape]="false"
   [(visible)]="dialogVisible"
   styleClass="max-w-[70rem] sm:min-w-[60rem]"
-  [attr.data-testid]="'kobo-integration-error-dialog'"
+  [attr.data-testid]="'kobo-error-dialog'"
 >
   <ng-template #header>
     <h3>
       <i class="pi pi-exclamation-triangle me-2"></i>
-      <ng-container i18n>Kobo form integration errors</ng-container>
+      {{ modalText().title }}
     </h3>
   </ng-template>
 
-  <p i18n>
-    There are issues in your Kobo form that are blocking the integration. Fix
-    the errors below in Kobo, then save, redeploy, and try again.
+  <p>
+    {{ modalText().message }}
   </p>
 
   @if (missingFieldErrors().length > 0) {
@@ -23,6 +22,7 @@
         <h4 class="text-base! font-semibold">
           <span i18n>Required fields not found</span>
           <app-info-tooltip
+            class="ms-1"
             message="These fields are expected by 121 but are missing from your Kobo form. Add them before redeploying."
             i18n-message
           />
@@ -55,6 +55,7 @@
         <h4 class="text-base! font-semibold">
           <span i18n>Form setting errors</span>
           <app-info-tooltip
+            class="ms-1"
             message="These are the errors related to your Kobo form settings."
             i18n-message
           />
@@ -69,7 +70,10 @@
           <li>
             {{ error.error }}, {{ error.solution }}
             @if (error.info) {
-              <app-info-tooltip message="{{ error.info }}" />
+              <app-info-tooltip
+                class="ms-1"
+                message="{{ error.info }}"
+              />
             }
           </li>
         }
@@ -131,7 +135,10 @@
             <td class="px-2">
               {{ error.solution }}
               @if (error.info) {
-                <app-info-tooltip message="{{ error.info }}" />
+                <app-info-tooltip
+                  class="ms-1"
+                  message="{{ error.info }}"
+                />
               }
             </td>
           </tr>
@@ -141,19 +148,28 @@
   }
 
   <div class="mt-5 flex justify-end gap-4">
-    <p-button
-      label="Cancel"
-      i18n-label="@@generic-cancel"
-      (click)="dialogVisible.set(false)"
-      outlined
-      rounded
-      severity="contrast"
-    />
-    <p-button
-      rounded
-      label="Try again"
-      i18n-label="@@generic-try-again"
-      (click)="handleTryAgainClick()"
-    />
+    @if (!isKoboIntegrated()) {
+      <p-button
+        label="Cancel"
+        i18n-label="@@generic-cancel"
+        (click)="dialogVisible.set(false)"
+        outlined
+        rounded
+        severity="contrast"
+      />
+      <p-button
+        rounded
+        label="Try again"
+        i18n-label="@@generic-try-again"
+        (click)="handleTryAgainClick()"
+      />
+    } @else {
+      <p-button
+        rounded
+        label="Close"
+        i18n-label="@@generic-close"
+        (click)="dialogVisible.set(false)"
+      />
+    }
   </div>
 </p-dialog>

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-error-dialog/kobo-error-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-error-dialog/kobo-error-dialog.component.ts
@@ -54,6 +54,17 @@ export class KoboErrorDialogComponent {
   readonly dialogVisible = model(false);
   readonly tryAgain = output();
 
+  readonly isKoboIntegrated = input<boolean>();
+
+  readonly modalText = computed(() => ({
+    title: this.isKoboIntegrated()
+      ? $localize`Kobo form refresh errors`
+      : $localize`Kobo form integration errors`,
+    message: this.isKoboIntegrated()
+      ? $localize`There are issues in your Kobo form that are blocking the refresh. Fix the errors below in Kobo, then save, redeploy, and try again.`
+      : $localize`There are issues in your Kobo form that are blocking the integration. Fix the errors below in Kobo, then save, redeploy, and try again.`,
+  }));
+
   readonly errorTable = computed(() => {
     return this.errors().filter(
       (error) =>

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.html
@@ -49,9 +49,16 @@
 <app-kobo-configuration-dialog
   #koboConfigurationDialog
   [programId]="programId()"
+  [isKoboIntegrated]="isKoboIntegrated()"
 />
 
 <app-kobo-import-existing-registration-dialog
   #koboImportExistingDialog
   [programId]="programId()"
+/>
+
+<app-kobo-error-dialog
+  #koboErrorDialog
+  [errors]="koboRefreshErrors()"
+  [isKoboIntegrated]="isKoboIntegrated()"
 />

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.html
@@ -49,7 +49,6 @@
 <app-kobo-configuration-dialog
   #koboConfigurationDialog
   [programId]="programId()"
-  [isKoboIntegrated]="isKoboIntegrated()"
 />
 
 <app-kobo-import-existing-registration-dialog

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.ts
@@ -127,7 +127,7 @@ export class KoboIntegrationCardComponent {
 
       this.toastService.showToast({
         severity: 'error',
-        detail: $localize`Kobo refresh unsuccessful`,
+        detail: $localize`Integration update unsuccessful. Please try again.`,
       });
     },
   }));

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-integration-card/kobo-integration-card.component.ts
@@ -5,6 +5,7 @@ import {
   computed,
   inject,
   input,
+  signal,
   viewChild,
 } from '@angular/core';
 
@@ -14,6 +15,7 @@ import {
 } from '@tanstack/angular-query-experimental';
 import { MenuItem } from 'primeng/api';
 
+import { KoboValidationError } from '@121-service/src/kobo/interfaces/kobo-validation-error.interface';
 import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 
 import { CardWithLinkComponent } from '~/components/card-with-link/card-with-link.component';
@@ -23,6 +25,7 @@ import {
 } from '~/domains/kobo/kobo.helpers';
 import { KoboApiService } from '~/domains/kobo/kobo-api.service';
 import { KoboConfigurationDialogComponent } from '~/pages/program-settings-registration-data/components/kobo-configuration-dialog/kobo-configuration-dialog.component';
+import { KoboErrorDialogComponent } from '~/pages/program-settings-registration-data/components/kobo-error-dialog/kobo-error-dialog.component';
 import { KoboImportExistingRegistrationsDialogComponent } from '~/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component';
 import { AuthService } from '~/services/auth.service';
 import { ToastService } from '~/services/toast.service';
@@ -34,6 +37,7 @@ import { ToastService } from '~/services/toast.service';
     DatePipe,
     KoboConfigurationDialogComponent,
     KoboImportExistingRegistrationsDialogComponent,
+    KoboErrorDialogComponent,
   ],
   templateUrl: './kobo-integration-card.component.html',
   styles: ``,
@@ -46,6 +50,11 @@ export class KoboIntegrationCardComponent {
   private readonly koboApiService = inject(KoboApiService);
   private readonly authService = inject(AuthService);
   private readonly toastService = inject(ToastService);
+
+  readonly koboRefreshErrors = signal<KoboValidationError[]>([]);
+
+  readonly koboErrorDialog =
+    viewChild.required<KoboErrorDialogComponent>('koboErrorDialog');
 
   readonly koboConfigurationDialog =
     viewChild.required<KoboConfigurationDialogComponent>(
@@ -104,10 +113,21 @@ export class KoboIntegrationCardComponent {
         detail: $localize`Integration is already up to date.`,
       });
     },
-    onError: () => {
+    onError: (errorResponse: Error) => {
+      const cause = errorResponse.cause as {
+        error?: { errors?: KoboValidationError[] };
+      };
+      const errors = cause.error?.errors;
+
+      // If the error contains Kobo validation errors, we want to show them in the KoboErrorDialog.
+      if (Array.isArray(errors) && errors.length > 0) {
+        this.koboRefreshErrors.set(errors);
+        this.koboErrorDialog().show();
+      }
+
       this.toastService.showToast({
         severity: 'error',
-        detail: $localize`Integration update unsuccessful. Please try again.`,
+        detail: $localize`Kobo refresh unsuccessful`,
       });
     },
   }));

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -2598,14 +2598,14 @@
       <trans-unit id="2818334334996550834" datatype="html">
         <source>Kobo form refresh errors</source>
       </trans-unit>
-      <trans-unit id="6147099473186988952" datatype="html">
-        <source>Kobo refresh unsuccessful</source>
-      </trans-unit>
       <trans-unit id="6622197825860768013" datatype="html">
         <source>There are issues in your Kobo form that are blocking the refresh. Fix the errors below in Kobo, then save, redeploy, and try again.</source>
       </trans-unit>
       <trans-unit id="7749949386756709227" datatype="html">
         <source>There are issues in your Kobo form that are blocking the integration. Fix the errors below in Kobo, then save, redeploy, and try again.</source>
+      </trans-unit>
+      <trans-unit id="508499092676439201" datatype="html">
+        <source>Integration update unsuccessful. Please try again.</source>
       </trans-unit>
     </body>
   </file>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -429,6 +429,9 @@
       <trans-unit id="2800411489772677471" datatype="html">
         <source>Fill up all 19 digits to link card</source>
       </trans-unit>
+      <trans-unit id="2818334334996550834" datatype="html">
+        <source>Kobo form refresh errors</source>
+      </trans-unit>
       <trans-unit id="2832894421278390919" datatype="html">
         <source>Invalid email or password. Double-check your credentials and try again.</source>
       </trans-unit>
@@ -956,6 +959,9 @@
       <trans-unit id="5081696702832953928" datatype="html">
         <source>Some of the registrations you have selected are not eligible for this payment. Change your selection and try again</source>
       </trans-unit>
+      <trans-unit id="508499092676439201" datatype="html">
+        <source>Integration update unsuccessful. Please try again.</source>
+      </trans-unit>
       <trans-unit id="5106050439674974101" datatype="html">
         <source>Choose an FSP from the FSPs integrated to this instance. You can add multiple FSPs to the same program. If you wish to integrate a new FSP, contact the 121 support team or talk to the account manager.</source>
       </trans-unit>
@@ -1199,6 +1205,9 @@
       <trans-unit id="6102855402615761891" datatype="html">
         <source>The base transfer value is multiplied by a set factor for each registration. For example, if the base value is $50 and the multiplier is based on household size, a 3-person household would receive $150 per payment.</source>
       </trans-unit>
+      <trans-unit id="6151408429233480883" datatype="html">
+        <source>Required fields not found</source>
+      </trans-unit>
       <trans-unit id="6169902268775373280" datatype="html">
         <source>Select users for this approval step</source>
       </trans-unit>
@@ -1293,6 +1302,9 @@
       <trans-unit id="6582831988869863310" datatype="html">
         <source>You&apos;re about to edit the user <x ctype="x-b" equiv-text="&lt;b&gt;" id="START_BOLD_TEXT"/><x equiv-text="{{ userToEdit()?.username }}" id="INTERPOLATION"/><x ctype="x-b" equiv-text="&lt;/b&gt;" id="CLOSE_BOLD_TEXT"/> in your program team.</source>
       </trans-unit>
+      <trans-unit id="6622197825860768013" datatype="html">
+        <source>There are issues in your Kobo form that are blocking the refresh. Fix the errors below in Kobo, then save, redeploy, and try again.</source>
+      </trans-unit>
       <trans-unit id="6627551976444260400" datatype="html">
         <source>or</source>
       </trans-unit>
@@ -1322,6 +1334,9 @@
       </trans-unit>
       <trans-unit id="6725574712013202474" datatype="html">
         <source>Payment created.</source>
+      </trans-unit>
+      <trans-unit id="6751289562324913219" datatype="html">
+        <source>Form setting errors</source>
       </trans-unit>
       <trans-unit id="6768832079771465748" datatype="html">
         <source>Field changed</source>
@@ -1527,6 +1542,9 @@
       <trans-unit id="7613791439001735010" datatype="html">
         <source>Template message</source>
       </trans-unit>
+      <trans-unit id="7615933189038112184" datatype="html">
+        <source>These fields are expected by 121 but are missing from your Kobo form. Add them before redeploying.</source>
+      </trans-unit>
       <trans-unit id="7617906385730294527" datatype="html">
         <source><x equiv-text="label" id="PH"/> payment (<x equiv-text="order" id="PH_1"/> of <x equiv-text="total" id="PH_2"/>)</source>
       </trans-unit>
@@ -1553,6 +1571,9 @@
       </trans-unit>
       <trans-unit id="7739650586737813677" datatype="html">
         <source>All Registrations</source>
+      </trans-unit>
+      <trans-unit id="7749949386756709227" datatype="html">
+        <source>There are issues in your Kobo form that are blocking the integration. Fix the errors below in Kobo, then save, redeploy, and try again.</source>
       </trans-unit>
       <trans-unit id="7750731471522839997" datatype="html">
         <source>Editing in <x equiv-text="{{ languageName }}" id="INTERPOLATION"/>.</source>
@@ -2585,27 +2606,6 @@
       </trans-unit>
       <trans-unit id="unsaved-changes-warning-label" datatype="html">
         <source>Unsaved changes warning</source>
-      </trans-unit>
-      <trans-unit id="6751289562324913219" datatype="html">
-        <source>Form setting errors</source>
-      </trans-unit>
-      <trans-unit id="6151408429233480883" datatype="html">
-        <source>Required fields not found</source>
-      </trans-unit>
-      <trans-unit id="7615933189038112184" datatype="html">
-        <source>These fields are expected by 121 but are missing from your Kobo form. Add them before redeploying.</source>
-      </trans-unit>
-      <trans-unit id="2818334334996550834" datatype="html">
-        <source>Kobo form refresh errors</source>
-      </trans-unit>
-      <trans-unit id="6622197825860768013" datatype="html">
-        <source>There are issues in your Kobo form that are blocking the refresh. Fix the errors below in Kobo, then save, redeploy, and try again.</source>
-      </trans-unit>
-      <trans-unit id="7749949386756709227" datatype="html">
-        <source>There are issues in your Kobo form that are blocking the integration. Fix the errors below in Kobo, then save, redeploy, and try again.</source>
-      </trans-unit>
-      <trans-unit id="508499092676439201" datatype="html">
-        <source>Integration update unsuccessful. Please try again.</source>
       </trans-unit>
     </body>
   </file>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -956,9 +956,6 @@
       <trans-unit id="5081696702832953928" datatype="html">
         <source>Some of the registrations you have selected are not eligible for this payment. Change your selection and try again</source>
       </trans-unit>
-      <trans-unit id="508499092676439201" datatype="html">
-        <source>Integration update unsuccessful. Please try again.</source>
-      </trans-unit>
       <trans-unit id="5106050439674974101" datatype="html">
         <source>Choose an FSP from the FSPs integrated to this instance. You can add multiple FSPs to the same program. If you wish to integrate a new FSP, contact the 121 support team or talk to the account manager.</source>
       </trans-unit>
@@ -2598,7 +2595,16 @@
       <trans-unit id="7615933189038112184" datatype="html">
         <source>These fields are expected by 121 but are missing from your Kobo form. Add them before redeploying.</source>
       </trans-unit>
-      <trans-unit id="7968872754950254240" datatype="html">
+      <trans-unit id="2818334334996550834" datatype="html">
+        <source>Kobo form refresh errors</source>
+      </trans-unit>
+      <trans-unit id="6147099473186988952" datatype="html">
+        <source>Kobo refresh unsuccessful</source>
+      </trans-unit>
+      <trans-unit id="6622197825860768013" datatype="html">
+        <source>There are issues in your Kobo form that are blocking the refresh. Fix the errors below in Kobo, then save, redeploy, and try again.</source>
+      </trans-unit>
+      <trans-unit id="7749949386756709227" datatype="html">
         <source>There are issues in your Kobo form that are blocking the integration. Fix the errors below in Kobo, then save, redeploy, and try again.</source>
       </trans-unit>
     </body>


### PR DESCRIPTION
[AB#42898](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42898) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Re-used the kobo error dialog to also show the kobo refresh errors.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding E2E tests is unfortunately not possible
- [x] I have made sure that all automated checks pass before requesting a review


## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8371.westeurope.3.azurestaticapps.net
