### PR TITLE
fix: Allow blob-URLs as images

### DIFF
--- a/interfaces/portal/scripts/build-deployment-configuration.mjs
+++ b/interfaces/portal/scripts/build-deployment-configuration.mjs
@@ -33,7 +33,7 @@ let contentSecurityPolicy = new Map([
   ['default-src', [`'self'`]],
   ['frame-ancestors', [`'self'`]],
   ['frame-src', [`blob:`, `'self'`]],
-  ['img-src', [`data:`, `'self'`]],
+  ['img-src', [`blob:`, `'self'`]],
   ['object-src', [`'none'`]],
   ['script-src', [`'self'`]],
   ['style-src', [`'self'`, `'unsafe-inline'`]],

--- a/interfaces/portal/scripts/test-deployment-configuration.mjs
+++ b/interfaces/portal/scripts/test-deployment-configuration.mjs
@@ -31,7 +31,7 @@ test('Deployment-configuration contains the defaults of the Content-Security-Pol
   const defaults = [
     `default-src 'self'`,
     `connect-src 'self'`,
-    `img-src data: 'self'`,
+    `img-src blob: 'self'`,
     `object-src 'none'`,
     `style-src 'self' 'unsafe-inline'`,
   ];

--- a/interfaces/portal/scripts/verify-deployment-configuration.mjs
+++ b/interfaces/portal/scripts/verify-deployment-configuration.mjs
@@ -41,7 +41,7 @@ test('Content-Security-Policy contains defaults', () => {
   const defaults = [
     `default-src 'self'`,
     `connect-src 'self'`,
-    `img-src data: 'self'`,
+    `img-src blob: 'self'`,
     `object-src 'none'`,
     `style-src 'self' 'unsafe-inline'`,
   ];


### PR DESCRIPTION
[AB#43357](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43357)

## Describe your changes

This should allow Firefox to show `blob:`-URLs as images in the Portal.

(The `data:`-URL scheme wasn't really used actually.)


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] I have also changed the tests
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8488.westeurope.3.azurestaticapps.net
