### PR TITLE
Disable search without personal read permission

### DIFF
--- a/services/121-service/src/registration/services/registrations-pagination.service.ts
+++ b/services/121-service/src/registration/services/registrations-pagination.service.ts
@@ -100,7 +100,7 @@ export class RegistrationsPaginationService {
       }
     }
 
-    if (query.search) {
+    if (query.search && hasPersonalReadPermission) {
       queryBuilder =
         this.registrationViewScopedRepository.addSearchToQueryBuilder(
           queryBuilder,

--- a/services/121-service/test/registrations/pagination/get-registration-permission.test.ts
+++ b/services/121-service/test/registrations/pagination/get-registration-permission.test.ts
@@ -94,5 +94,23 @@ describe('Load PA table', () => {
       expect(data[0]).toStrictEqual(expectedValueObject);
       expect(meta.totalItems).toBe(1);
     });
+
+    it('should ignore search parameter when user lacks personal read permission', async () => {
+      // Arrange
+      // Search for a personal data value that does not exist on the registration
+      const searchValue = 'non-existent-value';
+
+      // Act
+      const getRegistrationsResponse = await getRegistrations({
+        programId: programIdOCW,
+        accessToken: accessTokenPersonalReadOnly,
+        filter: { search: searchValue },
+      });
+      const meta = getRegistrationsResponse.body.meta;
+
+      // Assert
+      // Without personal read permission, search should be ignored and all registrations returned
+      expect(meta.totalItems).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
[AB#43372](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43372) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes
Disable search if you do not have personal read permission

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
