### PR TITLE
Fix flaky Export payments e2e test

### DIFF
--- a/e2e/portal/pages/BasePage.ts
+++ b/e2e/portal/pages/BasePage.ts
@@ -59,9 +59,13 @@ class BasePage {
     pageName: 'Registrations' | 'Payments' | 'Monitoring' | 'Settings',
   ) {
     const tab = this.programHeader.getByRole('tab', { name: pageName });
+
     await expect(async () => {
       await expect(tab).toBeVisible();
       await tab.click();
+
+      // Wait for the page to load after clicking the tab
+      await this.waitForPageLoad();
     }).toPass({ timeout: 5000 });
   }
 

--- a/e2e/portal/pages/PaymentsPage.ts
+++ b/e2e/portal/pages/PaymentsPage.ts
@@ -243,7 +243,9 @@ class PaymentsPage extends BasePage {
 
     for (let attempt = 0; attempt < 2; attempt++) {
       await this.exportButton.click();
-
+      console.log(
+        `Attempt ${attempt + 1}: Waiting for export menu item "${option}" to be visible...`,
+      );
       try {
         await expect(menuItem).toBeVisible({ timeout: 5_000 });
         break;

--- a/e2e/portal/pages/PaymentsPage.ts
+++ b/e2e/portal/pages/PaymentsPage.ts
@@ -245,7 +245,7 @@ class PaymentsPage extends BasePage {
       await this.exportButton.click();
 
       try {
-        await expect(menuItem).toBeVisible({ timeout: 5_000 });
+        await expect(menuItem).toBeVisible({ timeout: 1_000 });
         break;
       } catch {
         if (attempt === 1) {

--- a/e2e/portal/pages/PaymentsPage.ts
+++ b/e2e/portal/pages/PaymentsPage.ts
@@ -243,9 +243,7 @@ class PaymentsPage extends BasePage {
 
     for (let attempt = 0; attempt < 2; attempt++) {
       await this.exportButton.click();
-      console.log(
-        `Attempt ${attempt + 1}: Waiting for export menu item "${option}" to be visible...`,
-      );
+
       try {
         await expect(menuItem).toBeVisible({ timeout: 5_000 });
         break;

--- a/e2e/portal/pages/PaymentsPage.ts
+++ b/e2e/portal/pages/PaymentsPage.ts
@@ -238,23 +238,10 @@ class PaymentsPage extends BasePage {
     option: string;
     dateRange?: { start: Date; end: Date };
   }) {
-    await this.page.waitForLoadState('networkidle');
-    const menuItem = this.page.getByRole('menuitem', { name: option });
+    await this.exportButton.click();
 
-    for (let attempt = 0; attempt < 2; attempt++) {
-      await this.exportButton.click();
+    await this.page.getByRole('menuitem', { name: option }).click();
 
-      try {
-        await expect(menuItem).toBeVisible({ timeout: 1_000 });
-        break;
-      } catch {
-        if (attempt === 1) {
-          throw new Error(`Export menu item "${option}" did not appear`);
-        }
-      }
-    }
-
-    await menuItem.click();
     if (dateRange) {
       await this.dateRangeStartInput.selectDate({
         targetDate: dateRange.start,

--- a/e2e/portal/pages/PaymentsPage.ts
+++ b/e2e/portal/pages/PaymentsPage.ts
@@ -239,9 +239,22 @@ class PaymentsPage extends BasePage {
     dateRange?: { start: Date; end: Date };
   }) {
     await this.page.waitForLoadState('networkidle');
-    await this.page.waitForTimeout(200); // wait for the export options to be rendered
-    await this.exportButton.click();
-    await this.page.getByRole('menuitem', { name: option }).click();
+    const menuItem = this.page.getByRole('menuitem', { name: option });
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      await this.exportButton.click();
+
+      try {
+        await expect(menuItem).toBeVisible({ timeout: 5_000 });
+        break;
+      } catch {
+        if (attempt === 1) {
+          throw new Error(`Export menu item "${option}" did not appear`);
+        }
+      }
+    }
+
+    await menuItem.click();
     if (dateRange) {
       await this.dateRangeStartInput.selectDate({
         targetDate: dateRange.start,

--- a/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
+++ b/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
@@ -44,42 +44,22 @@ for (let j = 0; j < 20; j++) {
       await expect(paymentsPage.createNewPaymentButton).toBeVisible();
     });
 
-    await test.step('Export and validate file', async () => {
-      await paymentsPage.selectPaymentExportOption({
-        option: 'Payments',
-      });
+        if (aId !== bId) {
+          return Number.parseInt(aId, 10) - Number.parseInt(bId, 10);
+        }
 
-      await exportDataComponent.exportAndAssertData({
-        exactRowCount: 25, // defaults to export all payments, so 5 payments * 5 registrations
-        excludedColumns: ['id', 'created', 'updated', 'paymentDate'],
-        // Given that the payments are not consistently sorted,
-        // we need to sort them by registrationProgramId and payment
-        // to ensure the snapshot is stable.
-        sortFunction: (a: string[], b: string[], headerCells: string[]) => {
-          const registrationProgramIdIndex = headerCells.indexOf(
-            'registrationProgramId',
-          );
-          expect(registrationProgramIdIndex).toBeGreaterThan(-1);
-          const aId = a[registrationProgramIdIndex];
-          const bId = b[registrationProgramIdIndex];
+        const paymentIdIndex = headerCells.indexOf('paymentId');
+        expect(paymentIdIndex).toBeGreaterThan(-1);
+        const aPaymentId = a[paymentIdIndex];
+        const bPaymentId = b[paymentIdIndex];
 
-          if (aId !== bId) {
-            return Number.parseInt(aId, 10) - Number.parseInt(bId, 10);
-          }
-
-          const paymentIdIndex = headerCells.indexOf('paymentId');
-          expect(paymentIdIndex).toBeGreaterThan(-1);
-          const aPaymentId = a[paymentIdIndex];
-          const bPaymentId = b[paymentIdIndex];
-
-          return (
-            Number.parseInt(aPaymentId, 10) - Number.parseInt(bPaymentId, 10)
-          );
-        },
-      });
+        return (
+          Number.parseInt(aPaymentId, 10) - Number.parseInt(bPaymentId, 10)
+        );
+      },
     });
   });
-}
+});
 
 test('View available actions for admin', async ({ page, paymentsPage }) => {
   await test.step('Validate export options', async () => {

--- a/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
+++ b/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
@@ -21,59 +21,66 @@ test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   });
 });
 
-test('Export Payments', async ({ paymentsPage, exportDataComponent }) => {
-  const accessToken = await getAccessToken();
-  await test.step('Do payments', async () => {
-    for (let i = 0; i < 4; i++) {
-      await doPaymentAndWaitForCompletion({
-        programId: programIdOCW,
-        referenceIds: registrationsOCW.map((reg) => reg.referenceId),
-        transferValue: 25,
-        accessToken,
+for (let j = 0; j < 20; j++) {
+  test(`Export Payments - Try ${j}`, async ({
+    paymentsPage,
+    exportDataComponent,
+  }) => {
+    const accessToken = await getAccessToken();
+
+    await test.step('Do payments', async () => {
+      for (let i = 0; i < 4; i++) {
+        await doPaymentAndWaitForCompletion({
+          programId: programIdOCW,
+          referenceIds: registrationsOCW.map((reg) => reg.referenceId),
+          transferValue: 25,
+          accessToken,
+        });
+      }
+    });
+
+    await test.step('Go to payments page', async () => {
+      await paymentsPage.navigateToProgramPage('Payments');
+      // Check if we're really on the "Payments"-page
+      await expect(paymentsPage.createNewPaymentButton).toBeVisible();
+    });
+
+    await test.step('Export and validate file', async () => {
+      await paymentsPage.selectPaymentExportOption({
+        option: 'Payments',
       });
-    }
-    await paymentsPage.navigateToProgramPage('Payments');
-  });
 
-  await test.step('Validate export payment button', async () => {
-    await paymentsPage.exportButton.waitFor({ state: 'visible' });
-  });
+      await exportDataComponent.exportAndAssertData({
+        exactRowCount: 25, // defaults to export all payments, so 5 payments * 5 registrations
+        excludedColumns: ['id', 'created', 'updated', 'paymentDate'],
+        // Given that the payments are not consistently sorted,
+        // we need to sort them by registrationProgramId and payment
+        // to ensure the snapshot is stable.
+        sortFunction: (a: string[], b: string[], headerCells: string[]) => {
+          const registrationProgramIdIndex = headerCells.indexOf(
+            'registrationProgramId',
+          );
+          expect(registrationProgramIdIndex).toBeGreaterThan(-1);
+          const aId = a[registrationProgramIdIndex];
+          const bId = b[registrationProgramIdIndex];
 
-  await test.step('Export and validate file', async () => {
-    await paymentsPage.selectPaymentExportOption({
-      option: 'Payments',
-    });
+          if (aId !== bId) {
+            return Number.parseInt(aId, 10) - Number.parseInt(bId, 10);
+          }
 
-    await exportDataComponent.exportAndAssertData({
-      exactRowCount: 25, // defaults to export all payments, so 5 payments * 5 registrations
-      excludedColumns: ['id', 'created', 'updated', 'paymentDate'],
-      // Given that the payments are not consistently sorted,
-      // we need to sort them by registrationProgramId and payment
-      // to ensure the snapshot is stable.
-      sortFunction: (a: string[], b: string[], headerCells: string[]) => {
-        const registrationProgramIdIndex = headerCells.indexOf(
-          'registrationProgramId',
-        );
-        expect(registrationProgramIdIndex).toBeGreaterThan(-1);
-        const aId = a[registrationProgramIdIndex];
-        const bId = b[registrationProgramIdIndex];
+          const paymentIdIndex = headerCells.indexOf('paymentId');
+          expect(paymentIdIndex).toBeGreaterThan(-1);
+          const aPaymentId = a[paymentIdIndex];
+          const bPaymentId = b[paymentIdIndex];
 
-        if (aId !== bId) {
-          return Number.parseInt(aId, 10) - Number.parseInt(bId, 10);
-        }
-
-        const paymentIdIndex = headerCells.indexOf('paymentId');
-        expect(paymentIdIndex).toBeGreaterThan(-1);
-        const aPaymentId = a[paymentIdIndex];
-        const bPaymentId = b[paymentIdIndex];
-
-        return (
-          Number.parseInt(aPaymentId, 10) - Number.parseInt(bPaymentId, 10)
-        );
-      },
+          return (
+            Number.parseInt(aPaymentId, 10) - Number.parseInt(bPaymentId, 10)
+          );
+        },
+      });
     });
   });
-});
+}
 
 test('View available actions for admin', async ({ page, paymentsPage }) => {
   await test.step('Validate export options', async () => {

--- a/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
+++ b/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
@@ -21,62 +21,59 @@ test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   });
 });
 
-for (let run = 1; run <= 20; run++) {
-  test(`ExportPayments (run ${run})`, async ({
-    paymentsPage,
-    exportDataComponent,
-  }) => {
-    const accessToken = await getAccessToken();
-    await test.step('Do payments', async () => {
-      for (let i = 0; i < 4; i++) {
-        await doPaymentAndWaitForCompletion({
-          programId: programIdOCW,
-          referenceIds: registrationsOCW.map((reg) => reg.referenceId),
-          transferValue: 25,
-          accessToken,
-        });
-      }
-      await paymentsPage.navigateToProgramPage('Payments');
+test('Export Payments', async ({ paymentsPage, exportDataComponent }) => {
+  const accessToken = await getAccessToken();
+  await test.step('Do payments', async () => {
+    for (let i = 0; i < 4; i++) {
+      await doPaymentAndWaitForCompletion({
+        programId: programIdOCW,
+        referenceIds: registrationsOCW.map((reg) => reg.referenceId),
+        transferValue: 25,
+        accessToken,
+      });
+    }
+    await paymentsPage.navigateToProgramPage('Payments');
+  });
+
+  await test.step('Validate export payment button', async () => {
+    await paymentsPage.exportButton.waitFor({ state: 'visible' });
+  });
+
+  await test.step('Export and validate file', async () => {
+    await paymentsPage.selectPaymentExportOption({
+      option: 'Payments',
     });
 
-    await test.step('Validate export payment button', async () => {
-      await paymentsPage.exportButton.waitFor({ state: 'visible' });
-    });
+    await exportDataComponent.exportAndAssertData({
+      exactRowCount: 25, // defaults to export all payments, so 5 payments * 5 registrations
+      excludedColumns: ['id', 'created', 'updated', 'paymentDate'],
+      // Given that the payments are not consistently sorted,
+      // we need to sort them by registrationProgramId and payment
+      // to ensure the snapshot is stable.
+      sortFunction: (a: string[], b: string[], headerCells: string[]) => {
+        const registrationProgramIdIndex = headerCells.indexOf(
+          'registrationProgramId',
+        );
+        expect(registrationProgramIdIndex).toBeGreaterThan(-1);
+        const aId = a[registrationProgramIdIndex];
+        const bId = b[registrationProgramIdIndex];
 
-    await test.step('Export and validate file', async () => {
-      await paymentsPage.selectPaymentExportOption({
-        option: 'Payments',
-      });
+        if (aId !== bId) {
+          return Number.parseInt(aId, 10) - Number.parseInt(bId, 10);
+        }
 
-      await exportDataComponent.exportAndAssertData({
-        exactRowCount: 25, // defaults to export all payments, so 5 payments * 5 registrations
-        excludedColumns: ['id', 'created', 'updated', 'paymentDate'],
-        // Given that the payments are not consistently sorted,
-        // we need to sort them by registrationProgramId and payment
-        // to ensure the snapshot is stable.
-        sortFunction: (a: string[], b: string[], headerCells: string[]) => {
-          const registrationProgramIdIndex = headerCells.indexOf(
-            'registrationProgramId',
-          );
-          expect(registrationProgramIdIndex).toBeGreaterThan(-1);
-          const aId = a[registrationProgramIdIndex];
-          const bId = b[registrationProgramIdIndex];
+        const paymentIdIndex = headerCells.indexOf('paymentId');
+        expect(paymentIdIndex).toBeGreaterThan(-1);
+        const aPaymentId = a[paymentIdIndex];
+        const bPaymentId = b[paymentIdIndex];
 
-          if (aId !== bId) {
-            return parseInt(aId, 10) - parseInt(bId, 10);
-          }
-
-          const paymentIdIndex = headerCells.indexOf('paymentId');
-          expect(paymentIdIndex).toBeGreaterThan(-1);
-          const aPaymentId = a[paymentIdIndex];
-          const bPaymentId = b[paymentIdIndex];
-
-          return parseInt(aPaymentId, 10) - parseInt(bPaymentId, 10);
-        },
-      });
+        return (
+          Number.parseInt(aPaymentId, 10) - Number.parseInt(bPaymentId, 10)
+        );
+      },
     });
   });
-}
+});
 
 test('View available actions for admin', async ({ page, paymentsPage }) => {
   await test.step('Validate export options', async () => {

--- a/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
+++ b/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
@@ -27,6 +27,7 @@ for (let j = 0; j < 20; j++) {
     exportDataComponent,
   }) => {
     const accessToken = await getAccessToken();
+
     await test.step('Do payments', async () => {
       for (let i = 0; i < 4; i++) {
         await doPaymentAndWaitForCompletion({
@@ -44,22 +45,42 @@ for (let j = 0; j < 20; j++) {
       await expect(paymentsPage.createNewPaymentButton).toBeVisible();
     });
 
-        if (aId !== bId) {
-          return Number.parseInt(aId, 10) - Number.parseInt(bId, 10);
-        }
+    await test.step('Export and validate file', async () => {
+      await paymentsPage.selectPaymentExportOption({
+        option: 'Payments',
+      });
 
-        const paymentIdIndex = headerCells.indexOf('paymentId');
-        expect(paymentIdIndex).toBeGreaterThan(-1);
-        const aPaymentId = a[paymentIdIndex];
-        const bPaymentId = b[paymentIdIndex];
+      await exportDataComponent.exportAndAssertData({
+        exactRowCount: 25, // defaults to export all payments, so 5 payments * 5 registrations
+        excludedColumns: ['id', 'created', 'updated', 'paymentDate'],
+        // Given that the payments are not consistently sorted,
+        // we need to sort them by registrationProgramId and payment
+        // to ensure the snapshot is stable.
+        sortFunction: (a: string[], b: string[], headerCells: string[]) => {
+          const registrationProgramIdIndex = headerCells.indexOf(
+            'registrationProgramId',
+          );
+          expect(registrationProgramIdIndex).toBeGreaterThan(-1);
+          const aId = a[registrationProgramIdIndex];
+          const bId = b[registrationProgramIdIndex];
 
-        return (
-          Number.parseInt(aPaymentId, 10) - Number.parseInt(bPaymentId, 10)
-        );
-      },
+          if (aId !== bId) {
+            return Number.parseInt(aId, 10) - Number.parseInt(bId, 10);
+          }
+
+          const paymentIdIndex = headerCells.indexOf('paymentId');
+          expect(paymentIdIndex).toBeGreaterThan(-1);
+          const aPaymentId = a[paymentIdIndex];
+          const bPaymentId = b[paymentIdIndex];
+
+          return (
+            Number.parseInt(aPaymentId, 10) - Number.parseInt(bPaymentId, 10)
+          );
+        },
+      });
     });
   });
-});
+}
 
 test('View available actions for admin', async ({ page, paymentsPage }) => {
   await test.step('Validate export options', async () => {

--- a/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
+++ b/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
@@ -21,57 +21,62 @@ test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   });
 });
 
-test('ExportPayments', async ({ paymentsPage, exportDataComponent }) => {
-  const accessToken = await getAccessToken();
-  await test.step('Do payments', async () => {
-    for (let i = 0; i < 4; i++) {
-      await doPaymentAndWaitForCompletion({
-        programId: programIdOCW,
-        referenceIds: registrationsOCW.map((reg) => reg.referenceId),
-        transferValue: 25,
-        accessToken,
+for (let run = 1; run <= 20; run++) {
+  test(`ExportPayments (run ${run})`, async ({
+    paymentsPage,
+    exportDataComponent,
+  }) => {
+    const accessToken = await getAccessToken();
+    await test.step('Do payments', async () => {
+      for (let i = 0; i < 4; i++) {
+        await doPaymentAndWaitForCompletion({
+          programId: programIdOCW,
+          referenceIds: registrationsOCW.map((reg) => reg.referenceId),
+          transferValue: 25,
+          accessToken,
+        });
+      }
+      await paymentsPage.navigateToProgramPage('Payments');
+    });
+
+    await test.step('Validate export payment button', async () => {
+      await paymentsPage.exportButton.waitFor({ state: 'visible' });
+    });
+
+    await test.step('Export and validate file', async () => {
+      await paymentsPage.selectPaymentExportOption({
+        option: 'Payments',
       });
-    }
-    await paymentsPage.navigateToProgramPage('Payments');
-  });
 
-  await test.step('Validate export payment button', async () => {
-    await paymentsPage.exportButton.waitFor({ state: 'visible' });
-  });
+      await exportDataComponent.exportAndAssertData({
+        exactRowCount: 25, // defaults to export all payments, so 5 payments * 5 registrations
+        excludedColumns: ['id', 'created', 'updated', 'paymentDate'],
+        // Given that the payments are not consistently sorted,
+        // we need to sort them by registrationProgramId and payment
+        // to ensure the snapshot is stable.
+        sortFunction: (a: string[], b: string[], headerCells: string[]) => {
+          const registrationProgramIdIndex = headerCells.indexOf(
+            'registrationProgramId',
+          );
+          expect(registrationProgramIdIndex).toBeGreaterThan(-1);
+          const aId = a[registrationProgramIdIndex];
+          const bId = b[registrationProgramIdIndex];
 
-  await test.step('Export and validate file', async () => {
-    await paymentsPage.selectPaymentExportOption({
-      option: 'Payments',
-    });
+          if (aId !== bId) {
+            return parseInt(aId, 10) - parseInt(bId, 10);
+          }
 
-    await exportDataComponent.exportAndAssertData({
-      exactRowCount: 25, // defaults to export all payments, so 5 payments * 5 registrations
-      excludedColumns: ['id', 'created', 'updated', 'paymentDate'],
-      // Given that the payments are not consistently sorted,
-      // we need to sort them by registrationProgramId and payment
-      // to ensure the snapshot is stable.
-      sortFunction: (a: string[], b: string[], headerCells: string[]) => {
-        const registrationProgramIdIndex = headerCells.indexOf(
-          'registrationProgramId',
-        );
-        expect(registrationProgramIdIndex).toBeGreaterThan(-1);
-        const aId = a[registrationProgramIdIndex];
-        const bId = b[registrationProgramIdIndex];
+          const paymentIdIndex = headerCells.indexOf('paymentId');
+          expect(paymentIdIndex).toBeGreaterThan(-1);
+          const aPaymentId = a[paymentIdIndex];
+          const bPaymentId = b[paymentIdIndex];
 
-        if (aId !== bId) {
-          return parseInt(aId, 10) - parseInt(bId, 10);
-        }
-
-        const paymentIdIndex = headerCells.indexOf('paymentId');
-        expect(paymentIdIndex).toBeGreaterThan(-1);
-        const aPaymentId = a[paymentIdIndex];
-        const bPaymentId = b[paymentIdIndex];
-
-        return parseInt(aPaymentId, 10) - parseInt(bPaymentId, 10);
-      },
+          return parseInt(aPaymentId, 10) - parseInt(bPaymentId, 10);
+        },
+      });
     });
   });
-});
+}
 
 test('View available actions for admin', async ({ page, paymentsPage }) => {
   await test.step('Validate export options', async () => {

--- a/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
+++ b/e2e/portal/tests/ViewPayments/ExportPayments.spec.ts
@@ -27,7 +27,6 @@ for (let j = 0; j < 20; j++) {
     exportDataComponent,
   }) => {
     const accessToken = await getAccessToken();
-
     await test.step('Do payments', async () => {
       for (let i = 0; i < 4; i++) {
         await doPaymentAndWaitForCompletion({


### PR DESCRIPTION
[AB#43117](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43117) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

This pull request improves the reliability of the payments export end-to-end test by making the test more robust and running it multiple times to catch flakiness. The main changes are focused on the export functionality in both the test and the page object.

**Export menu interaction robustness:**

* In `PaymentsPage`, the logic for clicking the export menu item was updated to retry opening the export menu and waiting for the desired menu item to appear, making the test less likely to fail due to UI timing issues. If the menu item does not appear after two attempts, an error is thrown.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
