### PR TITLE
bugfix: do not create physical card when replacing card on-site

### DIFF
--- a/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.spec.ts
@@ -665,7 +665,7 @@ describe('IntersolveVisaService', () => {
       (childWalletRepo.save as jest.Mock).mockImplementation(
         async (wallet: IntersolveVisaChildWalletEntity) => ({
           ...wallet,
-          id: 20,
+          id: wallet.id ?? 20,
         }),
       );
       jest.spyOn(apiService, 'substituteToken').mockResolvedValue(undefined);

--- a/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.spec.ts
@@ -64,6 +64,7 @@ describe('IntersolveVisaService', () => {
             setTokenBlocked: jest.fn(),
             issueToken: jest.fn(),
             createPhysicalCard: jest.fn(),
+            substituteToken: jest.fn(),
             getAuthenticationToken: jest.fn().mockResolvedValue('mock-token'),
           },
         },
@@ -86,6 +87,7 @@ describe('IntersolveVisaService', () => {
           useValue: {
             updateUnscoped: jest.fn(),
             findOneOrFail: jest.fn(),
+            save: jest.fn(),
           },
         },
         {
@@ -625,6 +627,90 @@ describe('IntersolveVisaService', () => {
         coverLetterCode: 'COVER_LETTER',
         contactInformation,
       });
+    });
+  });
+
+  describe('replaceCard', () => {
+    const contactInformation = {
+      name: 'John Doe',
+      addressStreet: 'Damrak',
+      addressHouseNumber: '1',
+      addressPostalCode: '1011AB',
+      addressCity: 'Amsterdam',
+      phoneNumber: '+31600000000',
+      emailAddress: 'john.doe@example.org',
+    };
+    const brandCode = 'BRAND';
+    const coverLetterCode = 'COVER_LETTER';
+
+    beforeEach(() => {
+      const childWalletToReplace = new IntersolveVisaChildWalletEntity();
+      childWalletToReplace.id = 10;
+      childWalletToReplace.tokenCode = 'old-token';
+      childWalletToReplace.isTokenBlocked = false;
+      childWalletToReplace.isDebitCardCreated = true;
+      childWalletToReplace.created = new Date('2023-01-01T00:00:00Z');
+
+      const parentWalletWithCard = new IntersolveVisaParentWalletEntity();
+      parentWalletWithCard.tokenCode = 'parent-token';
+      parentWalletWithCard.intersolveVisaChildWallets = [childWalletToReplace];
+
+      const customerWithCard = new IntersolveVisaCustomerEntity();
+      customerWithCard.holderId = 'holder-1';
+      customerWithCard.intersolveVisaParentWallet = parentWalletWithCard;
+
+      jest
+        .spyOn(customerRepo, 'findOneWithWalletsByRegistrationId')
+        .mockResolvedValue(customerWithCard);
+      (childWalletRepo.save as jest.Mock).mockImplementation(
+        async (wallet: IntersolveVisaChildWalletEntity) => ({
+          ...wallet,
+          id: 20,
+        }),
+      );
+      jest.spyOn(apiService, 'substituteToken').mockResolvedValue(undefined);
+      jest.spyOn(childWalletRepo, 'updateUnscoped').mockImplementation();
+    });
+
+    it('should not create a physical card when replacing an on-site linked card, because the physical card already exists', async () => {
+      // Arrange: an on-site replacement provides an already-printed physical card token
+      jest.spyOn(apiService, 'getToken').mockResolvedValue({
+        status: IntersolveVisaTokenStatus.Active,
+        blocked: false,
+        balance: 0,
+      });
+
+      // Act
+      await service.replaceCard({
+        registrationId,
+        contactInformation,
+        brandCode,
+        coverLetterCode,
+        physicalCardToken: 'new-physical-token',
+      });
+
+      // Assert
+      expect(apiService.createPhysicalCard).not.toHaveBeenCalled();
+    });
+
+    it('should create a physical card when replacing a by-mail card, because no physical card exists yet', async () => {
+      // Arrange: a by-mail replacement has no physical card token, so a new token is issued
+      jest.spyOn(apiService, 'issueToken').mockResolvedValue({
+        code: 'new-token',
+        status: IntersolveVisaTokenStatus.Active,
+        blocked: false,
+      });
+
+      // Act
+      await service.replaceCard({
+        registrationId,
+        contactInformation,
+        brandCode,
+        coverLetterCode,
+      });
+
+      // Assert
+      expect(apiService.createPhysicalCard).toHaveBeenCalled();
     });
   });
 });

--- a/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.ts
@@ -587,16 +587,17 @@ export class IntersolveVisaService {
     );
 
     // Create new card
