### PR TITLE
Hiding minimize button for payment dialog

### DIFF
--- a/interfaces/portal/src/styles.css
+++ b/interfaces/portal/src/styles.css
@@ -463,7 +463,8 @@ svg-icon svg {
    * While minimized, the dialog changes size on step change.
    * See AB#43199 for details.
    */
-  app-create-program-dialog {
+  app-create-program-dialog,
+  app-fullscreen-stepper-dialog {
     .p-dialog-maximize-button {
       display: none;
     }

--- a/interfaces/portal/src/styles.css
+++ b/interfaces/portal/src/styles.css
@@ -459,9 +459,9 @@ svg-icon svg {
   }
 
   /**
-   * Workaround to disable minimizing app-crate-program-dialog.
-   * While minimized, the dialog changes size on step change.
-   * See AB#43199 for details.
+   * Workaround to disable minimizing 'maximized' PrimeNG dialogs.
+   * If a fullscreen dialog is minimized, the dialog UI is broken.
+   * See AB#43199 and AB#43622 for details.
    */
   app-create-program-dialog,
   app-fullscreen-stepper-dialog {


### PR DESCRIPTION
[AB#43622](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43622) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Because PrimeNG is a bad UI library it has no baked in props or other ways to set a dialog size, like _fullscreen_ (or any other sizing for that matter). The only way _fullscreen_ can be achieved is by allowing it to be minimized, and then use convoluted code to 'maximize' it on a  dialog open event... This then also renders a 'minimize' button by default.

This hides the minize button for the 'Create payment' dialog.
Same issue was picked up here: [AB#43199](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43199)

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8576.westeurope.3.azurestaticapps.net
