### PR TITLE
chore: remove fsp's endpoint permissions

### DIFF
--- a/services/121-service/src/fsp-management/fsp.controller.ts
+++ b/services/121-service/src/fsp-management/fsp.controller.ts
@@ -13,7 +13,7 @@ import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 export class FspsController {
   public constructor(private readonly fspService: FspsService) {}
 
-  @AuthenticatedUser({ isAdmin: true })
+  @AuthenticatedUser({ permissions: [PermissionEnum.ProgramREAD] })
   @ApiOperation({
     summary: 'Get all enabled Financial Service Providers. (Fsps)',
   })

--- a/services/121-service/src/fsp-management/fsp.controller.ts
+++ b/services/121-service/src/fsp-management/fsp.controller.ts
@@ -5,7 +5,6 @@ import { FspsService } from '@121-service/src/fsp-management/fsp.service';
 import { FspSettingsDto } from '@121-service/src/fsp-management/fsp-settings.dto';
 import { AuthenticatedUser } from '@121-service/src/guards/authenticated-user.decorator';
 import { AuthenticatedUserGuard } from '@121-service/src/guards/authenticated-user.guard';
-import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 
 @UseGuards(AuthenticatedUserGuard)
 @ApiTags('fsps')
@@ -13,7 +12,7 @@ import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 export class FspsController {
   public constructor(private readonly fspService: FspsService) {}
 
-  @AuthenticatedUser({ permissions: [PermissionEnum.ProgramREAD] })
+  @AuthenticatedUser()
   @ApiOperation({
     summary: 'Get all enabled Financial Service Providers. (Fsps)',
   })
@@ -38,7 +37,7 @@ export class FspsController {
     description: 'Fsp with attributes',
     type: FspSettingsDto,
   })
-  @AuthenticatedUser({ permissions: [PermissionEnum.ProgramREAD] })
+  @AuthenticatedUser()
   @Get(':fspName')
   public async getFspByName(
     @Param('fspName')


### PR DESCRIPTION
[AB#43577](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43577) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Removed permissions for fsp's endpoints. All authenticated users are now able to get fsp data.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
