### PR TITLE
refactor: Use own GitHub Action to show Docker logs

### DIFF
--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Docker logs
         if: always()
-        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e
+        uses: global-121/collect-container-logs@78594c6154439e32858bf3dc17c9ff36561a1d31
 
   # This job is here to make the above jobs "required" in GitHub.
   # This is a workaround for this issue: https://github.com/orgs/community/discussions/44490

--- a/.github/workflows/test_jest_performance_cronjob.yml
+++ b/.github/workflows/test_jest_performance_cronjob.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Docker logs
         if: always()
-        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e
+        uses: global-121/collect-container-logs@78594c6154439e32858bf3dc17c9ff36561a1d31
 
   performance-test-shard-resolution:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_service_api.yml
+++ b/.github/workflows/test_service_api.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Docker logs
         if: always()
-        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e
+        uses: global-121/collect-container-logs@78594c6154439e32858bf3dc17c9ff36561a1d31
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_service_check_migrations.yml
+++ b/.github/workflows/test_service_check_migrations.yml
@@ -54,4 +54,4 @@ jobs:
 
       - name: Docker logs
         if: always()
-        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e
+        uses: global-121/collect-container-logs@78594c6154439e32858bf3dc17c9ff36561a1d31

--- a/.github/workflows/test_service_only_restart.yml
+++ b/.github/workflows/test_service_only_restart.yml
@@ -67,4 +67,4 @@ jobs:
 
       - name: Docker logs
         if: always()
-        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e
+        uses: global-121/collect-container-logs@78594c6154439e32858bf3dc17c9ff36561a1d31


### PR DESCRIPTION
[AB#43004](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43004)

## Description

To replace an out-dated dependency with a version of our own ([without ANY dependencies!](https://github.com/global-121/collect-container-logs/blob/main/package-lock.json))

Test: https://github.com/global-121/121-platform/actions/runs/28157131063/job/83388348227?pr=8379#step:6:153 (works! ✅ )

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
