### PR TITLE
Fix flaky test: 'update multiple attributes'

### DIFF
--- a/services/121-service/src/program-registration-attributes/program-registration-attributes.service.ts
+++ b/services/121-service/src/program-registration-attributes/program-registration-attributes.service.ts
@@ -520,6 +520,7 @@ export class ProgramRegistrationAttributesService {
           name: In(programAttributesToUpdateNames),
           programId: Equal(programId),
         },
+        order: { name: 'ASC' },
       });
 
     for (const programRegistrationAttributeFromRepo of programRegistrationAttributesFromRepo) {

--- a/services/121-service/test/registrations/update-program-registration-attributes.test.ts
+++ b/services/121-service/test/registrations/update-program-registration-attributes.test.ts
@@ -55,9 +55,10 @@ describe('Update program registration attributes in batch', () => {
     const updatedAttributes = response.body;
 
     expect(updatedAttributes).toHaveLength(2);
-    expect(updatedAttributes[0]['label']['en']).toBe('WhatsApp Phone Number');
-    expect(updatedAttributes[1]['label']['en']).toBe('Address PostalCode');
-    expect(updatedAttributes[1]['placeholder']['en']).toBe('Postal code');
+    // Results are ordered by name ASC: addressPostalCode before whatsappPhoneNumber
+    expect(updatedAttributes[0]['label']['en']).toBe('Address PostalCode');
+    expect(updatedAttributes[0]['placeholder']['en']).toBe('Postal code');
+    expect(updatedAttributes[1]['label']['en']).toBe('WhatsApp Phone Number');
   });
 
   it('should fail on updating a non existing attribute name', async () => {


### PR DESCRIPTION
[AB#43106](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43106) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Fix non-deterministic ordering in updateBatchProgramRegistrationAttributes by adding order: { name: 'ASC' } to the repository query, ensuring the endpoint always returns attributes in a consistent alphabetical order. Update the corresponding test to assert on the now-guaranteed ordering instead of using order-independent lookups.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
