### PR TITLE
Stop browser smoothing from changing our bold into ugly bold

### DIFF
--- a/interfaces/portal/src/styles.css
+++ b/interfaces/portal/src/styles.css
@@ -55,7 +55,7 @@ html {
 }
 
 body {
-  @apply bg-grey-100 font-body text-base text-black;
+  @apply bg-grey-100 font-body text-base text-black antialiased;
 }
 
 :root {


### PR DESCRIPTION
[AB#43694](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43694)

## Describe your changes

Browser smoothing caused the font-weight bold to be bolder (and dirtier) in the application then in the design.
This PR fixes that small - but noticeable - difference.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes
- [x] Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a review

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8594.westeurope.3.azurestaticapps.net
