### PR TITLE
Removing confusing cancel button from team page

### DIFF
--- a/e2e/portal/pages/ProgramTeamPage.ts
+++ b/e2e/portal/pages/ProgramTeamPage.ts
@@ -42,10 +42,6 @@ class ProgramTeamPage extends BasePage {
     expectedSortedArraysToEqual(actualAssignedUsers, expectedAssignedUsers);
   }
 
-  async enableEditMode() {
-    await this.page.getByRole('button', { name: 'Edit team' }).click();
-  }
-
   async openAddUserForm() {
     await this.page.getByRole('button', { name: 'Add user to team' }).click();
   }

--- a/e2e/portal/tests/ManageTeam/AllSystemUsersCanBeAddedToProgramTeam.spec.ts
+++ b/e2e/portal/tests/ManageTeam/AllSystemUsersCanBeAddedToProgramTeam.spec.ts
@@ -46,7 +46,6 @@ test('All system-users are available to be added to a "program team"', async ({
     await programTeamPage.validateAssignedTeamMembers(expectedAssignedUsers);
   });
   await test.step('Validate available system users are visible', async () => {
-    await programTeamPage.enableEditMode();
     await programTeamPage.openAddUserForm();
     await programTeamPage.validateAvailableSystemUsers(
       expectedAvailablesystemUsers,

--- a/e2e/portal/tests/ManageTeam/AssignSuccessfullyRolesToUser.spec.ts
+++ b/e2e/portal/tests/ManageTeam/AssignSuccessfullyRolesToUser.spec.ts
@@ -35,7 +35,6 @@ test('Assign successfully roles to a user ', async ({ programTeamPage }) => {
   });
 
   await test.step('Validate available system users are visible', async () => {
-    await programTeamPage.enableEditMode();
     await programTeamPage.openAddUserForm();
     await programTeamPage.addUserToTeam({
       userSearchPhrase,

--- a/e2e/portal/tests/ManageTeam/RemoveUserFromTeam.spec.ts
+++ b/e2e/portal/tests/ManageTeam/RemoveUserFromTeam.spec.ts
@@ -44,7 +44,6 @@ test('Users should be removable from "program team"', async ({
   });
 
   await test.step('Validate available system users are visible', async () => {
-    await programTeamPage.enableEditMode();
     await programTeamPage.removeUserFromTeam({
       userEmail: userToRemove,
     });

--- a/e2e/portal/tests/ManageTeam/UserCannotAssignRolesToSelf.spec.ts
+++ b/e2e/portal/tests/ManageTeam/UserCannotAssignRolesToSelf.spec.ts
@@ -37,7 +37,6 @@ test('User cannot assign role to self', async ({ page, programTeamPage }) => {
 
   // Act
   await test.step('Check if warning appears that user cannot edit their own roles', async () => {
-    await programTeamPage.enableEditMode();
     await programTeamPage.editUser({
       userEmail: env.USERCONFIG_121_SERVICE_EMAIL_ADMIN,
     });

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/program-settings-registration-data.page.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/program-settings-registration-data.page.html
@@ -1,5 +1,5 @@
 <app-page-layout-program-settings [programId]="programId()">
-  <p-card class="[&_.p-card]:border-grey-300 mbe-4 [&_.p-card]:border">
+  <p-card>
     <h2
       i18n
       class="mbe-1"

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/program-settings-registration-data.page.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/program-settings-registration-data.page.html
@@ -1,5 +1,5 @@
 <app-page-layout-program-settings [programId]="programId()">
-  <p-card>
+  <p-card class="mbe-4">
     <h2
       i18n
       class="mbe-1"

--- a/interfaces/portal/src/app/pages/program-settings-team/program-settings-team.page.html
+++ b/interfaces/portal/src/app/pages/program-settings-team/program-settings-team.page.html
@@ -1,29 +1,28 @@
 <app-page-layout-program-settings [programId]="programId()">
-  <app-card-editable
-    header="Program team"
-    i18n-header="@@page-title-program-settings-team"
-    editPencilTitle="Edit team"
-    i18n-editPencilTitle
-    [canEdit]="canManageAidworkers()"
-    [(isEditing)]="isEditing"
-  >
-    <p
-      i18n
-      class="mbe-4"
+  <p-card>
+    <h2
+      i18n="@@page-title-program-settings-team"
+      class="mbe-1"
     >
-      Add users to your program team and assign roles to them.
-    </p>
+      Program team
+    </h2>
+    <div class="mbe-6">
+      <p i18n>Add users to your program team and assign roles to them.</p>
+    </div>
+
     <app-query-table
       [items]="programUsers.data() ?? []"
       [isPending]="programUsers.isPending()"
       [columns]="columns()"
       localStorageKey="program-team-table"
-      [contextMenuItems]="isEditing() ? contextMenuItems() : undefined"
+      [contextMenuItems]="
+        canManageAidworkers() ? contextMenuItems() : undefined
+      "
       (updateContextMenuItem)="selectedUser.set($event)"
       [globalFilterFields]="['username', 'allRolesLabel', 'scope']"
       [initialSortField]="'username'"
     >
-      @if (isEditing()) {
+      @if (canManageAidworkers()) {
         <div table-actions>
           <p-button
             label="Add user to team"
@@ -43,7 +42,7 @@
       [enableScope]="enableScope()"
       [userToEdit]="formMode() === 'edit' ? selectedUser() : undefined"
     />
-  </app-card-editable>
+  </p-card>
 </app-page-layout-program-settings>
 <app-form-dialog
   #removeUserConfirmationDialog

--- a/interfaces/portal/src/app/pages/program-settings-team/program-settings-team.page.ts
+++ b/interfaces/portal/src/app/pages/program-settings-team/program-settings-team.page.ts
@@ -63,7 +63,6 @@ export class ProgramSettingsTeamPageComponent {
     undefined,
   );
   readonly formMode = signal<'add' | 'edit'>('add');
-  readonly isEditing = signal(false);
 
   program = injectQuery(this.programApiService.getProgram(this.programId));
   programUsers = injectQuery(

--- a/interfaces/portal/src/app/pages/program-settings-team/program-settings-team.page.ts
+++ b/interfaces/portal/src/app/pages/program-settings-team/program-settings-team.page.ts
@@ -14,11 +14,11 @@ import {
 } from '@tanstack/angular-query-experimental';
 import { MenuItem } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 
 import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 
-import { CardEditableComponent } from '~/components/card-editable/card-editable.component';
 import { FormDialogComponent } from '~/components/form-dialog/form-dialog.component';
 import { PageLayoutProgramSettingsComponent } from '~/components/page-layout-program-settings/page-layout-program-settings.component';
 import { QueryTableComponent } from '~/components/query-table/query-table.component';
@@ -39,7 +39,7 @@ import { ToastService } from '~/services/toast.service';
     ConfirmDialogModule,
     FormDialogComponent,
     PageLayoutProgramSettingsComponent,
-    CardEditableComponent,
+    CardModule,
   ],
   providers: [ToastService],
   templateUrl: './program-settings-team.page.html',
@@ -143,7 +143,7 @@ export class ProgramSettingsTeamPageComponent {
     },
     {
       label: $localize`:@@remove-user-button:Remove user`,
-      icon: 'pi pi-times text-red-500',
+      icon: 'pi pi-trash text-red-500',
       visible: this.canManageAidworkers(),
       command: () => {
         this.removeUserConfirmationDialog().show();

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -1112,9 +1112,6 @@
       <trans-unit id="5641945527911431559" datatype="html">
         <source>Error: <x equiv-text="{{ versionInfo.error()?.message }}" id="INTERPOLATION"/></source>
       </trans-unit>
-      <trans-unit id="5649335820714201159" datatype="html">
-        <source>Edit team</source>
-      </trans-unit>
       <trans-unit id="5656654201977017111" datatype="html">
         <source>Refresh link</source>
       </trans-unit>
@@ -1171,6 +1168,9 @@
       </trans-unit>
       <trans-unit id="5918723526444903137" datatype="html">
         <source>Add user</source>
+      </trans-unit>
+      <trans-unit id="5923534039191412132" datatype="html">
+        <source>Add users to your program team and assign roles to them.</source>
       </trans-unit>
       <trans-unit id="5951235042771324221" datatype="html">
         <source>&quot;<x equiv-text="text" id="PH"/>&quot; copied to clipboard</source>
@@ -1733,9 +1733,6 @@
       </trans-unit>
       <trans-unit id="8390249546875631537" datatype="html">
         <source>Important Notice: The card balances available for download are not in real-time. The report includes the date and time of each card&apos;s last external update.</source>
-      </trans-unit>
-      <trans-unit id="8404737252518090392" datatype="html">
-        <source>Add users to your program team and assign roles to them.</source>
       </trans-unit>
       <trans-unit id="8409002705238592127" datatype="html">
         <source>Review summary and approve payment. The payment can only be started once all needed users approve the payment.</source>


### PR DESCRIPTION
[AB#43480](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43480)

## Describe your changes

The changes made in 'Edit mode' on this form are instantly executed. Having a 'Cancel' button there implies that changes are not saved instantly, but confusing since there is no 'Save' button present.

Issue found and discussed with Design prior to execution of PR

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes
- [x] Tests are updated
- [x] I have made sure that all automated checks pass before requesting a review


## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8521.westeurope.3.azurestaticapps.net
