### PR TITLE
ci: Add (actionable) warning for preview-deployment failures

### DIFF
--- a/.github/workflows/deploy_test_portal.yml
+++ b/.github/workflows/deploy_test_portal.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Deployment failed guidance
         if: ${{ failure() && steps.deploy_to_aswa.outcome == 'failure' }}
         run: |
-          MESSAGE='Try to delete some preview-deployments. See: <https://portal.azure.com/#@rodekruis.onmicrosoft.com/resource/subscriptions/a9fac20b-7963-401a-84e8-3cf91aea89ef/resourceGroups/121-Platform/providers/Microsoft.Web/staticSites/121-portal-test/environments>'
+          MESSAGE='Try to delete some preview-deployments. See: <${{ vars.AZURE_STATIC_WEB_APPS_PREVIEW_BUILDS_URL }}>'
           echo "$MESSAGE"
           echo "::warning::$MESSAGE"
           {
@@ -109,8 +109,6 @@ jobs:
             echo ""
             echo "> $MESSAGE"
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "$MESSAGE" >&2
-          exit 1
 
       - name: Verify Deployment
         if: steps.deploy_to_aswa.outputs.static_web_app_url != ''

--- a/.github/workflows/deploy_test_portal.yml
+++ b/.github/workflows/deploy_test_portal.yml
@@ -98,6 +98,20 @@ jobs:
           skip_app_build: true
           skip_api_build: true
 
+      - name: Deployment failed guidance
+        if: ${{ failure() && steps.deploy_to_aswa.outcome == 'failure' }}
+        run: |
+          MESSAGE='Try to delete some preview-deployments. See: <https://portal.azure.com/#@rodekruis.onmicrosoft.com/resource/subscriptions/a9fac20b-7963-401a-84e8-3cf91aea89ef/resourceGroups/121-Platform/providers/Microsoft.Web/staticSites/121-portal-test/environments>'
+          echo "$MESSAGE"
+          echo "::warning::$MESSAGE"
+          {
+            echo "### ⚠️ Deployment failed"
+            echo ""
+            echo "> $MESSAGE"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "$MESSAGE" >&2
+          exit 1
+
       - name: Verify Deployment
         if: steps.deploy_to_aswa.outputs.static_web_app_url != ''
         working-directory: ${{ env.workingDirectory }}


### PR DESCRIPTION
[AB#43271](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43271)

In case of these type of errors: https://github.com/global-121/121-platform/actions/runs/28648045875/job/84959229906?pr=8469#step:5:44

We can add a little helpful text+link. ;)

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8472.westeurope.3.azurestaticapps.net
