### PR TITLE
Added no sniff to kobo image

### DIFF
--- a/services/121-service/src/kobo/kobo.controller.ts
+++ b/services/121-service/src/kobo/kobo.controller.ts
@@ -335,6 +335,7 @@ export class KoboController {
 
     res.writeHead(HttpStatus.OK, {
       'Content-Type': mimetype,
+      'X-Content-Type-Options': 'nosniff',
     });
 
     stream.pipe(res);


### PR DESCRIPTION
[AB#43220](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43220) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes
Added no sniff. 

By default, browsers do "MIME sniffing": if a response's declared Content-Type looks wrong, the browser inspects the actual bytes and may decide to treat the file as a different type than what the server said. This is a convenience feature, but it's also a security hole — a file served as image/png could be sniffed and rendered as HTML/JavaScript, leading to XSS.

nosniff disables that behavior. It tells the browser: "Trust my Content-Type header exactly, never guess." So a response labeled image/png will only ever be treated as an image, never as HTML or a script — even if the body contains <script> or SVG markup

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
