### PR TITLE
Add debit cards order status

### DIFF
--- a/e2e/portal/pages/ProgramMonitoringPage.ts
+++ b/e2e/portal/pages/ProgramMonitoringPage.ts
@@ -402,6 +402,7 @@ class ProgramMonitoring extends BasePage {
 
     expect(headers).toEqual([
       'No of Cards Ordered',
+      'Order Status',
       'Address',
       'Ordered By',
       'Ordered On',
@@ -412,6 +413,7 @@ class ProgramMonitoring extends BasePage {
 
     expect(rowValues).toEqual([
       noOfCards,
+      'Completed',
       addressColumn,
       'admin@example.org',
       expect.any(String), // Ordered On can be variable, so we just check that it's a string

--- a/interfaces/portal/src/app/components/colored-chip/colored-chip.helper.ts
+++ b/interfaces/portal/src/app/components/colored-chip/colored-chip.helper.ts
@@ -1,10 +1,14 @@
+import { VisaCardOrderStatus } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/intersolve-visa-card-order-status.enum';
 import { VisaCard121Status } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/wallet-status-121.enum';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { DuplicateStatus } from '@121-service/src/registration/enum/duplicate-status.enum';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 
 import { ChipVariant } from '~/components/colored-chip/colored-chip.component';
-import { VISA_CARD_STATUS_LABELS } from '~/domains/fsp-account-management/intersolve-visa.helper';
+import {
+  VISA_CARD_ORDER_STATUS_LABELS,
+  VISA_CARD_STATUS_LABELS,
+} from '~/domains/fsp-account-management/intersolve-visa.helper';
 import {
   ImportExistingSubmissionsResultKey,
   SUBMISSION_RESULT_LABELS,
@@ -133,5 +137,17 @@ export const getChipDataBySubmissionsKey = (
       [ImportExistingSubmissionsResultKey.numberOfSubmissionsFailed]: 'red',
       [ImportExistingSubmissionsResultKey.numberOfSubmissionsImported]: 'green',
       [ImportExistingSubmissionsResultKey.numberOfSubmissionsSkipped]: 'orange',
+    },
+  });
+
+export const getChipDataByVisaCardOrderStatus = (
+  status: VisaCardOrderStatus,
+): ChipData =>
+  mapValueToChipData({
+    value: status,
+    labels: VISA_CARD_ORDER_STATUS_LABELS,
+    chipVariants: {
+      [VisaCardOrderStatus.Processing]: 'yellow',
+      [VisaCardOrderStatus.Completed]: 'green',
     },
   });

--- a/interfaces/portal/src/app/domains/fsp-account-management/intersolve-visa.helper.ts
+++ b/interfaces/portal/src/app/domains/fsp-account-management/intersolve-visa.helper.ts
@@ -1,3 +1,4 @@
+import { VisaCardOrderStatus } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/intersolve-visa-card-order-status.enum';
 import { VisaCard121Status } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/wallet-status-121.enum';
 
 export const VISA_CARD_STATUS_LABELS: Record<VisaCard121Status, string> = {
@@ -10,4 +11,12 @@ export const VISA_CARD_STATUS_LABELS: Record<VisaCard121Status, string> = {
   [VisaCard121Status.Unknown]: $localize`:@@debit-card-status-unknown:Unknown`,
   [VisaCard121Status.Substituted]: $localize`:@@debit-card-status-substituted:Substituted`,
   [VisaCard121Status.CardDataMissing]: $localize`:@@debit-card-status-card-data-missing:Debit card data missing`,
+};
+
+export const VISA_CARD_ORDER_STATUS_LABELS: Record<
+  VisaCardOrderStatus,
+  string
+> = {
+  [VisaCardOrderStatus.Processing]: $localize`:@@debit-card-order-status-processing:Processing`,
+  [VisaCardOrderStatus.Completed]: $localize`:@@debit-card-order-status-completed:Completed`,
 };

--- a/interfaces/portal/src/app/pages/program-monitoring-debit-cards/program-monitoring-debit-cards.page.ts
+++ b/interfaces/portal/src/app/pages/program-monitoring-debit-cards/program-monitoring-debit-cards.page.ts
@@ -12,13 +12,16 @@ import { injectQuery } from '@tanstack/angular-query-experimental';
 import { ButtonModule } from 'primeng/button';
 
 import { VisaCardOrderResponseDto } from '@121-service/src/fsp-integrations/account-management/intersolve-visa/dto/visa-card-order-response.dto';
+import { VisaCardOrderStatus } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/intersolve-visa-card-order-status.enum';
 
+import { getChipDataByVisaCardOrderStatus } from '~/components/colored-chip/colored-chip.helper';
 import { PageLayoutMonitoringComponent } from '~/components/page-layout-monitoring/page-layout-monitoring.component';
 import { QueryTableComponent } from '~/components/query-table/query-table.component';
 import {
   QueryTableColumn,
   QueryTableColumnType,
 } from '~/components/query-table/query-table.types';
+import { VISA_CARD_ORDER_STATUS_LABELS } from '~/domains/fsp-account-management/intersolve-visa.helper';
 import { ProgramApiService } from '~/domains/program/program.api.service';
 import { OrderDebitCardsDialogComponent } from '~/pages/program-monitoring-debit-cards/components/order-debit-cards-dialog.component';
 import { Dto } from '~/utils/dto-type';
@@ -54,6 +57,18 @@ export class ProgramMonitoringDebitCardsPageComponent {
       field: 'noOfCardsOrdered',
       header: $localize`No of Cards Ordered`,
       type: QueryTableColumnType.TEXT,
+    },
+    {
+      field: 'status',
+      header: $localize`Order Status`,
+      type: QueryTableColumnType.MULTISELECT,
+      options: Object.values(VisaCardOrderStatus).map((status) => ({
+        label: VISA_CARD_ORDER_STATUS_LABELS[status],
+        value: status,
+      })),
+      displayAsChip: true,
+      getCellChipData: (order) =>
+        getChipDataByVisaCardOrderStatus(order.status),
     },
     {
       field: 'address',

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -1205,6 +1205,9 @@
       <trans-unit id="6057281094654962766" datatype="html">
         <source>Validate</source>
       </trans-unit>
+      <trans-unit id="606178495678960598" datatype="html">
+        <source>Order Status</source>
+      </trans-unit>
       <trans-unit id="6102855402615761891" datatype="html">
         <source>The base transfer value is multiplied by a set factor for each registration. For example, if the base value is $50 and the multiplier is based on household size, a 3-person household would receive $150 per payment.</source>
       </trans-unit>
@@ -2036,6 +2039,12 @@
       </trans-unit>
       <trans-unit id="debit-card-number" datatype="html">
         <source>Serial number</source>
+      </trans-unit>
+      <trans-unit id="debit-card-order-status-completed" datatype="html">
+        <source>Completed</source>
+      </trans-unit>
+      <trans-unit id="debit-card-order-status-processing" datatype="html">
+        <source>Processing</source>
       </trans-unit>
       <trans-unit id="debit-card-spent-this-month" datatype="html">
         <source>Spent this month (max. EUR <x equiv-text="this.convertCentsToMainUnits(this.walletWithCards.data()?.maxToSpendPerMonth)" id="PH"/>)</source>

--- a/services/121-service/src/fsp-integrations/account-management/intersolve-visa/dto/visa-card-order-response.dto.ts
+++ b/services/121-service/src/fsp-integrations/account-management/intersolve-visa/dto/visa-card-order-response.dto.ts
@@ -1,8 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+import { VisaCardOrderStatus } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/intersolve-visa-card-order-status.enum';
+
 export class VisaCardOrderResponseDto {
   @ApiProperty({ example: 1 })
   public readonly id: number;
+
+  @ApiProperty({ enum: VisaCardOrderStatus, example: VisaCardOrderStatus.Completed })
+  public readonly status: VisaCardOrderStatus;
+
+  @ApiProperty({ example: 100 })
+  public readonly noOfCards: number;
 
   @ApiProperty({ example: 100 })
   public readonly noOfCardsOrdered: number;

--- a/services/121-service/src/fsp-integrations/account-management/intersolve-visa/intersolve-visa-account-management.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/account-management/intersolve-visa/intersolve-visa-account-management.service.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { IntersolveVisaAccountManagementService } from '@121-service/src/fsp-integrations/account-management/intersolve-visa/intersolve-visa-account-management.service';
 import { IntersolveVisaDataSynchronizationService } from '@121-service/src/fsp-integrations/data-synchronization/intersolve-visa/intersolve-visa-data-synchronization.service';
+import { VisaCardOrderStatus } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/intersolve-visa-card-order-status.enum';
 import { IntersolveVisaCardStatus } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/intersolve-visa-card-status.enum';
 import { IntersolveVisaApiError } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/intersolve-visa-api.error';
 import { IntersolveVisaCardOrderRepository } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/repositories/intersolve-visa-card-order.repository';
@@ -551,6 +552,8 @@ describe('IntersolveVisaAccountManagementService', () => {
       cardOrderRepository.getForProgram.mockResolvedValue([
         {
           id: 42,
+          status: VisaCardOrderStatus.Completed,
+          noOfCards: 5,
           noOfCardsOrdered: 5,
           addressee: 'John Doe',
           addressStreet: 'Damrak',
@@ -571,6 +574,8 @@ describe('IntersolveVisaAccountManagementService', () => {
       expect(result).toEqual([
         {
           id: 42,
+          status: VisaCardOrderStatus.Completed,
+          noOfCards: 5,
           noOfCardsOrdered: 5,
           address: 'John Doe, Damrak 1 A, 1011AB, Amsterdam',
           orderedByUsername: 'manager@example.org',

--- a/services/121-service/src/fsp-integrations/account-management/intersolve-visa/intersolve-visa-account-management.service.ts
+++ b/services/121-service/src/fsp-integrations/account-management/intersolve-visa/intersolve-visa-account-management.service.ts
@@ -9,6 +9,7 @@ import { IntersolveVisaWalletDto } from '@121-service/src/fsp-integrations/integ
 import { VisaCardOrderEntity } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/entities/intersolve-visa-card-order.entity';
 import { IntersolveVisaChildWalletEntity } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/entities/intersolve-visa-child-wallet.entity';
 import { IntersolveVisa121ErrorText } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/intersolve-visa-121-error-text.enum';
+import { VisaCardOrderStatus } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/intersolve-visa-card-order-status.enum';
 import { IntersolveVisaCardStatus } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/intersolve-visa-card-status.enum';
 import { ExportVisaWalletClosure } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/interfaces/export-visa-wallet-closure.interface';
 import { ContactInformation } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/interfaces/partials/contact-information.interface';
@@ -594,6 +595,7 @@ export class IntersolveVisaAccountManagementService {
     order.userId = userId;
     order.noOfCards = noOfCards;
     order.noOfCardsOrdered = cardsSentByIntersolve;
+    order.status = VisaCardOrderStatus.Completed;
     order.addressee = addressee;
     order.addressStreet = addressStreet;
     order.addressHouseNumber = addressHouseNumber;

--- a/services/121-service/src/fsp-integrations/account-management/intersolve-visa/mappers/visa-card-order.mapper.spec.ts
+++ b/services/121-service/src/fsp-integrations/account-management/intersolve-visa/mappers/visa-card-order.mapper.spec.ts
@@ -1,5 +1,6 @@
 import { VisaCardOrderMapper } from '@121-service/src/fsp-integrations/account-management/intersolve-visa/mappers/visa-card-order.mapper';
 import { VisaCardOrderEntity } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/entities/intersolve-visa-card-order.entity';
+import { VisaCardOrderStatus } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/intersolve-visa-card-order-status.enum';
 
 describe('VisaCardOrderMapper', () => {
   function createVisaCardOrderEntity(
@@ -9,6 +10,7 @@ describe('VisaCardOrderMapper', () => {
       id: 1,
       programId: 1,
       userId: 1,
+      status: VisaCardOrderStatus.Completed,
       noOfCards: 1,
       noOfCardsOrdered: 1,
       addressee: 'Default User',
@@ -27,6 +29,8 @@ describe('VisaCardOrderMapper', () => {
   it('maps an entity to a response dto', () => {
     const entity = createVisaCardOrderEntity({
       id: 42,
+      status: VisaCardOrderStatus.Completed,
+      noOfCards: 5,
       noOfCardsOrdered: 5,
       addressee: 'John Doe',
       addressStreet: 'Damrak',
@@ -45,6 +49,8 @@ describe('VisaCardOrderMapper', () => {
 
     expect(result).toEqual({
       id: 42,
+      status: VisaCardOrderStatus.Completed,
+      noOfCards: 5,
       noOfCardsOrdered: 5,
       address: 'John Doe, Damrak 1 A, 1011AB, Amsterdam',
       orderedByUsername: 'manager@example.org',

--- a/services/121-service/src/fsp-integrations/account-management/intersolve-visa/mappers/visa-card-order.mapper.ts
+++ b/services/121-service/src/fsp-integrations/account-management/intersolve-visa/mappers/visa-card-order.mapper.ts
@@ -17,6 +17,8 @@ export class VisaCardOrderMapper {
   }): VisaCardOrderResponseDto {
     return {
       id: entity.id,
+      status: entity.status,
+      noOfCards: entity.noOfCards,
       noOfCardsOrdered: entity.noOfCardsOrdered,
       address: this.formatAddressForDisplay({ entity }),
       orderedByUsername: entity.user?.username ?? `${entity.userId}`,

--- a/services/121-service/src/fsp-integrations/integrations/intersolve-visa/entities/intersolve-visa-card-order.entity.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-visa/entities/intersolve-visa-card-order.entity.ts
@@ -1,6 +1,14 @@
-import { Column, Entity, Index, JoinColumn, ManyToOne, Relation } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  Relation,
+} from 'typeorm';
 
 import { Base121Entity } from '@121-service/src/base.entity';
+import { VisaCardOrderStatus } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/intersolve-visa-card-order-status.enum';
 import { UserEntity } from '@121-service/src/user/entities/user.entity';
 
 @Entity('intersolve_visa_card_order')
@@ -21,6 +29,9 @@ export class VisaCardOrderEntity extends Base121Entity {
 
   @Column({ type: 'int' })
   public noOfCardsOrdered: number;
+
+  @Column({ type: 'character varying' })
+  public status: VisaCardOrderStatus;
 
   @Column({ type: 'character varying' })
   public addressStreet: string;

--- a/services/121-service/src/fsp-integrations/integrations/intersolve-visa/enums/intersolve-visa-card-order-status.enum.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-visa/enums/intersolve-visa-card-order-status.enum.ts
@@ -1,0 +1,4 @@
+export enum VisaCardOrderStatus {
+  Processing = 'processing',
+  Completed = 'completed',
+}

--- a/services/121-service/src/migration/1782950400000-debit-card-order-add-status.ts
+++ b/services/121-service/src/migration/1782950400000-debit-card-order-add-status.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DebitCardOrderAddStatus1782950400000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "121-service"."intersolve_visa_card_order"
+      ADD "status" character varying
+    `);
+
+    await queryRunner.query(`
+      UPDATE "121-service"."intersolve_visa_card_order"
+      SET "status" = 'completed'
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "121-service"."intersolve_visa_card_order"
+      ALTER COLUMN "status" SET NOT NULL
+    `);
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // Intentionally left empty — we never run down migrations.
+  }
+}

--- a/services/121-service/test/helpers/registration.helper.ts
+++ b/services/121-service/test/helpers/registration.helper.ts
@@ -689,6 +689,54 @@ export function getVisaWalletClosuresExport({
     .send();
 }
 
+export function createVisaCardOrder({
+  programId,
+  accessToken,
+  noOfCards,
+  addressStreet,
+  addressHouseNumber,
+  addressHouseNumberAddition,
+  addressPostalCode,
+  addressCity,
+  addressee,
+}: {
+  programId: number;
+  accessToken: string;
+  noOfCards: number;
+  addressStreet: string;
+  addressHouseNumber: string;
+  addressHouseNumberAddition?: string;
+  addressPostalCode: string;
+  addressCity: string;
+  addressee: string;
+}): Promise<request.Response> {
+  return getServer()
+    .post(`/programs/${programId}/fsps/intersolve-visa/wallet/cards/orders`)
+    .set('Cookie', [accessToken])
+    .send({
+      noOfCards,
+      addressStreet,
+      addressHouseNumber,
+      addressHouseNumberAddition,
+      addressPostalCode,
+      addressCity,
+      addressee,
+    });
+}
+
+export function getVisaCardOrders({
+  programId,
+  accessToken,
+}: {
+  programId: number;
+  accessToken: string;
+}): Promise<request.Response> {
+  return getServer()
+    .get(`/programs/${programId}/fsps/intersolve-visa/wallet/cards/orders`)
+    .set('Cookie', [accessToken])
+    .send();
+}
+
 export async function getMessageHistory(
   programId: number,
   referenceId: string,

--- a/services/121-service/test/visa-card/order-visa-cards.test.ts
+++ b/services/121-service/test/visa-card/order-visa-cards.test.ts
@@ -1,0 +1,69 @@
+import { HttpStatus } from '@nestjs/common';
+
+import { VisaCardOrderStatus } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/intersolve-visa-card-order-status.enum';
+import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
+import { programIdVisa } from '@121-service/src/seed-data/mock/visa-card.data';
+import { updateProgramCardDistributionByMail } from '@121-service/test/helpers/program-fsp-configuration.helper';
+import {
+  createVisaCardOrder,
+  getVisaCardOrders,
+} from '@121-service/test/helpers/registration.helper';
+import {
+  getAccessToken,
+  resetDB,
+} from '@121-service/test/helpers/utility.helper';
+
+describe('Order visa debit cards in batch', () => {
+  let accessToken: string;
+
+  beforeAll(async () => {
+    await resetDB({ seedScript: SeedScript.nlrcMultiple });
+    accessToken = await getAccessToken();
+    // Disable card distribution by mail to allow batch ordering
+    await updateProgramCardDistributionByMail({
+      isCardDistributionByMail: false,
+      accessToken,
+    });
+  });
+
+  it('should successfully order a batch of visa debit cards', async () => {
+    // Arrange
+    const noOfCards = 3;
+
+    // Act
+    const orderResponse = await createVisaCardOrder({
+      programId: programIdVisa,
+      accessToken,
+      noOfCards,
+      addressStreet: 'Damrak',
+      addressHouseNumber: '1',
+      addressHouseNumberAddition: 'A',
+      addressPostalCode: '1011AB',
+      addressCity: 'Amsterdam',
+      addressee: 'John Doe',
+    });
+
+    // Assert
+    expect(orderResponse.status).toBe(HttpStatus.CREATED);
+    expect(orderResponse.body).toEqual({
+      noOfCardsSent: noOfCards,
+      noOfCardsOrdered: noOfCards,
+    });
+
+    const ordersResponse = await getVisaCardOrders({
+      programId: programIdVisa,
+      accessToken,
+    });
+    expect(ordersResponse.status).toBe(HttpStatus.OK);
+    expect(ordersResponse.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: VisaCardOrderStatus.Completed,
+          noOfCards,
+          noOfCardsOrdered: noOfCards,
+          address: 'John Doe, Damrak 1 A, 1011AB, Amsterdam',
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
Signed-off-by: Ruben <vandervalk@geoit.nl>[AB#43256](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43256) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

This PR adds a status field and an API test to visa debit cards orders

Make the order process fire and forget will be a seperate PR

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8473.westeurope.3.azurestaticapps.net
Signed-off-by: Ruben <vandervalk@geoit.nl>