### PR TITLE
Add addressee phone number field for visa card ordering

### DIFF
--- a/e2e/portal/pages/ProgramMonitoringPage.ts
+++ b/e2e/portal/pages/ProgramMonitoringPage.ts
@@ -369,7 +369,7 @@ class ProgramMonitoring extends BasePage {
     await this.page
       .getByLabel('Addressee (name of the recipient of the package)')
       .fill(addressee);
-    await this.page.getByLabel('Addressee Phone number').fill(phoneNumber);
+    await this.page.getByLabel('Addressee phone number').fill(phoneNumber);
     await this.page.getByLabel('Street').fill(addressStreet);
     await this.page.getByLabel('House number').fill(addressHouseNumber);
     await this.page.getByLabel('Addition').fill(addressHouseNumberAddition);

--- a/e2e/portal/pages/ProgramMonitoringPage.ts
+++ b/e2e/portal/pages/ProgramMonitoringPage.ts
@@ -13,6 +13,7 @@ interface OrderDebitCardOrder {
   addressHouseNumber: string;
   addressHouseNumberAddition: string;
   addressee: string;
+  phoneNumber: string;
 }
 class ProgramMonitoring extends BasePage {
   page: Page;
@@ -355,6 +356,7 @@ class ProgramMonitoring extends BasePage {
   async orderCards({
     noOfCards,
     addressee,
+    phoneNumber,
     addressPostalCode,
     addressCity,
     addressStreet,
@@ -364,7 +366,10 @@ class ProgramMonitoring extends BasePage {
     await this.page.getByRole('button', { name: 'Order cards' }).click();
 
     await this.page.getByLabel('Number of cards').fill(noOfCards);
-    await this.page.getByLabel('Addressee').fill(addressee);
+    await this.page
+      .getByLabel('Addressee (name of the recipient of the package)')
+      .fill(addressee);
+    await this.page.getByLabel('Addressee Phone number').fill(phoneNumber);
     await this.page.getByLabel('Street').fill(addressStreet);
     await this.page.getByLabel('House number').fill(addressHouseNumber);
     await this.page.getByLabel('Addition').fill(addressHouseNumberAddition);

--- a/interfaces/portal/src/app/pages/program-monitoring-debit-cards/components/order-debit-cards-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-monitoring-debit-cards/components/order-debit-cards-dialog.component.html
@@ -52,6 +52,22 @@
       />
     </app-form-field-wrapper>
 
+    <app-form-field-wrapper
+      label="Addressee phone number"
+      i18n-label
+      [errorMessage]="formFieldErrors()('addresseePhoneNumber')"
+      [isRequired]="true"
+    >
+      <input
+        pInputText
+        [pSize]="'large'"
+        inputmode="tel"
+        type="text"
+        formControlName="addresseePhoneNumber"
+        autocomplete="off"
+      />
+    </app-form-field-wrapper>
+
     <div class="grid-cols-2 gap-4 inline-full sm:grid">
       <app-form-field-wrapper
         label="City"

--- a/interfaces/portal/src/app/pages/program-monitoring-debit-cards/components/order-debit-cards-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-monitoring-debit-cards/components/order-debit-cards-dialog.component.ts
@@ -121,6 +121,17 @@ export class OrderDebitCardsDialogComponent {
         nonNullable: true,
       },
     ),
+    addresseePhoneNumber: new FormControl<string>(
+      {
+        value: '',
+        disabled: false,
+      },
+      {
+        // eslint-disable-next-line @typescript-eslint/unbound-method -- https://github.com/typescript-eslint/typescript-eslint/issues/1929#issuecomment-618695608
+        validators: [Validators.required],
+        nonNullable: true,
+      },
+    ),
   });
 
   readonly formEvents = toSignal(this.formGroup.events);
@@ -139,6 +150,7 @@ export class OrderDebitCardsDialogComponent {
           addressHouseNumber: formValues.addressHouseNumber,
           addressHouseNumberAddition: formValues.addressHouseNumberAddition,
           addressee: formValues.addressee,
+          addresseePhoneNumber: formValues.addresseePhoneNumber,
         },
       });
     },

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -1272,6 +1272,9 @@
       <trans-unit id="641865702986102945" datatype="html">
         <source>Are you sure you want to delete this payment? This action cannot be undone.</source>
       </trans-unit>
+      <trans-unit id="6421318567345904044" datatype="html">
+        <source>Addressee phone number</source>
+      </trans-unit>
       <trans-unit id="6430223777327451722" datatype="html">
         <source>Total payment amount</source>
       </trans-unit>

