### PR TITLE
Remove unused Teams-notification from Performance-tests

### DIFF
--- a/.github/workflows/test_jest_performance_cronjob.yml
+++ b/.github/workflows/test_jest_performance_cronjob.yml
@@ -117,13 +117,3 @@ jobs:
         run: |
           echo "All performance tests have successfully passed." >> $GITHUB_STEP_SUMMARY
           echo "Test results: ${{ toJson(needs.*.result) }}" >> $GITHUB_STEP_SUMMARY
-
-      - name: Microsoft Teams Notification
-        if: always()
-        uses: tlolkema/simple-teams-message@18ffc37b4253de8243ff28318ac51abccdacd024
-        env:
-          JOB_STATUS_WITH_NICE_EMOJI: ${{ job.status == 'success' && '✅ Success' || '❌ Failed' }}
-        with:
-          message_title: 'Jest Performance Tests Cronjob'
-          message_description: 'Job status: ${{ env.JOB_STATUS_WITH_NICE_EMOJI }}'
-          webhook: ${{ secrets.MSTEAMS_WEBHOOK }}


### PR DESCRIPTION
[AB#42643](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42643)

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
