### PR TITLE
Change validation of exported data because column-order is not guaranteed

### DIFF
--- a/e2e/portal/pages/BasePage.ts
+++ b/e2e/portal/pages/BasePage.ts
@@ -340,6 +340,7 @@ class BasePage {
     const headerIndexByName = new Map(
       headerCells.map((columnName, index) => [columnName, index]),
     );
+    const excludedColumnSet = new Set(excludedColumns);
 
     // Validate excluded columns and remove them from the normalized output.
     for (const column of excludedColumns) {
@@ -351,7 +352,7 @@ class BasePage {
     }
 
     const headerCellsToValidate = headerCells.filter(
-      (columnName) => !excludedColumns.includes(columnName),
+      (columnName) => !excludedColumnSet.has(columnName),
     );
     const sortedHeaderCells = [...headerCellsToValidate].sort((a, b) =>
       a.localeCompare(b),

--- a/e2e/portal/pages/BasePage.ts
+++ b/e2e/portal/pages/BasePage.ts
@@ -337,26 +337,41 @@ class BasePage {
       data.sort((a, b) => a.localeCompare(b));
     }
 
-    const dataToValidate = data[0];
-    const dataCells = dataToValidate?.split(',') ?? [];
+    const headerIndexByName = new Map(
+      headerCells.map((columnName, index) => [columnName, index]),
+    );
 
-    // remove excluded columns from the header and data
-    excludedColumns.forEach((column) => {
-      const index = headerCells.indexOf(column);
-      if (index > -1) {
-        headerCells.splice(index, 1);
-        dataCells.splice(index, 1);
-      } else {
+    // Validate excluded columns and remove them from the normalized output.
+    for (const column of excludedColumns) {
+      if (!headerIndexByName.has(column)) {
         throw new Error(
           `Column to exclude "${column}" not found in header row`,
         );
       }
-    });
+    }
 
-    let normalizedDownloadedFile = headerCells.join(',');
+    const headerCellsToValidate = headerCells.filter(
+      (columnName) => !excludedColumns.includes(columnName),
+    );
+    const sortedHeaderCells = [...headerCellsToValidate].sort((a, b) =>
+      a.localeCompare(b),
+    );
+
+    let normalizedDownloadedFile = sortedHeaderCells.join(',');
 
     if (data.length > 0) {
-      normalizedDownloadedFile += '\n' + dataCells.join(',');
+      const dataToValidate = data[0];
+      const dataCells = dataToValidate?.split(',') ?? [];
+
+      const normalizedDataCells = sortedHeaderCells.map((columnName) => {
+        const columnIndex = headerIndexByName.get(columnName);
+        if (columnIndex === undefined) {
+          throw new Error(`Column "${columnName}" not found in header row`);
+        }
+        return dataCells[columnIndex] ?? '';
+      });
+
+      normalizedDownloadedFile += '\n' + normalizedDataCells.join(',');
     }
 
     // make sure we have the expected columns, and also validate the first row of data


### PR DESCRIPTION
[AB#43628](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43628) 

## Describe your changes

After me and skyNet did some investigation as to why ExportPayments.spec.ts is flaky we came to understand that the order of the exported columns is not always the same, and can change during runs.

My T-800 said the following on this:

> The test was flaky because the exported file sometimes had the same information in a different column order. Nothing important in the data changed, but the test compared the exact CSV text, so it treated that harmless reshuffling as a failure.
> 
>The backend is not explicitly saying “these export columns must always come in this exact order,” so the final order depends on how fields happen to be collected and merged at runtime.
>
>In this case, the export row is built from multiple pieces:
> - transaction fields
> - registration fields
> - some dynamically configured program attributes
>
> Those pieces are merged into one object in `payments-reporting.service.ts`, and some of the registration attributes come from database queries that do not enforce a fixed ORDER BY. If the database returns those attributes in a slightly different sequence, or the merged object is assembled in a different insertion order, the XLSX/CSV generator uses that order for the columns. So the data is still correct, but the column layout can vary because the backend never guaranteed one strict column sequence.
>
> The implemented solution makes the test ignore column order and focus on the actual content instead. We did it this way because it keeps the test checking the real thing we care about, whether the export contains the right data, without hardcoding one exact column layout or changing backend behavior.


## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have addressed all Copilot comments
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a review

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
