### PR TITLE
feat: Add workflow to auto-commit any upgraded shared dependencies

### DIFF
--- a/.github/workflows/upgrade_shared_dependencies.yml
+++ b/.github/workflows/upgrade_shared_dependencies.yml
@@ -1,0 +1,45 @@
+# See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+
+name: 'Upgrade: Shared dependencies'
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'packages/eslint-config-121-platform/package-lock.json'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  upgrade_shared_dependencies:
+    runs-on: ubuntu-slim
+    # Don't run this check on forks and Dependabot PRs
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.head.repo.fork == false && contains(github.actor, 'dependabot') == false)
+
+    steps:
+      # See: https://github.com/actions/checkout/#push-a-commit-to-a-pr-using-the-built-in-token
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+
+      - name: Set up Node.js version
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+
+      - name: Install all shared dependencies
+        run: |
+          npm run install:local:all
+
+      - name: Commit changes
+        run: |
+          git config user.name "dependabot[bot]"
+          git config user.email "dependabot[bot]@users.noreply.github.com"
+          git add --all
+          git diff-index --quiet HEAD || git commit --message "chore(deps): upgrade shared dependencies"
+          git push


### PR DESCRIPTION
[AB#43211](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43211)

## Describe your changes

This will (hopefully) reduce some 'churn' on the dependencies in our "shared eslint-config".

Whenever there is a change, this workflow will make the necessary changes in all consuming packages for it.

## See results

See the PoC: https://github.com/global-121/121-platform/pull/8435/commits

(For user-created branches) It seems to work. (it adds the commit with all changes)
For "Dependabot-initiated"-PRs it will likely not work... so we'll have to see how to handle those... ;)

Intended way of working would be to:
- Copy the dependabot-PR-branch-name
- Make this workflow run on that branch
- See the changes added to the PR
- Check & Approve the PR
- Let it merge
- Win! 🥳

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