--- a/services/121-service/src/fsp-integrations/account-management/intersolve-visa/dto/create-visa-card-order.dto.ts
+++ b/services/121-service/src/fsp-integrations/account-management/intersolve-visa/dto/create-visa-card-order.dto.ts
@@ -44,4 +44,9 @@ export class CreateVisaCardOrderDto {
   @IsNotEmpty()
   @IsString()
   public readonly addressee: string;
+
+  @ApiProperty({ example: '+31612345678' })
+  @IsNotEmpty()
+  @IsString()
+  public readonly addresseePhoneNumber: string;
 }

--- a/services/121-service/test/helpers/registration.helper.ts
+++ b/services/121-service/test/helpers/registration.helper.ts
@@ -699,6 +699,7 @@ export function createVisaCardOrder({
   addressPostalCode,
   addressCity,
   addressee,
+  addresseePhoneNumber,
 }: {
   programId: number;
   accessToken: string;
@@ -709,6 +710,7 @@ export function createVisaCardOrder({
   addressPostalCode: string;
   addressCity: string;
   addressee: string;
+  addresseePhoneNumber: string;
 }): Promise<request.Response> {
   return getServer()
     .post(`/programs/${programId}/fsps/intersolve-visa/wallet/cards/orders`)
@@ -721,6 +723,7 @@ export function createVisaCardOrder({
       addressPostalCode,
       addressCity,
       addressee,
+      addresseePhoneNumber,
     });
 }
 

--- a/services/121-service/test/program/manage-program-fsp-configuration.test.ts
+++ b/services/121-service/test/program/manage-program-fsp-configuration.test.ts
@@ -230,6 +230,7 @@ describe('Manage FSP-configurations', () => {
 
   it('should create multiple FSP-configurations from a list of fsp names', async () => {
     // Arrange
+    programId = await createProgramWithFspConfigurations({ accessToken });
     const fspNamesToCreate = [Fsps.airtel, Fsps.nedbank];
 
     // Act
@@ -246,9 +247,9 @@ describe('Manage FSP-configurations', () => {
 
     // Assert
     expect(result.statusCode).toBe(HttpStatus.OK);
-    expect(getResult.body.map((configuration) => configuration.fspName)).toEqual(
-      expect.arrayContaining(fspNamesToCreate),
-    );
+    expect(
+      getResult.body.map((configuration) => configuration.fspName),
+    ).toEqual(expect.arrayContaining(fspNamesToCreate));
   });
 
   it('should add a FSP configuration to program FSP configurations', async () => {

--- a/services/121-service/test/visa-card/order-visa-cards.test.ts
+++ b/services/121-service/test/visa-card/order-visa-cards.test.ts
@@ -13,7 +13,7 @@ import {
   resetDB,
 } from '@121-service/test/helpers/utility.helper';
 
-const addresseePhoneNumber = '123456789';
+const addresseePhoneNumber = '+31612345678';
 
 describe('Order visa debit cards in batch', () => {
   let accessToken: string;

--- a/services/121-service/test/visa-card/order-visa-cards.test.ts
+++ b/services/121-service/test/visa-card/order-visa-cards.test.ts
@@ -46,7 +46,6 @@ describe('Order visa debit cards in batch', () => {
       addresseePhoneNumber,
     });
 
-    console.log('orderResponse: ', orderResponse.body);
     // Assert
     expect(orderResponse.status).toBe(HttpStatus.CREATED);
     expect(orderResponse.body).toEqual({

--- a/services/121-service/test/visa-card/order-visa-cards.test.ts
+++ b/services/121-service/test/visa-card/order-visa-cards.test.ts
@@ -13,6 +13,8 @@ import {
   resetDB,
 } from '@121-service/test/helpers/utility.helper';
 
+const addresseePhoneNumber = '123456789';
+
 describe('Order visa debit cards in batch', () => {
   let accessToken: string;
 
@@ -41,8 +43,10 @@ describe('Order visa debit cards in batch', () => {
       addressPostalCode: '1011AB',
       addressCity: 'Amsterdam',
       addressee: 'John Doe',
+      addresseePhoneNumber,
     });
 
+    console.log('orderResponse: ', orderResponse.body);
     // Assert
     expect(orderResponse.status).toBe(HttpStatus.CREATED);
     expect(orderResponse.body).toEqual({
@@ -55,6 +59,7 @@ describe('Order visa debit cards in batch', () => {
       accessToken,
     });
     expect(ordersResponse.status).toBe(HttpStatus.OK);
+    // TODO: add phone number validation here once BE is ready
     expect(ordersResponse.body).toEqual(
       expect.arrayContaining([
         expect.objectContaining({


### PR DESCRIPTION
[AB#43387](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43387) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes


This pull request adds support for collecting and storing the addressee's phone number when ordering debit cards. The phone number is now a required field in the form, is included in the backend DTO, and is properly localized in the UI.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have added tests for my changes
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8492.westeurope.3.azurestaticapps.net
