### PR TITLE
fix: Use a correct label for Transaction-event meta-data (Remove confusion arount "Who approved/created the payment")

### DIFF
--- a/interfaces/portal/src/app/pages/program-registration-activity-log/components/activity-log-expanded-row/activity-log-expanded-row.component.ts
+++ b/interfaces/portal/src/app/pages/program-registration-activity-log/components/activity-log-expanded-row/activity-log-expanded-row.component.ts
@@ -229,7 +229,7 @@ export class ActivityLogExpandedRowComponent implements TableCellComponent<
             },
           },
           {
-            label: $localize`Approved by`,
+            label: $localize`Created by`,
             chipLabel: user.username,
             chipVariant: 'blue',
           },

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -579,9 +579,6 @@
       <trans-unit id="3460608979438095670" datatype="html">
         <source>Retry failed transaction</source>
       </trans-unit>
-      <trans-unit id="3488602326654044677" datatype="html">
-        <source>Approved by</source>
-      </trans-unit>
       <trans-unit id="349264413670639690" datatype="html">
         <source>Choose message</source>
       </trans-unit>
@@ -1538,6 +1535,9 @@
       </trans-unit>
       <trans-unit id="7410432243549869948" datatype="html">
         <source>Duration</source>
+      </trans-unit>
+      <trans-unit id="7448808151142843482" datatype="html">
+        <source>Created by</source>
       </trans-unit>
       <trans-unit id="7450324673386885301" datatype="html">
         <source>Postal code</source>


### PR DESCRIPTION
Closes #8596
Resolves [AB#43672](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43672)

## Describe your changes

Only replacing the label.

(Contrary to the fix provided in #8596 ; So either merge _that_ PR or _**this one**_.)

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have NOT asked the design team to review these changes, as it fixes incorrectness in the UI
- [x] I have NOT added tests for my changes, its sort of irrelevant for this text-only issue
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)
- [⚠️] See discussion on [AB#43672](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43672)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8583.westeurope.3.azurestaticapps.net