-    await this.intersolveVisaApiService.createPhysicalCard({
-      tokenCode: newChildWallet.tokenCode,
+    const { isNewCardCreated } = await this.createDebitCardIfNotExists({
+      childWallet: newChildWallet,
       contactInformation: input.contactInformation,
       coverLetterCode: input.coverLetterCode,
     });
 
-    // Update child wallet: set isDebitCardCreated to true
-    newChildWallet.isDebitCardCreated = true;
-    newChildWallet.cardStatus = IntersolveVisaCardStatus.CardOk;
-    await this.intersolveVisaChildWalletScopedRepository.save(newChildWallet);
+    if (!isNewCardCreated) {
+      newChildWallet.isDebitCardCreated = true;
+      newChildWallet.cardStatus = IntersolveVisaCardStatus.CardOk;
+      await this.intersolveVisaChildWalletScopedRepository.save(newChildWallet);
+    }
   }
 
   public async hasIntersolveCustomer(registrationId: number): Promise<boolean> {

--- a/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.ts
@@ -571,7 +571,7 @@ export class IntersolveVisaService {
     newIntersolveVisaChildWallet.walletStatus =
       tokenResult.status as IntersolveVisaTokenStatus;
     newIntersolveVisaChildWallet.lastExternalUpdate = new Date();
-    newIntersolveVisaChildWallet.isLinkedToParentWallet = true; 
+    newIntersolveVisaChildWallet.isLinkedToParentWallet = true;
     const newChildWallet =
       await this.intersolveVisaChildWalletScopedRepository.save(
         newIntersolveVisaChildWallet,
@@ -579,7 +579,7 @@ export class IntersolveVisaService {
     intersolveVisaCustomer.intersolveVisaParentWallet.intersolveVisaChildWallets.push(
       newChildWallet,
     );
- 
+
     // Update old child wallet: set status to SUBSTITUTED
     childWalletToReplace.walletStatus = IntersolveVisaTokenStatus.Substituted;
     await this.intersolveVisaChildWalletScopedRepository.save(

--- a/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.ts
@@ -571,12 +571,7 @@ export class IntersolveVisaService {
     newIntersolveVisaChildWallet.walletStatus =
       tokenResult.status as IntersolveVisaTokenStatus;
     newIntersolveVisaChildWallet.lastExternalUpdate = new Date();
-    newIntersolveVisaChildWallet.isLinkedToParentWallet = true;
-    // An on-site replacement uses an already-printed physical card, so no new card has to be created for it
-    if (input.physicalCardToken) {
-      newIntersolveVisaChildWallet.isDebitCardCreated = true;
-      newIntersolveVisaChildWallet.cardStatus = IntersolveVisaCardStatus.CardOk;
-    }
+    newIntersolveVisaChildWallet.isLinkedToParentWallet = true; 
     const newChildWallet =
       await this.intersolveVisaChildWalletScopedRepository.save(
         newIntersolveVisaChildWallet,
@@ -584,18 +579,24 @@ export class IntersolveVisaService {
     intersolveVisaCustomer.intersolveVisaParentWallet.intersolveVisaChildWallets.push(
       newChildWallet,
     );
-
+ 
     // Update old child wallet: set status to SUBSTITUTED
     childWalletToReplace.walletStatus = IntersolveVisaTokenStatus.Substituted;
     await this.intersolveVisaChildWalletScopedRepository.save(
       childWalletToReplace,
     );
+ 
+    if (!input.physicalCardToken) {
+      await this.intersolveVisaApiService.createPhysicalCard({
+        tokenCode: newChildWallet.tokenCode,
+        contactInformation: input.contactInformation,
+        coverLetterCode: input.coverLetterCode,
+      });
+    }
 
-    await this.createDebitCardIfNotExists({
-      childWallet: newChildWallet,
-      contactInformation: input.contactInformation,
-      coverLetterCode: input.coverLetterCode,
-    });
+    newChildWallet.isDebitCardCreated = true;
+    newChildWallet.cardStatus = IntersolveVisaCardStatus.CardOk;
+    await this.intersolveVisaChildWalletScopedRepository.save(newChildWallet);
   }
 
   public async hasIntersolveCustomer(registrationId: number): Promise<boolean> {

--- a/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.ts
@@ -572,6 +572,11 @@ export class IntersolveVisaService {
       tokenResult.status as IntersolveVisaTokenStatus;
     newIntersolveVisaChildWallet.lastExternalUpdate = new Date();
     newIntersolveVisaChildWallet.isLinkedToParentWallet = true;
+    // An on-site replacement uses an already-printed physical card, so no new card has to be created for it
+    if (input.physicalCardToken) {
+      newIntersolveVisaChildWallet.isDebitCardCreated = true;
+      newIntersolveVisaChildWallet.cardStatus = IntersolveVisaCardStatus.CardOk;
+    }
     const newChildWallet =
       await this.intersolveVisaChildWalletScopedRepository.save(
         newIntersolveVisaChildWallet,
@@ -586,18 +591,11 @@ export class IntersolveVisaService {
       childWalletToReplace,
     );
 
-    // Create new card
-    const { isNewCardCreated } = await this.createDebitCardIfNotExists({
+    await this.createDebitCardIfNotExists({
       childWallet: newChildWallet,
       contactInformation: input.contactInformation,
       coverLetterCode: input.coverLetterCode,
     });
-
-    if (!isNewCardCreated) {
-      newChildWallet.isDebitCardCreated = true;
-      newChildWallet.cardStatus = IntersolveVisaCardStatus.CardOk;
-      await this.intersolveVisaChildWalletScopedRepository.save(newChildWallet);
-    }
   }
 
   public async hasIntersolveCustomer(registrationId: number): Promise<boolean> {


### PR DESCRIPTION
[AB#43776](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43776) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

During replacement on-site an attempt was done to create a physical card. Because the card already exists, the request fails, leaving the wallet with a nulled status.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
