### PR TITLE
chore: Use smaller runner for less-demanding jobs

### DIFF
--- a/.github/workflows/deploy_test_portal.yml
+++ b/.github/workflows/deploy_test_portal.yml
@@ -126,7 +126,7 @@ jobs:
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     name: Close Pull Request Job
     environment: 'test'
     steps:

--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -157,7 +157,7 @@ jobs:
   # This job is here to make the above jobs "required" in GitHub.
   # This is a workaround for this issue: https://github.com/orgs/community/discussions/44490
   test-shard-resolution-e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [test-shard-e2e]
     if: always()
     steps:

--- a/.github/workflows/test_jest_performance_cronjob.yml
+++ b/.github/workflows/test_jest_performance_cronjob.yml
@@ -101,7 +101,7 @@ jobs:
         uses: global-121/collect-container-logs@78594c6154439e32858bf3dc17c9ff36561a1d31
 
   performance-test-shard-resolution:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [performance-test-shard]
     if: always()
     steps:

--- a/.github/workflows/test_service_api.yml
+++ b/.github/workflows/test_service_api.yml
@@ -182,7 +182,7 @@ jobs:
   # This job is here to make the above jobs "required" in GitHub.
   # This is a workaround for this issue: https://github.com/orgs/community/discussions/44490
   test-shard-resolution-api:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [test-shard, test]
     if: always()
     steps:


### PR DESCRIPTION
[AB#43238](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43238)

## Describe your changes

The removal of preview-builds doesn't need to compete with other (test-)runs etc. (and vice versa)

It can make due with a smaller runner to send the 'close' signal.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8439.westeurope.3.azurestaticapps.net
