### PR TITLE
Set debit card created on true when linking existing debit card

### DIFF
--- a/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.ts
@@ -959,6 +959,7 @@ export class IntersolveVisaService {
     newIntersolveVisaChildWallet.walletStatus =
       IntersolveVisaTokenStatus.Inactive;
     newIntersolveVisaChildWallet.isLinkedToParentWallet = true;
+    newIntersolveVisaChildWallet.isDebitCardCreated = true;
     newIntersolveVisaChildWallet.lastExternalUpdate = new Date();
     const savedChildWallet =
       await this.intersolveVisaChildWalletScopedRepository.save(

--- a/services/121-service/test/visa-card/link-card-on-site.test.ts
+++ b/services/121-service/test/visa-card/link-card-on-site.test.ts
@@ -2,11 +2,18 @@ import { HttpStatus } from '@nestjs/common';
 
 import { IntersolveVisaWalletDto } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/dtos/internal/intersolve-visa-wallet.dto';
 import { VisaCard121Status } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/enums/wallet-status-121.enum';
+import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import {
   programIdVisa,
   registrationVisa,
+  transferValueVisa,
 } from '@121-service/src/seed-data/mock/visa-card.data';
+import {
+  doPayment,
+  getTransactionsByPaymentIdPaginated,
+  waitForPaymentAndTransactionsToComplete,
+} from '@121-service/test/helpers/program.helper';
 import { updateProgramCardDistributionByMail } from '@121-service/test/helpers/program-fsp-configuration.helper';
 import {
   getVisaWalletsAndDetails,
@@ -48,20 +55,46 @@ describe('Link Visa debit card on site', () => {
       tokenCode,
     });
 
+    const doPaymentResponse = await doPayment({
+      programId: programIdVisa,
+      transferValue: transferValueVisa,
+      referenceIds: [registrationVisa.referenceId],
+      accessToken,
+    });
+    const paymentId = doPaymentResponse.body.id;
+
+    await waitForPaymentAndTransactionsToComplete({
+      programId: programIdVisa,
+      paymentReferenceIds: [registrationVisa.referenceId],
+      paymentId,
+      accessToken,
+      maxWaitTimeMs: 10_000,
+      completeStatuses: [TransactionStatusEnum.success],
+    });
+
     const getVisaWalletResponse = await getVisaWalletsAndDetails(
       programIdVisa,
       registrationVisa.referenceId,
       accessToken,
     );
     const parentWallet = getVisaWalletResponse.body as IntersolveVisaWalletDto;
-
     const card = parentWallet.cards[0];
+
+    const transactionsResponse = await getTransactionsByPaymentIdPaginated({
+      programId: programIdVisa,
+      paymentId,
+      registrationReferenceId: registrationVisa.referenceId,
+      accessToken,
+    });
 
     // Assert
     expect(response.status).toBe(HttpStatus.CREATED);
-
     expect(card.tokenCode).toBe(tokenCode);
     expect(card.status).toBe(VisaCard121Status.Active);
+    expect(doPaymentResponse.status).toBe(HttpStatus.CREATED);
+    expect(transactionsResponse.body.data[0].status).toBe(
+      TransactionStatusEnum.success,
+    );
   });
 
   it('should throw when linking a Visa Debit card that is already linked', async () => {


### PR DESCRIPTION
[AB#43743](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43743) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Set isDebitCardCreated to true when linking a debit card & extend related test

See more extensive description in devops

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
