### PR TITLE
Trimming the fsp name before dashing

### DIFF
--- a/interfaces/portal/src/app/pages/program-settings-fsps/components/fsp-configuration-form-dialog/fsp-configuration-form-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-fsps/components/fsp-configuration-form-dialog/fsp-configuration-form-dialog.component.ts
@@ -109,7 +109,7 @@ export class FspConfigurationFormDialogComponent {
 
       const fspConfiguration = {
         // TODO: AB#38589 - edit name separately from display name
-        name: dash(formGroupData.displayName),
+        name: dash(formGroupData.displayName.trim()),
         label: {
           // Intentionally using 'en' here, as we don't actually want to translate the display name
           en: formGroupData.displayName,

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/required-attributes/required-attributes.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/required-attributes/required-attributes.component.ts
@@ -47,9 +47,9 @@ export class RequiredAttributesComponent {
     this.fspConfigurationApiService.getFspConfigurations(this.programId),
   );
 
-  readonly programFsps = computed(() => {
+  readonly programFspNames = computed(() => {
     const fspConfigs = this.fspConfigurations.data() ?? [];
-    return fspConfigs.map((config) => FSP_SETTINGS[config.fspName]);
+    return fspConfigs.map((fspConfig) => fspConfig.name);
   });
 
   readonly program = injectQuery(
@@ -100,10 +100,8 @@ export class RequiredAttributesComponent {
       name: 'fsp',
       label: 'Fsp',
       infoTooltip: () => {
-        const fspNames = this.programFsps()
-          .map((fsp) => fsp.name)
-          .join(', ');
-        return this.programFsps().length === 1
+        const fspNames = this.programFspNames().join(', ');
+        return this.programFspNames().length === 1
           ? $localize`fsp should be a 'hidden' field in your form that has the 'default response' set to the FSP name: ${fspNames}`
           : $localize`fsp should be 'select many' with the following FSP names as options: ${fspNames}`;
       },


### PR DESCRIPTION
[AB#43581](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43581) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

- Remove leading and trailing white space before 'dashing'
- Make sure that the popover displays correct array of `name` instead of `FspName`

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a reviews)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8556.westeurope.3.azurestaticapps.net
