### PR TITLE
Fix: link visa card not vissible if configuration name does not match 'Intersolve visa'

### DIFF
--- a/interfaces/portal/src/app/domains/fsp-configuration/fsp-configuration.api.service.ts
+++ b/interfaces/portal/src/app/domains/fsp-configuration/fsp-configuration.api.service.ts
@@ -102,7 +102,7 @@ export class FspConfigurationApiService extends DomainApiService {
     configurationName,
   }: {
     programId: Signal<number | string>;
-    configurationName: string;
+    configurationName: Signal<string>;
   }) {
     return this.generateQueryOptions<FspConfigurationProperty[]>({
       path: [

--- a/interfaces/portal/src/app/pages/program-registration-debit-cards/program-registration-debit-cards.page.ts
+++ b/interfaces/portal/src/app/pages/program-registration-debit-cards/program-registration-debit-cards.page.ts
@@ -115,12 +115,20 @@ export class ProgramRegistrationDebitCardsPageComponent {
 
   program = injectQuery(this.programApiService.getProgram(this.programId));
 
-  fspConfigurationProperties = injectQuery(
-    this.fspConfigurationApiService.getPublicFspConfigurationProperties({
-      programId: this.programId,
-      configurationName: 'Intersolve-visa',
-    }),
+  // The public FSP-configuration properties must be read from the configuration
+  // the registration is actually enrolled in (this page is only reachable for
+  // Intersolve Visa registrations).
+  readonly programFspConfigurationName = computed(
+    () => this.registration.data()?.programFspConfigurationName ?? '',
   );
+
+  fspConfigurationProperties = injectQuery(() => ({
+    ...this.fspConfigurationApiService.getPublicFspConfigurationProperties({
+      programId: this.programId,
+      configurationName: this.programFspConfigurationName,
+    })(),
+    enabled: !!this.programFspConfigurationName(),
+  }));
 
   readonly cardDistributionByMailEnabled = computed(() => {
     if (!this.fspConfigurationProperties.isSuccess()) {

--- a/interfaces/portal/src/app/pages/program-registration-debit-cards/program-registration-debit-cards.page.ts
+++ b/interfaces/portal/src/app/pages/program-registration-debit-cards/program-registration-debit-cards.page.ts
@@ -115,9 +115,6 @@ export class ProgramRegistrationDebitCardsPageComponent {
 
   program = injectQuery(this.programApiService.getProgram(this.programId));
 
-  // The public FSP-configuration properties must be read from the configuration
-  // the registration is actually enrolled in (this page is only reachable for
-  // Intersolve Visa registrations).
   readonly programFspConfigurationName = computed(
     () => this.registration.data()?.programFspConfigurationName ?? '',
   );


### PR DESCRIPTION
[AB#42983](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42983) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Fixed hardcoded FSP configuration name on the debit cards page. The page previously always queried public FSP-configuration properties using the literal string 'Intersolve-visa', which broke on environments where the Visa configuration was created under a different name. 

See also: https://teams.microsoft.com/l/message/19:ba131b3596f94ba2b3fe806c65fc9a7b@thread.skype/1782227880125?tenantId=d3ab9790-6ae2-4bd8-aa5e-02864483e7c7&groupId=55f2fa49-7d9b-4c63-b616-b986f3136c3a&parentMessageId=1781626471787&teamName=510%20-%20CVA&channelName=Caribbean%20NL&createdTime=1782227880125

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8374.westeurope.3.azurestaticapps.net
