### PR TITLE
Fix flaky test export payments

### DIFF
--- a/e2e/portal/pages/PaymentsPage.ts
+++ b/e2e/portal/pages/PaymentsPage.ts
@@ -231,6 +231,14 @@ class PaymentsPage extends BasePage {
     expect(actualText).toBe(expectedText);
   }
 
+  async openExportMenu() {
+    // The export menu options are a computed signal derived from the payments
+    // and program queries. Wait until those requests have settled so that
+    // opening the menu isn't dismissed by a background re-render.
+    await this.page.waitForLoadState('networkidle');
+    await this.exportButton.click();
+  }
+
   async selectPaymentExportOption({
     option,
     dateRange,
@@ -238,9 +246,7 @@ class PaymentsPage extends BasePage {
     option: string;
     dateRange?: { start: Date; end: Date };
   }) {
-    await this.page.waitForLoadState('networkidle');
-    await this.page.waitForTimeout(200); // wait for the export options to be rendered
-    await this.exportButton.click();
+    await this.openExportMenu();
     await this.page.getByRole('menuitem', { name: option }).click();
     if (dateRange) {
       await this.dateRangeStartInput.selectDate({

--- a/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
+++ b/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
@@ -76,8 +76,7 @@ test('ExportPayments', async ({ paymentsPage, exportDataComponent }) => {
 test('View available actions for admin', async ({ page, paymentsPage }) => {
   await test.step('Validate export options', async () => {
     await paymentsPage.navigateToProgramPage('Payments');
-    await paymentsPage.table.waitForLoaded(); // wait for payments data to settle so the menu isn't dismissed by a re-render
-    await paymentsPage.exportButton.click();
+    await paymentsPage.openExportMenu();
 
     const expectedMenuItems = [
       'Payments',

--- a/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
+++ b/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
@@ -76,7 +76,7 @@ test('ExportPayments', async ({ paymentsPage, exportDataComponent }) => {
 test('View available actions for admin', async ({ page, paymentsPage }) => {
   await test.step('Validate export options', async () => {
     await paymentsPage.navigateToProgramPage('Payments');
-    await page.waitForTimeout(200); // wait for the export options to be rendered
+    await paymentsPage.table.waitForLoaded(); // wait for payments data to settle so the menu isn't dismissed by a re-render
     await paymentsPage.exportButton.click();
 
     const expectedMenuItems = [


### PR DESCRIPTION
[AB#43117](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43117) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Should fix this flakey test: (I lost the link to the test run so just pasting here the stack trace):


```
[chromium] › portal/tests/ViewPayments/ExportPayments.spec.ts:76:5 › View available actions for admin › Validate export options 

    Error: expect(locator).toHaveText(expected) failed

    Locator: getByRole('menuitem')
    Timeout: 5000ms
    - Expected  - 6
    + Received  + 1

    - Array [
    -   "Payments",
    -   "Unused vouchers",
    -   "Debit card usage",
    -   "Refunded debit cards",
    - ]
    + Array []

    Call log:
      - Expect "toHaveText" with timeout 5000ms
      - waiting for getByRole('menuitem')
        14 × locator resolved to 0 elements


      89 |     // This part is to wait for the menu items to be visible before asserting
      90 |     const menuItems = page.getByRole('menuitem');
    > 91 |     await expect(menuItems).toHaveText(expectedMenuItems);
         |                             ^
      92 |
      93 |     // This part is to assert the actual text content of the menu items, also ensures there are no extra items
      94 |     const exportOptions = await menuItems.all();
        at /home/runner/work/121-platform/121-platform/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts:91:29
        at /home/runner/work/121-platform/121-platform/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts:77:3

    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
    test-results/ViewPayments-ExportPayments-View-available-actions-for-admin-chromium/test-failed-1.png
    ────────────────────────────────────────────────────────────────────────────────────────────────

    Error Context: test-results/ViewPayments-ExportPayments-View-available-actions-for-admin-chromium/error-context.md

    Retry #1 ───────────────────────────────────────────────────────────────────────────────────────

    Error: expect(locator).toHaveText(expected) failed

    Locator: getByRole('menuitem')
    Timeout: 5000ms
    - Expected  - 6
    + Received  + 1

    - Array [
    -   "Payments",
    -   "Unused vouchers",
    -   "Debit card usage",
    -   "Refunded debit cards",
    - ]
    + Array []

    Call log:
      - Expect "toHaveText" with timeout 5000ms
      - waiting for getByRole('menuitem')
        - locator resolved to 2 elements
        13 × locator resolved to 0 elements


      89 |     // This part is to wait for the menu items to be visible before asserting
      90 |     const menuItems = page.getByRole('menuitem');
    > 91 |     await expect(menuItems).toHaveText(expectedMenuItems);
         |                             ^
      92 |
      93 |     // This part is to assert the actual text content of the menu items, also ensures there are no extra items
      94 |     const exportOptions = await menuItems.all();
        at /home/runner/work/121-platform/121-platform/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts:91:29
        at /home/runner/work/121-platform/121-platform/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts:77:3

    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
    test-results/ViewPayments-ExportPayments-View-available-actions-for-admin-chromium-retry1/test-failed-1.png
    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #2: video (video/webm) ──────────────────────────────────────────────────────────────
    test-results/ViewPayments-ExportPayments-View-available-actions-for-admin-chromium-retry1/video.webm
    ────────────────────────────────────────────────────────────────────────────────────────────────

    Error Context: test-results/ViewPayments-ExportPayments-View-available-actions-for-admin-chromium-retry1/error-context.md

    attachment #4: trace (application/zip) ─────────────────────────────────────────────────────────
    test-results/ViewPayments-ExportPayments-View-available-actions-for-admin-chromium-retry1/trace.zip
    Usage:

        npx playwright show-trace test-results/ViewPayments-ExportPayments-View-available-actions-for-admin-chromium-retry1/trace.zip

    ────────────────────────────────────────────────────────────────────────────────────────────────

  1 failed
    [chromium] › portal/tests/ViewPayments/ExportPayments.spec.ts:76:5 › View available actions for admin 
  32 passed (6.5m)
Error: Process completed with exit code 1.
```

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have addressed all Copilot comments
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [ ] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [ ] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
