### PR TITLE
chore: Exclude sensitive files from GitHub Copilot chat context

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,13 @@
     "source.removeUnusedImports": "explicit"
   },
   "js/ts.tsdk.path": "./node_modules/typescript/lib",
+  "github.copilot.chat.context.fileExclusions": [
+    "**/.env",
+    "**/.env.*",
+    "**/secrets.*",
+    "**/*.pem",
+    "**/*.key"
+  ],
   "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "regexrobin.rules": [
     {
@@ -43,6 +50,7 @@
       ]
     }
   ],
+
   "tailwindCSS.rootFontSize": 14,
   "tailwindCSS.showPixelEquivalents": true,
   "tailwindCSS.classAttributes": [

--- a/e2e/.vscode/settings.json
+++ b/e2e/.vscode/settings.json
@@ -26,6 +26,13 @@
       "severity": "info"
     }
   ],
+  "github.copilot.chat.editorContext.fileExclusions": [
+    "**/.env",
+    "**/.env.*",
+    "**/secrets.*",
+    "**/*.pem",
+    "**/*.key"
+  ],
   "eslint.workingDirectories": [{ "mode": "auto" }],
   "js/ts.tsdk.path": "./node_modules/typescript/lib",
   "js/ts.tsdk.promptToUseWorkspaceVersion": true,

--- a/interfaces/portal/.vscode/settings.json
+++ b/interfaces/portal/.vscode/settings.json
@@ -26,6 +26,13 @@
       "severity": "info"
     }
   ],
+  "github.copilot.chat.editorContext.fileExclusions": [
+    "**/.env",
+    "**/.env.*",
+    "**/secrets.*",
+    "**/*.pem",
+    "**/*.key"
+  ],
   "eslint.workingDirectories": [{ "mode": "auto" }],
   "css.customData": [".vscode/tailwind.json"],
   "js/ts.tsdk.path": "./node_modules/typescript/lib",

--- a/services/121-service/.vscode/settings.json
+++ b/services/121-service/.vscode/settings.json
@@ -22,6 +22,13 @@
       "severity": "info"
     }
   ],
+  "github.copilot.chat.editorContext.fileExclusions": [
+    "**/.env",
+    "**/.env.*",
+    "**/secrets.*",
+    "**/*.pem",
+    "**/*.key"
+  ],
   "eslint.workingDirectories": [{ "mode": "auto" }],
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit",

--- a/services/mock-service/.vscode/settings.json
+++ b/services/mock-service/.vscode/settings.json
@@ -27,6 +27,13 @@
     "source.fixAll.eslint": "explicit",
     "source.removeUnusedImports": "explicit"
   },
+  "github.copilot.chat.context.fileExclusions": [
+    "**/.env",
+    "**/.env.*",
+    "**/secrets.*",
+    "**/*.pem",
+    "**/*.key"
+  ],
   "js/ts.tsdk.path": "./node_modules/typescript/lib",
   "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "regexrobin.rules": [


### PR DESCRIPTION
[AB#42968](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/42968) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Disable passing sensitive files to chat context by accident.
Tested: "The `yolo.pem` file is correctly excluded from my context by the `**/*.pem` rule in the file exclusions setting — I cannot see its contents."

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8378.westeurope.3.azurestaticapps.net
