### PR TITLE
Testing run-test label trigger

### DIFF
--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       ${{ github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'run-tests') }}
+      contains(github.event.pull_request.labels.*.name, 'run-e2e-portal') }}
     outputs:
       should_skip: ${{ steps.filter.outputs.should_skip }}
     steps:
@@ -58,10 +58,7 @@ jobs:
   lint-code:
     needs: path-filter
     runs-on: ubuntu-latest
-    if: >-
-      ${{ needs.path-filter.outputs.should_skip != 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'run-tests')) }}
+    if: ${{ needs.path-filter.outputs.should_skip != 'true' }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v7
@@ -87,10 +84,7 @@ jobs:
     needs:
       - path-filter
       - lint-code
-    if: >-
-      ${{ needs.path-filter.outputs.should_skip != 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'run-tests')) }}
+    if: ${{ needs.path-filter.outputs.should_skip != 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -25,6 +25,9 @@ env:
 jobs:
   path-filter:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'run-tests')
     outputs:
       should_skip: ${{ steps.filter.outputs.should_skip }}
     steps:

--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -58,7 +58,7 @@ jobs:
     if: >-
       needs.path-filter.outputs.should_skip != 'true' &&
       (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'run-e2e'))
+       contains(github.event.pull_request.labels.*.name, 'run-tests'))
     steps:
       - name: Check out repository code
         uses: actions/checkout@v7
@@ -87,7 +87,7 @@ jobs:
     if: >-
       needs.path-filter.outputs.should_skip != 'true' &&
       (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'run-e2e'))
+       contains(github.event.pull_request.labels.*.name, 'run-tests'))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -26,8 +26,8 @@ jobs:
   path-filter:
     runs-on: ubuntu-latest
     if: >-
-      github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'run-tests')
+      ${{ github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'run-tests') }}
     outputs:
       should_skip: ${{ steps.filter.outputs.should_skip }}
     steps:
@@ -59,9 +59,9 @@ jobs:
     needs: path-filter
     runs-on: ubuntu-latest
     if: >-
-      needs.path-filter.outputs.should_skip != 'true' &&
+      ${{ needs.path-filter.outputs.should_skip != 'true' &&
       (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'run-tests'))
+       contains(github.event.pull_request.labels.*.name, 'run-tests')) }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v7
@@ -88,9 +88,9 @@ jobs:
       - path-filter
       - lint-code
     if: >-
-      needs.path-filter.outputs.should_skip != 'true' &&
+      ${{ needs.path-filter.outputs.should_skip != 'true' &&
       (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'run-tests'))
+       contains(github.event.pull_request.labels.*.name, 'run-tests')) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -10,6 +10,7 @@ on:
   merge_group:
     types: [checks_requested]
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -54,7 +55,10 @@ jobs:
   lint-code:
     needs: path-filter
     runs-on: ubuntu-latest
-    if: ${{ needs.path-filter.outputs.should_skip != 'true' }}
+    if: >-
+      needs.path-filter.outputs.should_skip != 'true' &&
+      (github.event_name != 'pull_request' ||
+       contains(github.event.pull_request.labels.*.name, 'run-e2e'))
     steps:
       - name: Check out repository code
         uses: actions/checkout@v7
@@ -80,7 +84,10 @@ jobs:
     needs:
       - path-filter
       - lint-code
-    if: ${{ needs.path-filter.outputs.should_skip != 'true' }}
+    if: >-
+      needs.path-filter.outputs.should_skip != 'true' &&
+      (github.event_name != 'pull_request' ||
+       contains(github.event.pull_request.labels.*.name, 'run-e2e'))
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
[AB#43540](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43540) 

## Describe your changes

- If the `run-e2e-portal` label is not present, no E2E test jobs run. Only the lightweight test-shard-resolution-e2e job executes so the required status check still reports success and doesn't block the PR.
- If the `run-e2e-portal` label is present, the full E2E pipeline is triggered — and re-triggered on each new commit (synchronize) while the label remains.

Removing the label does not cancel an in-progress run; it simply prevents the pipeline from running on subsequent commits.

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have addressed all Copilot comments
- [ ] The changes do not touch the UI/UX
- [ ] Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a review

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
