### PR TITLE
Optimize Redis job ID addition with batching for high load

### DIFF
--- a/services/121-service/src/fsp-integrations/transaction-queues/transaction-queues.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/transaction-queues/transaction-queues.service.spec.ts
@@ -1,8 +1,10 @@
 import { TestBed } from '@automock/jest';
+import Redis from 'ioredis';
 
 import { IntersolveVisaTransactionJobDto } from '@121-service/src/fsp-integrations/transaction-queues/dto/intersolve-visa-transaction-job.dto';
 import { SafaricomTransactionJobDto } from '@121-service/src/fsp-integrations/transaction-queues/dto/safaricom-transaction-job.dto';
 import { TransactionQueuesService } from '@121-service/src/fsp-integrations/transaction-queues/transaction-queues.service';
+import { REDIS_CLIENT } from '@121-service/src/payments/redis/redis-client';
 import { QueuesRegistryService } from '@121-service/src/queues-registry/queues-registry.service';
 import { JobNames } from '@121-service/src/shared/enum/job-names.enum';
 
@@ -44,8 +46,18 @@ const mockSafaricomTransactionJobDto: SafaricomTransactionJobDto[] = [
 describe('TransactionQueuesService', () => {
   let transactionQueuesService: TransactionQueuesService;
   let queuesService: QueuesRegistryService;
+  let mockPipeline: { sadd: jest.Mock; exec: jest.Mock };
+  let mockRedisClient: { pipeline: jest.Mock };
 
   beforeEach(() => {
+    mockPipeline = {
+      sadd: jest.fn().mockReturnThis(),
+      exec: jest.fn().mockResolvedValue([]),
+    };
+    mockRedisClient = {
+      pipeline: jest.fn().mockReturnValue(mockPipeline),
+    };
+
     const { unit, unitRef } = TestBed.create(TransactionQueuesService)
       .mock(QueuesRegistryService)
       .using({
@@ -56,6 +68,8 @@ describe('TransactionQueuesService', () => {
           addBulk: jest.fn(),
         },
       })
+      .mock<Redis>(REDIS_CLIENT)
+      .using(mockRedisClient as unknown as Redis)
       .compile();
 
     transactionQueuesService = unit;
@@ -112,5 +126,94 @@ describe('TransactionQueuesService', () => {
         data: mockSafaricomTransactionJobDto[0],
       },
     ]);
+  });
+
+  it('should pipeline sadd calls in batches of 10,000', async () => {
+    const jobCount = 25_000;
+    const mockJobs = Array.from({ length: jobCount }, (_, i) => ({
+      id: i + 1,
+    }));
+    jest
+      .spyOn(queuesService.transactionJobSafaricomQueue as any, 'addBulk')
+      .mockResolvedValue(mockJobs);
+    mockPipeline.exec.mockResolvedValue(
+      Array.from({ length: 3 }, () => [null, jobCount]),
+    );
+
+    // Act
+    await transactionQueuesService.addSafaricomTransactionJobs(
+      mockSafaricomTransactionJobDto,
+    );
+
+    // Assert
+    expect(mockRedisClient.pipeline).toHaveBeenCalledTimes(1);
+    expect(mockPipeline.sadd).toHaveBeenCalledTimes(3); // 10k + 10k + 5k
+    expect(mockPipeline.exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('should make a single sadd call when job count is under batch size', async () => {
+    const mockJobs = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    jest
+      .spyOn(queuesService.transactionJobSafaricomQueue as any, 'addBulk')
+      .mockResolvedValue(mockJobs);
+    mockPipeline.exec.mockResolvedValue([[null, 3]]);
+
+    // Act
+    await transactionQueuesService.addSafaricomTransactionJobs(
+      mockSafaricomTransactionJobDto,
+    );
+
+    // Assert
+    expect(mockPipeline.sadd).toHaveBeenCalledTimes(1);
+    expect(mockPipeline.sadd).toHaveBeenCalledWith(
+      'program:3:jobs',
+      '1',
+      '2',
+      '3',
+    );
+  });
+
+  it('should not call pipeline when there are no job IDs', async () => {
+    jest
+      .spyOn(queuesService.transactionJobSafaricomQueue as any, 'addBulk')
+      .mockResolvedValue([]);
+
+    // Act
+    await transactionQueuesService.addSafaricomTransactionJobs(
+      mockSafaricomTransactionJobDto,
+    );
+
+    // Assert
+    expect(mockRedisClient.pipeline).not.toHaveBeenCalled();
+  });
+
+  it('should throw when pipeline exec returns null', async () => {
+    jest
+      .spyOn(queuesService.transactionJobSafaricomQueue as any, 'addBulk')
+      .mockResolvedValue([{ id: 1 }]);
+    mockPipeline.exec.mockResolvedValue(null);
+
+    // Act & Assert
+    await expect(
+      transactionQueuesService.addSafaricomTransactionJobs(
+        mockSafaricomTransactionJobDto,
+      ),
+    ).rejects.toThrow('pipeline aborted');
+  });
+
+  it('should throw when a pipeline command returns an error', async () => {
+    jest
+      .spyOn(queuesService.transactionJobSafaricomQueue as any, 'addBulk')
+      .mockResolvedValue([{ id: 1 }]);
+    mockPipeline.exec.mockResolvedValue([
+      [new Error('Redis SADD failed'), null],
+    ]);
+
+    // Act & Assert
+    await expect(
+      transactionQueuesService.addSafaricomTransactionJobs(
+        mockSafaricomTransactionJobDto,
+      ),
+    ).rejects.toThrow('Redis SADD failed');
   });
 });

--- a/services/121-service/src/fsp-integrations/transaction-queues/transaction-queues.service.ts
+++ b/services/121-service/src/fsp-integrations/transaction-queues/transaction-queues.service.ts
@@ -148,7 +148,17 @@ export class TransactionQueuesService {
         const batch = jobIds.slice(i, i + batchSize);
         pipeline.sadd(redisSetName, ...batch);
       }
-      await pipeline.exec();
+      const results = await pipeline.exec();
+      if (results == null) {
+        throw new Error(
+          `Failed to add job IDs to Redis set ${redisSetName}: pipeline aborted`,
+        );
+      }
+      for (const [error] of results) {
+        if (error) {
+          throw error;
+        }
+      }
     }
   }
 }

--- a/services/121-service/src/fsp-integrations/transaction-queues/transaction-queues.service.ts
+++ b/services/121-service/src/fsp-integrations/transaction-queues/transaction-queues.service.ts
@@ -141,10 +141,14 @@ export class TransactionQueuesService {
       .map((job) => String(job.id));
 
     if (jobIds.length > 0) {
-      await this.redisClient.sadd(
-        getRedisSetName(transactionJobs[0].programId),
-        ...jobIds,
-      );
+      const redisSetName = getRedisSetName(transactionJobs[0].programId);
+      const batchSize = 10_000;
+      const pipeline = this.redisClient.pipeline();
+      for (let i = 0; i < jobIds.length; i += batchSize) {
+        const batch = jobIds.slice(i, i + batchSize);
+        pipeline.sadd(redisSetName, ...batch);
+      }
+      await pipeline.exec();
     }
   }
 }


### PR DESCRIPTION
[AB#43778](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43778) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

This pull request optimizes how job IDs are added to a Redis set in the `TransactionQueuesService`. Instead of adding all job IDs at once, the code now batches the additions in groups of 10,000 using a Redis pipeline, which improves performance and reliability for large datasets.

**Redis performance improvement:**

* Updated the logic in `transaction-queues.service.ts` to batch `sadd` operations for job IDs into Redis using a pipeline, processing them in chunks of 10,000 for better scalability and efficiency.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Added tests for the changes
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
