### PR TITLE
Do not delete phonenumber while twilio is enabled

### DIFF
--- a/services/121-service/src/program-registration-attributes/program-registration-attributes.service.spec.ts
+++ b/services/121-service/src/program-registration-attributes/program-registration-attributes.service.spec.ts
@@ -3,6 +3,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Equal, Repository } from 'typeorm';
 
+import { env } from '@121-service/src/env';
+import { TwilioMode } from '@121-service/src/notifications/enum/twilio-mode.enum';
 import { ProgramRegistrationAttributesService } from '@121-service/src/program-registration-attributes/program-registration-attributes.service';
 import {
   CreateProgramRegistrationAttributeDto,
@@ -13,6 +15,15 @@ import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/en
 import { RegistrationViewEntity } from '@121-service/src/registration/entities/registration-view.entity';
 import { RegistrationAttributeTypes } from '@121-service/src/registration/enum/registration-attribute.enum';
 import { generateMockCreateQueryBuilder } from '@121-service/src/utils/test-helpers/createQueryBuilderMock.helper';
+
+jest.mock('@121-service/src/env', () => ({
+  env: {
+    ...jest.requireActual('@121-service/src/env').env,
+    TWILIO_MODE: 'MOCK',
+  },
+}));
+
+const mockEnv = env as unknown as { TWILIO_MODE: string };
 
 describe('ProgramRegistrationAttributesService', () => {
   let programRegistrationAttributeRepository: Repository<ProgramRegistrationAttributeEntity>;
@@ -203,6 +214,10 @@ describe('ProgramRegistrationAttributesService', () => {
   });
 
   describe('deleteProgramRegistrationAttribute', () => {
+    beforeEach(() => {
+      mockEnv.TWILIO_MODE = TwilioMode.mock;
+    });
+
     it('should scope lookup by both program id and attribute id before delete', async () => {
       // Arrange
       const programId = 1;
@@ -261,6 +276,64 @@ describe('ProgramRegistrationAttributesService', () => {
           }),
         }),
       );
+    });
+
+    it('should throw when deleting the phoneNumber attribute while Twilio is enabled', async () => {
+      // Arrange
+      mockEnv.TWILIO_MODE = TwilioMode.mock;
+      const programId = 1;
+      const programRegistrationAttributeId = 99;
+      const attributeEntity = createAttributeEntity({
+        id: programRegistrationAttributeId,
+        programId,
+        name: 'phoneNumber',
+      });
+
+      jest
+        .spyOn(programRegistrationAttributeRepository, 'findOne')
+        .mockResolvedValue(attributeEntity);
+      const removeSpy = jest
+        .spyOn(programRegistrationAttributeRepository, 'remove')
+        .mockResolvedValue(attributeEntity);
+
+      // Act + Assert
+      await expect(
+        programRegistrationAttributesService.deleteProgramRegistrationAttribute(
+          programId,
+          programRegistrationAttributeId,
+        ),
+      ).rejects.toBeHttpExceptionWithStatus(HttpStatus.BAD_REQUEST);
+      expect(removeSpy).not.toHaveBeenCalled();
+    });
+
+    it('should delete the phoneNumber attribute when Twilio is disabled', async () => {
+      // Arrange
+      mockEnv.TWILIO_MODE = TwilioMode.disabled;
+      const programId = 1;
+      const programRegistrationAttributeId = 99;
+      const attributeEntity = createAttributeEntity({
+        id: programRegistrationAttributeId,
+        programId,
+        name: 'phoneNumber',
+      });
+
+      jest
+        .spyOn(programRegistrationAttributeRepository, 'findOne')
+        .mockResolvedValue(attributeEntity);
+      const removeSpy = jest
+        .spyOn(programRegistrationAttributeRepository, 'remove')
+        .mockResolvedValue(attributeEntity);
+
+      // Act
+      const result =
+        await programRegistrationAttributesService.deleteProgramRegistrationAttribute(
+          programId,
+          programRegistrationAttributeId,
+        );
+
+      // Assert
+      expect(result).toEqual(attributeEntity);
+      expect(removeSpy).toHaveBeenCalledWith(attributeEntity);
     });
   });
 

--- a/services/121-service/src/program-registration-attributes/program-registration-attributes.service.ts
+++ b/services/121-service/src/program-registration-attributes/program-registration-attributes.service.ts
@@ -4,6 +4,8 @@ import { chunk } from 'lodash';
 import { FilterOperator } from 'nestjs-paginate';
 import { Equal, In, QueryFailedError, Repository } from 'typeorm';
 
+import { env } from '@121-service/src/env';
+import { TwilioMode } from '@121-service/src/notifications/enum/twilio-mode.enum';
 import {
   CreateProgramRegistrationAttributeDto,
   UpdateProgramRegistrationAttributeDto,
@@ -21,6 +23,7 @@ import {
 import { FilterAttributeDto } from '@121-service/src/registration/dto/filter-attribute.dto';
 import {
   Attribute,
+  DefaultRegistrationDataAttributeNames,
   GenericRegistrationAttributes,
   RegistrationAttributeTypes,
 } from '@121-service/src/registration/enum/registration-attribute.enum';
@@ -575,6 +578,17 @@ export class ProgramRegistrationAttributesService {
       const errors = `Program registration attribute with id: '${programRegistrationAttributeId}' not found for program '${programId}'.`;
       throw new HttpException({ errors }, HttpStatus.NOT_FOUND);
     }
+
+    // Twilio needs a phoneNumber to send messages, so it cannot be removed while Twilio is enabled.
+    if (
+      env.TWILIO_MODE !== TwilioMode.disabled &&
+      programRegistrationAttribute.name ===
+        DefaultRegistrationDataAttributeNames.phoneNumber
+    ) {
+      const errors = `The '${DefaultRegistrationDataAttributeNames.phoneNumber}' attribute cannot be deleted while Twilio is enabled.`;
+      throw new HttpException({ errors }, HttpStatus.BAD_REQUEST);
+    }
+
     return await this.programRegistrationAttributeRepository.remove(
       programRegistrationAttribute,
     );


### PR DESCRIPTION
[AB#43767](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43767) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes
Do not delete phonenumber question when twilio is disabled

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
