### PR TITLE
Remove allow empty phone number setting

### DIFF
--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/required-attributes/required-attributes.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/required-attributes/required-attributes.component.ts
@@ -72,10 +72,15 @@ export class RequiredAttributesComponent {
       return [];
     }
 
-    const requiredAttributeNames = new Set<string>([
-      FspAttributes.fullName,
-      FspAttributes.phoneNumber,
-    ]);
+    const requiredAttributeNames = new Set<string>([FspAttributes.fullName]);
+
+    // Workaround: the backend only auto-adds phoneNumber when Twilio is enabled, so its presence here is
+    // a proxy for "Twilio is enabled" (an admin manually adding it via the API instead is very unlikely).
+    // Kobo forms must include this field whenever Twilio is enabled
+    const phoneNumberAttributeName: string = FspAttributes.phoneNumber;
+    if (attributes.some((attr) => attr.name === phoneNumberAttributeName)) {
+      requiredAttributeNames.add(phoneNumberAttributeName);
+    }
 
     for (const fspConfig of fspConfigs) {
       const fspSetting = FSP_SETTINGS[fspConfig.fspName];

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/required-attributes/required-attributes.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/required-attributes/required-attributes.component.ts
@@ -13,6 +13,7 @@ import { TableModule } from 'primeng/table';
 
 import { FSP_SETTINGS } from '@121-service/src/fsp-integrations/settings/fsp-settings.const';
 import { FspAttributes } from '@121-service/src/fsp-integrations/shared/enum/fsp-attributes.enum';
+import { DefaultRegistrationDataAttributeNames } from '@121-service/src/registration/enum/registration-attribute.enum';
 
 import { FspTagsComponent } from '~/components/fsp-tags/fsp-tags.component';
 import { InfoTooltipComponent } from '~/components/info-tooltip/info-tooltip.component';
@@ -77,7 +78,8 @@ export class RequiredAttributesComponent {
     // Workaround: the backend only auto-adds phoneNumber when Twilio is enabled, so its presence here is
     // a proxy for "Twilio is enabled" (an admin manually adding it via the API instead is very unlikely).
     // Kobo forms must include this field whenever Twilio is enabled
-    const phoneNumberAttributeName: string = FspAttributes.phoneNumber;
+    const phoneNumberAttributeName: string =
+      DefaultRegistrationDataAttributeNames.phoneNumber;
     if (attributes.some((attr) => attr.name === phoneNumberAttributeName)) {
       requiredAttributeNames.add(phoneNumberAttributeName);
     }

--- a/services/121-service/src/kobo/services/kobo.validation.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo.validation.service.spec.ts
@@ -1,13 +1,24 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { env } from '@121-service/src/env';
 import { FspAttributes } from '@121-service/src/fsp-integrations/shared/enum/fsp-attributes.enum';
 import { Fsps } from '@121-service/src/fsp-integrations/shared/enum/fsp-name.enum';
 import { KoboFormDefinition } from '@121-service/src/kobo/interfaces/kobo-form-definition.interface';
 import { KoboValidationService } from '@121-service/src/kobo/services/kobo.validation.service';
+import { TwilioMode } from '@121-service/src/notifications/enum/twilio-mode.enum';
 import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';
 import { ProgramRepository } from '@121-service/src/programs/repositories/program.repository';
 import { GenericRegistrationAttributes } from '@121-service/src/registration/enum/registration-attribute.enum';
+
+jest.mock('@121-service/src/env', () => ({
+  env: {
+    ...jest.requireActual('@121-service/src/env').env,
+    TWILIO_MODE: 'DISABLED',
+  },
+}));
+
+const mockEnv = env as unknown as { TWILIO_MODE: string };
 
 describe('KoboValidationService', () => {
   let service: KoboValidationService;
@@ -98,6 +109,7 @@ describe('KoboValidationService', () => {
   const programId = 1;
 
   beforeEach(async () => {
+    mockEnv.TWILIO_MODE = TwilioMode.disabled;
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         KoboValidationService,
@@ -393,7 +405,6 @@ describe('KoboValidationService', () => {
 
       (programRepository.findOneOrFail as jest.Mock).mockResolvedValue({
         fullnameNamingConvention: [],
-        allowEmptyPhoneNumber: false,
       });
       (programFspConfigurationRepository.find as jest.Mock).mockResolvedValue(
         mockFspConfigs,
@@ -408,8 +419,9 @@ describe('KoboValidationService', () => {
       ).resolves.not.toThrow();
     });
 
-    it('should throw HttpException when phoneNumber is missing and allowEmptyPhoneNumber is false', async () => {
+    it('should throw HttpException when phoneNumber is missing and Twilio is enabled', async () => {
       // Arrange
+      mockEnv.TWILIO_MODE = TwilioMode.mock;
       const mockFspConfigs = [];
 
       const formDefinitionMissingPhoneNumber: KoboFormDefinition = {
@@ -422,7 +434,6 @@ describe('KoboValidationService', () => {
 
       (programRepository.findOneOrFail as jest.Mock).mockResolvedValue({
         fullnameNamingConvention: [],
-        allowEmptyPhoneNumber: false,
       });
       (programFspConfigurationRepository.find as jest.Mock).mockResolvedValue(
         mockFspConfigs,
@@ -446,15 +457,16 @@ describe('KoboValidationService', () => {
          {
            "attributeName": "phoneNumber",
            "error": "Attribute 'phoneNumber' is missing",
-           "solution": "Add a phoneNumber field with text type including country code, or set program.allowEmptyPhoneNumber to true",
+           "solution": "Add a phoneNumber field with text type including country code, or contact 121 support to disable Twilio for this instance",
            "type": "missingField",
          },
        ]
       `);
     });
 
-    it('should pass validation when phoneNumber is missing but allowEmptyPhoneNumber is true', async () => {
+    it('should pass validation when phoneNumber is missing and Twilio is disabled', async () => {
       // Arrange
+      mockEnv.TWILIO_MODE = TwilioMode.disabled;
       const mockFspConfigs = [];
 
       const formDefinitionMissingPhoneNumber: KoboFormDefinition = {
@@ -467,7 +479,6 @@ describe('KoboValidationService', () => {
 
       (programRepository.findOneOrFail as jest.Mock).mockResolvedValue({
         fullnameNamingConvention: [],
-        allowEmptyPhoneNumber: true,
       });
       (programFspConfigurationRepository.find as jest.Mock).mockResolvedValue(
         mockFspConfigs,
@@ -501,7 +512,6 @@ describe('KoboValidationService', () => {
 
       (programRepository.findOneOrFail as jest.Mock).mockResolvedValue({
         fullnameNamingConvention: [],
-        allowEmptyPhoneNumber: false,
       });
       (programFspConfigurationRepository.find as jest.Mock).mockResolvedValue(
         mockFspConfigs,
@@ -549,7 +559,6 @@ describe('KoboValidationService', () => {
 
       (programRepository.findOneOrFail as jest.Mock).mockResolvedValue({
         fullnameNamingConvention: [],
-        allowEmptyPhoneNumber: true,
         enableScope: false,
       });
       (programFspConfigurationRepository.find as jest.Mock).mockResolvedValue(
@@ -584,7 +593,6 @@ describe('KoboValidationService', () => {
 
       (programRepository.findOneOrFail as jest.Mock).mockResolvedValue({
         fullnameNamingConvention: [],
-        allowEmptyPhoneNumber: true,
         enableScope: true,
       });
       (programFspConfigurationRepository.find as jest.Mock).mockResolvedValue(
@@ -614,7 +622,6 @@ describe('KoboValidationService', () => {
 
       (programRepository.findOneOrFail as jest.Mock).mockResolvedValue({
         fullnameNamingConvention: [],
-        allowEmptyPhoneNumber: true,
         enableScope: true,
       });
       (programFspConfigurationRepository.find as jest.Mock).mockResolvedValue(
@@ -665,7 +672,6 @@ describe('KoboValidationService', () => {
 
       (programRepository.findOneOrFail as jest.Mock).mockResolvedValue({
         fullnameNamingConvention: [],
-        allowEmptyPhoneNumber: true,
         enableScope: true,
       });
       (programFspConfigurationRepository.find as jest.Mock).mockResolvedValue(
@@ -719,7 +725,6 @@ describe('KoboValidationService', () => {
 
       (programRepository.findOneOrFail as jest.Mock).mockResolvedValue({
         fullnameNamingConvention: [],
-        allowEmptyPhoneNumber: true,
         enableScope: false,
       });
       (programFspConfigurationRepository.find as jest.Mock).mockResolvedValue(
@@ -772,7 +777,6 @@ describe('KoboValidationService', () => {
 
       (programRepository.findOneOrFail as jest.Mock).mockResolvedValue({
         fullnameNamingConvention: [],
-        allowEmptyPhoneNumber: true,
         enableScope: false,
       });
       (programFspConfigurationRepository.find as jest.Mock).mockResolvedValue(
@@ -818,7 +822,6 @@ describe('KoboValidationService', () => {
 
       (programRepository.findOneOrFail as jest.Mock).mockResolvedValue({
         fullnameNamingConvention: [],
-        allowEmptyPhoneNumber: true,
         enableScope: false,
       });
       (programFspConfigurationRepository.find as jest.Mock).mockResolvedValue(
@@ -846,7 +849,6 @@ describe('KoboValidationService', () => {
 
       (programRepository.findOneOrFail as jest.Mock).mockResolvedValue({
         fullnameNamingConvention: [],
-        allowEmptyPhoneNumber: true,
         enableScope: false,
       });
       (programFspConfigurationRepository.find as jest.Mock).mockResolvedValue(
@@ -899,7 +901,6 @@ describe('KoboValidationService', () => {
 
       (programRepository.findOneOrFail as jest.Mock).mockResolvedValue({
         fullnameNamingConvention: [],
-        allowEmptyPhoneNumber: true,
         enableScope: false,
       });
       (programFspConfigurationRepository.find as jest.Mock).mockResolvedValue(
@@ -939,7 +940,6 @@ describe('KoboValidationService', () => {
     beforeEach(() => {
       (programRepository.findOneOrFail as jest.Mock).mockResolvedValue({
         fullnameNamingConvention: [],
-        allowEmptyPhoneNumber: true,
         enableScope: false,
       });
       (programFspConfigurationRepository.find as jest.Mock).mockResolvedValue(
@@ -1309,7 +1309,6 @@ describe('KoboValidationService', () => {
     // Arrange
     (programRepository.findOneOrFail as jest.Mock).mockResolvedValue({
       fullnameNamingConvention: [],
-      allowEmptyPhoneNumber: true,
       enableScope: false,
     });
     (programFspConfigurationRepository.find as jest.Mock).mockResolvedValue([]);

--- a/services/121-service/src/kobo/services/kobo.validation.service.ts
+++ b/services/121-service/src/kobo/services/kobo.validation.service.ts
@@ -2,6 +2,7 @@ import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { isDefined } from 'class-validator';
 import { Equal } from 'typeorm';
 
+import { env } from '@121-service/src/env';
 import { Fsps } from '@121-service/src/fsp-integrations/shared/enum/fsp-name.enum';
 import { FINANCIAL_SERVICE_PROVIDER_ATTRIBUTE_TYPE_MAPPING } from '@121-service/src/fsp-management/fsp-attribute-type-mapping';
 import { getFspAttributeNames } from '@121-service/src/fsp-management/fsp-settings.helpers';
@@ -13,6 +14,7 @@ import { KoboSurveyItemCleaned } from '@121-service/src/kobo/interfaces/kobo-sur
 import { KoboValidationError } from '@121-service/src/kobo/interfaces/kobo-validation-error.interface';
 import { KoboLanguageMapper } from '@121-service/src/kobo/mappers/kobo-language.mapper';
 import { fspQuestionName } from '@121-service/src/kobo/services/kobo.service';
+import { TwilioMode } from '@121-service/src/notifications/enum/twilio-mode.enum';
 import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';
 import { ProgramRepository } from '@121-service/src/programs/repositories/program.repository';
 import { RegistrationViewEntity } from '@121-service/src/registration/entities/registration-view.entity';
@@ -46,7 +48,6 @@ export class KoboValidationService {
       where: { id: Equal(programId) },
       select: {
         fullnameNamingConvention: true,
-        allowEmptyPhoneNumber: true,
         enableScope: true,
       },
     });
@@ -83,7 +84,6 @@ export class KoboValidationService {
       accumulatedErrors: errors,
       error: this.validatePhoneNumberSurveyItem({
         koboSurveyItems: formDefinition.survey,
-        allowEmptyPhoneNumber: program.allowEmptyPhoneNumber,
       }),
     });
 
@@ -297,10 +297,8 @@ export class KoboValidationService {
   // Phone number is a special case in validation as it part of the registration entity and not only a program registration attribute
   private validatePhoneNumberSurveyItem({
     koboSurveyItems,
-    allowEmptyPhoneNumber,
   }: {
     koboSurveyItems: KoboSurveyItemCleaned[];
-    allowEmptyPhoneNumber: boolean;
   }): KoboValidationError[] {
     const errors: KoboValidationError[] = [];
 
@@ -308,14 +306,14 @@ export class KoboValidationService {
       (item) => item.name === DefaultRegistrationDataAttributeNames.phoneNumber,
     );
 
-    // Only validate existence if empty phone numbers are not allowed
-    if (!phoneNumberItem && !allowEmptyPhoneNumber) {
+    // Twilio needs a phoneNumber to send messages, so the survey item is required when Twilio is enabled.
+    if (!phoneNumberItem && env.TWILIO_MODE !== TwilioMode.disabled) {
       errors.push({
         type: KoboValidationErrorType.missingField,
         attributeName: DefaultRegistrationDataAttributeNames.phoneNumber,
         error: `Attribute '${DefaultRegistrationDataAttributeNames.phoneNumber}' is missing`,
         solution:
-          'Add a phoneNumber field with text type including country code, or set program.allowEmptyPhoneNumber to true',
+          'Add a phoneNumber field with text type including country code, or contact 121 support to disable Twilio for this instance',
       });
     }
 

--- a/services/121-service/src/migration/1786008918000-remove-allow-empty-phone-number.ts
+++ b/services/121-service/src/migration/1786008918000-remove-allow-empty-phone-number.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveAllowEmptyPhoneNumber1786008918000 implements MigrationInterface {
+  name = 'RemoveAllowEmptyPhoneNumber1786008918000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Move the "allow empty phone number" setting to the phoneNumber attribute's isRequired property (inverted).
+    await queryRunner.query(
+      `UPDATE "121-service"."program_registration_attribute" AS pra
+       SET "isRequired" = NOT p."allowEmptyPhoneNumber"
+       FROM "121-service"."program" AS p
+       WHERE pra."programId" = p."id" AND pra."name" = 'phoneNumber'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "121-service"."program" DROP COLUMN "allowEmptyPhoneNumber"`,
+    );
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    console.log('we do not revert');
+  }
+}

--- a/services/121-service/src/notifications/sms/sms.service.ts
+++ b/services/121-service/src/notifications/sms/sms.service.ts
@@ -36,7 +36,7 @@ export class SmsService {
   ): Promise<void> {
     const to = recipientPhoneNr
       ? formatPhoneNumber(recipientPhoneNr)
-      : 'not available'; // When allowEmptyPhoneNumber is true in a program, the to number can be empty and an error will be stored
+      : 'not available'; // When the phoneNumber attribute is not required, the to number can be empty and an error will be stored
 
     try {
       const messageToStore = await twilioClient.messages.create({

--- a/services/121-service/src/program-registration-attributes/program-registration-attributes.service.spec.ts
+++ b/services/121-service/src/program-registration-attributes/program-registration-attributes.service.spec.ts
@@ -457,7 +457,7 @@ describe('ProgramRegistrationAttributesService', () => {
       mockEnv.TWILIO_MODE = TwilioMode.mock;
     });
 
-    it('adds a required phoneNumber attribute when it is missing and Twilio is enabled', async () => {
+    it('adds a non-required phoneNumber attribute when it is missing and Twilio is enabled', async () => {
       // Act
       const result =
         await programRegistrationAttributesService.applyProgramRegistrationAttributesFallbackIfNecessary(
@@ -474,6 +474,7 @@ describe('ProgramRegistrationAttributesService', () => {
       );
       expect(phoneNumberAttribute).toBeDefined();
       expect(phoneNumberAttribute?.isRequired).toBe(false);
+      expect(phoneNumberAttribute?.type).toBe(RegistrationAttributeTypes.tel);
     });
 
     it('does not duplicate the phoneNumber attribute when it is already present', async () => {

--- a/services/121-service/src/program-registration-attributes/program-registration-attributes.service.spec.ts
+++ b/services/121-service/src/program-registration-attributes/program-registration-attributes.service.spec.ts
@@ -13,7 +13,10 @@ import {
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/entities/program-registration-attribute.entity';
 import { RegistrationViewEntity } from '@121-service/src/registration/entities/registration-view.entity';
-import { RegistrationAttributeTypes } from '@121-service/src/registration/enum/registration-attribute.enum';
+import {
+  DefaultRegistrationDataAttributeNames,
+  RegistrationAttributeTypes,
+} from '@121-service/src/registration/enum/registration-attribute.enum';
 import { generateMockCreateQueryBuilder } from '@121-service/src/utils/test-helpers/createQueryBuilderMock.helper';
 
 jest.mock('@121-service/src/env', () => ({
@@ -286,7 +289,7 @@ describe('ProgramRegistrationAttributesService', () => {
       const attributeEntity = createAttributeEntity({
         id: programRegistrationAttributeId,
         programId,
-        name: 'phoneNumber',
+        name: DefaultRegistrationDataAttributeNames.phoneNumber,
       });
 
       jest
@@ -314,7 +317,7 @@ describe('ProgramRegistrationAttributesService', () => {
       const attributeEntity = createAttributeEntity({
         id: programRegistrationAttributeId,
         programId,
-        name: 'phoneNumber',
+        name: DefaultRegistrationDataAttributeNames.phoneNumber,
       });
 
       jest
@@ -446,6 +449,76 @@ describe('ProgramRegistrationAttributesService', () => {
           },
         ),
       ).rejects.toBeHttpExceptionWithStatus(HttpStatus.NOT_FOUND);
+    });
+  });
+
+  describe('Applying the phoneNumber attribute fallback', () => {
+    beforeEach(() => {
+      mockEnv.TWILIO_MODE = TwilioMode.mock;
+    });
+
+    it('adds a required phoneNumber attribute when it is missing and Twilio is enabled', async () => {
+      // Act
+      const result =
+        await programRegistrationAttributesService.applyProgramRegistrationAttributesFallbackIfNecessary(
+          {
+            attributesData: [createAttributeDto({ name: 'firstName' })],
+            namingConventionData: [],
+          },
+        );
+
+      // Assert
+      const phoneNumberAttribute = result.find(
+        (attr) =>
+          attr.name === DefaultRegistrationDataAttributeNames.phoneNumber,
+      );
+      expect(phoneNumberAttribute).toBeDefined();
+      expect(phoneNumberAttribute?.isRequired).toBe(false);
+    });
+
+    it('does not duplicate the phoneNumber attribute when it is already present', async () => {
+      // Act
+      const result =
+        await programRegistrationAttributesService.applyProgramRegistrationAttributesFallbackIfNecessary(
+          {
+            attributesData: [
+              createAttributeDto({
+                name: DefaultRegistrationDataAttributeNames.phoneNumber,
+              }),
+            ],
+            namingConventionData: [],
+          },
+        );
+
+      // Assert
+      expect(
+        result.filter(
+          (attr) =>
+            attr.name === DefaultRegistrationDataAttributeNames.phoneNumber,
+        ),
+      ).toHaveLength(1);
+    });
+
+    it('does not add a phoneNumber attribute when Twilio is disabled', async () => {
+      // Arrange
+      mockEnv.TWILIO_MODE = TwilioMode.disabled;
+
+      // Act
+      const result =
+        await programRegistrationAttributesService.applyProgramRegistrationAttributesFallbackIfNecessary(
+          {
+            attributesData: [createAttributeDto({ name: 'firstName' })],
+            namingConventionData: [],
+          },
+        );
+
+      // Assert
+      expect(
+        result.find(
+          (attr) =>
+            attr.name === DefaultRegistrationDataAttributeNames.phoneNumber,
+        ),
+      ).toBeUndefined();
     });
   });
 });

--- a/services/121-service/src/program-registration-attributes/program-registration-attributes.service.spec.ts
+++ b/services/121-service/src/program-registration-attributes/program-registration-attributes.service.spec.ts
@@ -3,6 +3,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Equal, Repository } from 'typeorm';
 
+import { env } from '@121-service/src/env';
+import { TwilioMode } from '@121-service/src/notifications/enum/twilio-mode.enum';
 import { ProgramRegistrationAttributesService } from '@121-service/src/program-registration-attributes/program-registration-attributes.service';
 import {
   CreateProgramRegistrationAttributeDto,
@@ -13,6 +15,15 @@ import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/en
 import { RegistrationViewEntity } from '@121-service/src/registration/entities/registration-view.entity';
 import { RegistrationAttributeTypes } from '@121-service/src/registration/enum/registration-attribute.enum';
 import { generateMockCreateQueryBuilder } from '@121-service/src/utils/test-helpers/createQueryBuilderMock.helper';
+
+jest.mock('@121-service/src/env', () => ({
+  env: {
+    ...jest.requireActual('@121-service/src/env').env,
+    TWILIO_MODE: 'MOCK',
+  },
+}));
+
+const mockEnv = env as unknown as { TWILIO_MODE: string };
 
 describe('ProgramRegistrationAttributesService', () => {
   let programRegistrationAttributeRepository: Repository<ProgramRegistrationAttributeEntity>;
@@ -203,6 +214,10 @@ describe('ProgramRegistrationAttributesService', () => {
   });
 
   describe('deleteProgramRegistrationAttribute', () => {
+    beforeEach(() => {
+      mockEnv.TWILIO_MODE = TwilioMode.mock;
+    });
+
     it('should scope lookup by both program id and attribute id before delete', async () => {
       // Arrange
       const programId = 1;
@@ -261,6 +276,64 @@ describe('ProgramRegistrationAttributesService', () => {
           }),
         }),
       );
+    });
+
+    it('should throw when deleting the phoneNumber attribute while Twilio is enabled', async () => {
+      // Arrange
+      mockEnv.TWILIO_MODE = TwilioMode.mock;
+      const programId = 1;
+      const programRegistrationAttributeId = 99;
+      const attributeEntity = createAttributeEntity({
+        id: programRegistrationAttributeId,
+        programId,
+        name: 'phoneNumber',
+      });
+
+      jest
+        .spyOn(programRegistrationAttributeRepository, 'findOne')
+        .mockResolvedValue(attributeEntity);
+      const removeSpy = jest
+        .spyOn(programRegistrationAttributeRepository, 'remove')
+        .mockResolvedValue(attributeEntity);
+
+      // Act + Assert
+      await expect(
+        programRegistrationAttributesService.deleteProgramRegistrationAttribute(
+          programId,
+          programRegistrationAttributeId,
+        ),
+      ).rejects.toBeHttpExceptionWithStatus(HttpStatus.BAD_REQUEST);
+      expect(removeSpy).not.toHaveBeenCalled();
+    });
+
+    it('should delete the phoneNumber attribute when Twilio is disabled', async () => {
+      // Arrange
+      mockEnv.TWILIO_MODE = TwilioMode.disabled;
+      const programId = 1;
+      const programRegistrationAttributeId = 99;
+      const attributeEntity = createAttributeEntity({
+        id: programRegistrationAttributeId,
+        programId,
+        name: 'phoneNumber',
+      });
+
+      jest
+        .spyOn(programRegistrationAttributeRepository, 'findOne')
+        .mockResolvedValue(attributeEntity);
+      const removeSpy = jest
+        .spyOn(programRegistrationAttributeRepository, 'remove')
+        .mockResolvedValue(attributeEntity);
+
+      // Act
+      const result =
+        await programRegistrationAttributesService.deleteProgramRegistrationAttribute(
+          programId,
+          programRegistrationAttributeId,
+        );
+
+      // Assert
+      expect(result).toEqual(attributeEntity);
+      expect(removeSpy).toHaveBeenCalledWith(attributeEntity);
     });
   });
 

--- a/services/121-service/src/program-registration-attributes/program-registration-attributes.service.ts
+++ b/services/121-service/src/program-registration-attributes/program-registration-attributes.service.ts
@@ -226,15 +226,19 @@ export class ProgramRegistrationAttributesService {
   }): Promise<ProgramRegistrationAttribute[]> {
     const programRegistrationAttributes = attributesData ?? [];
 
-    // make sure phoneNumber is in programRegistrationAttributes
-
+    // Twilio needs a required phoneNumber to send messages, so only add it when Twilio is enabled.
     if (
-      !programRegistrationAttributes.find((attr) => attr.name === 'phoneNumber')
+      env.TWILIO_MODE !== TwilioMode.disabled &&
+      !programRegistrationAttributes.find(
+        (attr) =>
+          attr.name === DefaultRegistrationDataAttributeNames.phoneNumber,
+      )
     ) {
       programRegistrationAttributes.push({
-        name: 'phoneNumber',
+        name: DefaultRegistrationDataAttributeNames.phoneNumber,
         type: RegistrationAttributeTypes.text,
         label: { en: 'Phone number' },
+        isRequired: false,
       });
     }
 

--- a/services/121-service/src/program-registration-attributes/program-registration-attributes.service.ts
+++ b/services/121-service/src/program-registration-attributes/program-registration-attributes.service.ts
@@ -230,14 +230,14 @@ export class ProgramRegistrationAttributesService {
       (attr) => attr.name === DefaultRegistrationDataAttributeNames.phoneNumber,
     );
 
-    // Twilio needs a required phoneNumber to send messages, so only add it when Twilio is enabled.
+    // Twilio uses the phoneNumber to send messages, so add it (non-required) when Twilio is enabled.
     if (
       env.TWILIO_MODE !== TwilioMode.disabled &&
       phoneNumberAttributeMissing
     ) {
       programRegistrationAttributes.push({
         name: DefaultRegistrationDataAttributeNames.phoneNumber,
-        type: RegistrationAttributeTypes.text,
+        type: RegistrationAttributeTypes.tel,
         label: { en: 'Phone number' },
         isRequired: false,
       });

--- a/services/121-service/src/program-registration-attributes/program-registration-attributes.service.ts
+++ b/services/121-service/src/program-registration-attributes/program-registration-attributes.service.ts
@@ -226,13 +226,14 @@ export class ProgramRegistrationAttributesService {
   }): Promise<ProgramRegistrationAttribute[]> {
     const programRegistrationAttributes = attributesData ?? [];
 
+    const phoneNumberAttributeMissing = !programRegistrationAttributes.find(
+      (attr) => attr.name === DefaultRegistrationDataAttributeNames.phoneNumber,
+    );
+
     // Twilio needs a required phoneNumber to send messages, so only add it when Twilio is enabled.
     if (
       env.TWILIO_MODE !== TwilioMode.disabled &&
-      !programRegistrationAttributes.find(
-        (attr) =>
-          attr.name === DefaultRegistrationDataAttributeNames.phoneNumber,
-      )
+      phoneNumberAttributeMissing
     ) {
       programRegistrationAttributes.push({
         name: DefaultRegistrationDataAttributeNames.phoneNumber,

--- a/services/121-service/src/program-registration-attributes/program-registration-attributes.service.ts
+++ b/services/121-service/src/program-registration-attributes/program-registration-attributes.service.ts
@@ -4,6 +4,8 @@ import { chunk } from 'lodash';
 import { FilterOperator } from 'nestjs-paginate';
 import { Equal, In, QueryFailedError, Repository } from 'typeorm';
 
+import { env } from '@121-service/src/env';
+import { TwilioMode } from '@121-service/src/notifications/enum/twilio-mode.enum';
 import {
   CreateProgramRegistrationAttributeDto,
   UpdateProgramRegistrationAttributeDto,
@@ -21,6 +23,7 @@ import {
 import { FilterAttributeDto } from '@121-service/src/registration/dto/filter-attribute.dto';
 import {
   Attribute,
+  DefaultRegistrationDataAttributeNames,
   GenericRegistrationAttributes,
   RegistrationAttributeTypes,
 } from '@121-service/src/registration/enum/registration-attribute.enum';
@@ -575,6 +578,17 @@ export class ProgramRegistrationAttributesService {
       const errors = `Program registration attribute with id: '${programRegistrationAttributeId}' not found for program '${programId}'.`;
       throw new HttpException({ errors }, HttpStatus.NOT_FOUND);
     }
+
+    // Twilio needs a phoneNumber to send messages, so it cannot be removed while Twilio is enabled.
+    if (
+      env.TWILIO_MODE !== TwilioMode.disabled &&
+      programRegistrationAttribute.name ===
+        DefaultRegistrationDataAttributeNames.phoneNumber
+    ) {
+      const errors = `The '${DefaultRegistrationDataAttributeNames.phoneNumber}' attribute cannot be deleted while Twilio is enabled.`;
+      throw new HttpException({ errors }, HttpStatus.BAD_REQUEST);
+    }
+
     return await this.programRegistrationAttributeRepository.remove(
       programRegistrationAttribute,
     );

--- a/services/121-service/src/programs/dto/base-program.dto.ts
+++ b/services/121-service/src/programs/dto/base-program.dto.ts
@@ -101,10 +101,6 @@ export abstract class BaseProgramDto {
   @IsBoolean()
   public readonly enableScope?: boolean;
 
-  @IsOptional()
-  @IsBoolean()
-  public readonly allowEmptyPhoneNumber?: boolean;
-
   @ApiProperty({ example: 'https://example.org/dashboard' })
   @IsOptional()
   @IsString()

--- a/services/121-service/src/programs/dto/program-return.dto.ts
+++ b/services/121-service/src/programs/dto/program-return.dto.ts
@@ -199,10 +199,6 @@ export class ProgramReturnDto {
   @IsBoolean()
   public readonly enableScope: boolean;
 
-  @ApiProperty({ example: false })
-  @IsBoolean()
-  public readonly allowEmptyPhoneNumber: boolean;
-
   @ApiProperty()
   @IsArray()
   public readonly fspConfigurations: ProgramFspConfigurationResponseDto[];

--- a/services/121-service/src/programs/entities/program.entity.ts
+++ b/services/121-service/src/programs/entities/program.entity.ts
@@ -105,9 +105,6 @@ export class ProgramEntity extends Base121Entity {
   @Column({ nullable: true, default: null, type: 'character varying' })
   public monitoringDashboardUrl: string | null;
 
-  @Column({ default: false })
-  public allowEmptyPhoneNumber: boolean;
-
   @OneToMany(
     () => MessageTemplateEntity,
     (messageTemplates) => messageTemplates.program,

--- a/services/121-service/src/programs/programs.service.ts
+++ b/services/121-service/src/programs/programs.service.ts
@@ -181,7 +181,6 @@ export class ProgramService {
     ];
     program.enableMaxPayments = !!programData.enableMaxPayments;
     program.enableScope = !!programData.enableScope;
-    program.allowEmptyPhoneNumber = !!programData.allowEmptyPhoneNumber;
     program.monitoringDashboardUrl = programData.monitoringDashboardUrl ?? null;
     program.budget = programData.budget ?? null;
 
@@ -231,14 +230,12 @@ export class ProgramService {
       await queryRunner.release();
     }
 
-    const role = isAdmin
-      ? DefaultUserRole.Admin
-      : DefaultUserRole.ProgramAdmin;
+    const role = isAdmin ? DefaultUserRole.Admin : DefaultUserRole.ProgramAdmin;
 
     await this.userService.assignAidworkerToProgram(newProgram.id, userId, {
       roles: [role],
       scope: undefined,
-    }); 
+    });
 
     return newProgram;
   }
@@ -460,7 +457,6 @@ export class ProgramService {
       languages: program.languages,
       enableMaxPayments: program.enableMaxPayments,
       enableScope: program.enableScope,
-      allowEmptyPhoneNumber: program.allowEmptyPhoneNumber,
     };
     if (program.monitoringDashboardUrl) {
       programDto.monitoringDashboardUrl = program.monitoringDashboardUrl;

--- a/services/121-service/src/registration/services/registrations-creation.service.spec.ts
+++ b/services/121-service/src/registration/services/registrations-creation.service.spec.ts
@@ -24,9 +24,7 @@ describe('RegistrationsCreationService', () => {
     const programService = unitRef.get(ProgramService);
     jest
       .spyOn(programService as any, 'findProgramOrThrow')
-      .mockImplementation(() => ({
-        allowEmptyPhoneNumber: false,
-      }));
+      .mockImplementation(() => ({}));
 
     // Mock registrationsInputValidator.findProgramOrThrow
     const registrationsInputValidator = unitRef.get(
@@ -62,7 +60,6 @@ describe('RegistrationsCreationService', () => {
     );
     jest.spyOn(programRepository as any, 'findOneBy').mockImplementation(() => {
       return Promise.resolve({
-        allowEmptyPhoneNumber: false,
         languages: [language],
       });
     });

--- a/services/121-service/src/registration/services/registrations-creation.service.spec.ts
+++ b/services/121-service/src/registration/services/registrations-creation.service.spec.ts
@@ -3,7 +3,6 @@ import { HttpException, HttpStatus } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
-import { ProgramService } from '@121-service/src/programs/programs.service';
 import { DefaultRegistrationDataAttributeNames } from '@121-service/src/registration/enum/registration-attribute.enum';
 import { RegistrationsCreationService } from '@121-service/src/registration/services/registrations-creation.service';
 import { RegistrationsInputValidator } from '@121-service/src/registration/validators/registrations-input-validator';
@@ -19,12 +18,6 @@ describe('RegistrationsCreationService', () => {
       RegistrationsCreationService,
     ).compile();
     registrationsCreationService = unit;
-
-    // Mock programService.findProgramOrThrow
-    const programService = unitRef.get(ProgramService);
-    jest
-      .spyOn(programService as any, 'findProgramOrThrow')
-      .mockImplementation(() => ({}));
 
     // Mock registrationsInputValidator.findProgramOrThrow
     const registrationsInputValidator = unitRef.get(

--- a/services/121-service/src/registration/services/registrations.service.ts
+++ b/services/121-service/src/registration/services/registrations.service.ts
@@ -281,14 +281,7 @@ export class RegistrationsService {
   public async cleanCustomDataIfPhoneNr(
     customDataKey: string,
     customDataValue: string | number | string[] | boolean | null,
-    programId: number,
   ) {
-    const allowEmptyPhoneNumber = (
-      await this.programRepository.findOneBy({
-        id: programId,
-      })
-    )?.allowEmptyPhoneNumber;
-
     const answersTypeTel: string[] = [];
     const programRegistrationAttributes =
       await this.programRegistrationAttributeRepository.find({
@@ -302,26 +295,9 @@ export class RegistrationsService {
       return customDataValue;
     }
 
-    if (
-      !allowEmptyPhoneNumber &&
-      customDataKey === DefaultRegistrationDataAttributeNames.phoneNumber
-    ) {
-      // phoneNumber cannot be empty
-      if (!customDataValue) {
-        throw new HttpException(
-          'Phone number cannot be empty',
-          HttpStatus.BAD_REQUEST,
-        );
-      }
-      // otherwise check
-      return await this.lookupService.lookupAndCorrect(String(customDataValue));
-    }
-
     if (!customDataValue) {
-      // other tel-types (e.g. whatsappPhoneNumber) can be empty
       return customDataValue;
     }
-    // otherwise check
     return await this.lookupService.lookupAndCorrect(String(customDataValue));
   }
 
@@ -561,11 +537,7 @@ export class RegistrationsService {
     registration: RegistrationEntity;
     program: ProgramEntity;
   }): Promise<RegistrationEntity> {
-    value = await this.cleanCustomDataIfPhoneNr(
-      attribute,
-      value,
-      registration.programId,
-    );
+    value = await this.cleanCustomDataIfPhoneNr(attribute, value);
 
     if (typeof registration[attribute] !== 'undefined') {
       registration[attribute] = value;

--- a/services/121-service/src/registration/validators/registrations-input-validator.spec.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.spec.ts
@@ -106,6 +106,15 @@ const program = {
   programRegistrationAttributes: dynamicAttributes,
 };
 
+const programWithRequiredPhoneNumber = {
+  ...program,
+  programRegistrationAttributes: dynamicAttributes.map((att) =>
+    att.name === DefaultRegistrationDataAttributeNames.phoneNumber
+      ? { ...att, isRequired: true }
+      : att,
+  ),
+};
+
 describe('RegistrationsInputValidator', () => {
   let validator: RegistrationsInputValidator;
   let mockProgramRepository: Partial<Repository<ProgramEntity>>;
@@ -293,16 +302,15 @@ describe('RegistrationsInputValidator', () => {
     expect(validRegistrations.length).toBe(0);
   });
 
-  it('should report errors for a missing phonenumber when it is not allowed', async () => {
+  it('should report an error when a required tel attribute is missing on create', async () => {
+    mockProgramRepository.findOneOrFail = jest
+      .fn()
+      .mockResolvedValue(programWithRequiredPhoneNumber);
+
     const csvArray = [
       {
-        namePartnerOrganization: 'ABC',
         preferredLanguage: RegistrationPreferredLanguage.en,
-        maxPayments: '5',
-        nameFirst: 'Test',
-        nameLast: 'Test',
-        programFspConfigurationName: Fsps.intersolveVoucherWhatsapp,
-        whatsappPhoneNumber: '1234567890',
+        programFspConfigurationName: Fsps.excel,
         scope: 'country',
       },
     ];
@@ -319,16 +327,62 @@ describe('RegistrationsInputValidator', () => {
 
     expect(errors).toEqual(
       expect.arrayContaining([
-        {
-          index: 0,
-          referenceId: undefined,
+        expect.objectContaining({
           column: DefaultRegistrationDataAttributeNames.phoneNumber,
-          value: undefined,
           error:
-            'PhoneNumber is required when creating a new registration for this program. Set allowEmptyPhoneNumber to true in the program settings to allow empty phone numbers',
-        },
+            'phoneNumber is required when creating a new registration for this program.',
+        }),
       ]),
     );
+  });
+
+  it('should report an error when a required tel attribute is cleared on update', async () => {
+    mockProgramRepository.findOneOrFail = jest
+      .fn()
+      .mockResolvedValue(programWithRequiredPhoneNumber);
+
+    // an empty string represents an explicit attempt to clear the field, as opposed to omitting it
+    const csvArray = [{ phoneNumber: '' }];
+
+    const { errors } = await validator.validateAndCleanInput({
+      registrationInputArray: csvArray,
+      programId,
+      userId,
+      typeOfInput: RegistrationValidationInputType.update,
+      validationConfig: {
+        validateExistingReferenceId: false,
+      },
+    });
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          column: DefaultRegistrationDataAttributeNames.phoneNumber,
+          error: 'phoneNumber is not allowed to be updated to an empty value.',
+        }),
+      ]),
+    );
+  });
+
+  it('should not report an error when a required tel attribute is left out of an update', async () => {
+    mockProgramRepository.findOneOrFail = jest
+      .fn()
+      .mockResolvedValue(programWithRequiredPhoneNumber);
+
+    // omitting the key entirely (undefined) means the field is left untouched, unlike an explicit empty string
+    const csvArray = [{ fullName: 'Unchanged phoneNumber' }];
+
+    const { errors } = await validator.validateAndCleanInput({
+      registrationInputArray: csvArray,
+      programId,
+      userId,
+      typeOfInput: RegistrationValidationInputType.update,
+      validationConfig: {
+        validateExistingReferenceId: false,
+      },
+    });
+
+    expect(errors).toEqual([]);
   });
 
   it('should add max payment when its null', async () => {
@@ -356,13 +410,7 @@ describe('RegistrationsInputValidator', () => {
   // This can happen we creating registrations with a csv file
   it('should be able to post all non required attributes as empty string', async () => {
     jest.spyOn(userService, 'getUserScopeForProgram').mockResolvedValue('');
-    const programAllowsEmptyPhoneNumber = {
-      ...program,
-      allowEmptyPhoneNumber: true,
-    };
-    mockProgramRepository.findOneOrFail = jest
-      .fn()
-      .mockResolvedValue(programAllowsEmptyPhoneNumber);
+    mockProgramRepository.findOneOrFail = jest.fn().mockResolvedValue(program);
 
     const csvArray = [
       {

--- a/services/121-service/src/registration/validators/registrations-input-validator.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.ts
@@ -12,7 +12,6 @@ import { MappedPaginatedRegistrationDto } from '@121-service/src/registration/dt
 import { AdditionalAttributes } from '@121-service/src/registration/dto/update-registration.dto';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import {
-  DefaultRegistrationDataAttributeNames,
   GenericRegistrationAttributes,
   RegistrationAttributeTypes,
 } from '@121-service/src/registration/enum/registration-attribute.enum';
@@ -193,16 +192,6 @@ export class RegistrationsInputValidator {
         validatedRegistrationInput.referenceId = row.referenceId as string;
       }
 
-      const errorObjValidatePhoneNr = this.validatePhoneNumberEmpty({
-        row,
-        i,
-        program,
-        typeOfInput,
-      });
-      if (errorObjValidatePhoneNr) {
-        rowErrors.push(errorObjValidatePhoneNr);
-      }
-
       /*
        * =============================================
        * Validate fsp config related attributes
@@ -272,6 +261,21 @@ export class RegistrationsInputValidator {
             if (RegistrationValidationInputType.bulkUpdate === typeOfInput) {
               return;
             }
+
+            // row[att.name] is undefined here only for create (update/bulkUpdate with undefined already returned above), meaning the attribute was left out entirely
+            if (att.isRequired && !row[att.name]) {
+              rowErrors.push({
+                index: i,
+                column: att.name,
+                value: row[att.name],
+                error:
+                  typeOfInput === RegistrationValidationInputType.create
+                    ? `${att.name} is required when creating a new registration for this program.`
+                    : `${att.name} is not allowed to be updated to an empty value.`,
+              });
+              return;
+            }
+
             /*
              * ==================================================================
              * If an attribute is a phone number, validate it using Twilio lookup
@@ -347,9 +351,7 @@ export class RegistrationsInputValidator {
             rowErrors.push(errorObj);
           } else if (row[att.name] !== undefined) {
             validatedRegistrationInput.data[att.name] = row[att.name] as
-              | string
-              | number
-              | boolean;
+              string | number | boolean;
           }
         }),
       );
@@ -682,49 +684,6 @@ export class RegistrationsInputValidator {
           error: 'referenceId already exists in database',
         };
       }
-    }
-  }
-
-  private validatePhoneNumberEmpty({
-    row,
-    i,
-    program,
-    typeOfInput,
-  }: {
-    row: any;
-    i: number;
-    program: ProgramEntity;
-    typeOfInput: RegistrationValidationInputType;
-  }): ValidateRegistrationErrorObject | undefined {
-    // If the program allows empty phone numbers, skip this validation
-    if (program.allowEmptyPhoneNumber) {
-      return;
-    }
-    if (
-      typeOfInput === RegistrationValidationInputType.create &&
-      !row.phoneNumber
-    ) {
-      return {
-        index: i,
-        column: DefaultRegistrationDataAttributeNames.phoneNumber,
-        value: undefined,
-        error:
-          'PhoneNumber is required when creating a new registration for this program. Set allowEmptyPhoneNumber to true in the program settings to allow empty phone numbers',
-      };
-    }
-
-    if (
-      typeOfInput === RegistrationValidationInputType.update &&
-      row.phoneNumber === ''
-    ) {
-      // on an update phonenumber can be empty if it is not being updated
-      return {
-        index: i,
-        column: DefaultRegistrationDataAttributeNames.phoneNumber,
-        value: row.phoneNumber,
-        error:
-          'PhoneNumber is not allowed to be updated to an empty value. Set allowEmptyPhoneNumber to true in the program settings to allow empty phone numbers',
-      };
     }
   }
 

--- a/services/121-service/src/seed-data/program/demo-program-bank-transfer.json
+++ b/services/121-service/src/seed-data/program/demo-program-bank-transfer.json
@@ -35,6 +35,7 @@
     },
     {
       "name": "phoneNumber",
+      "isRequired": true,
       "label": {
         "en": "Phone number",
         "am": "ስልክ ቁጥር"
@@ -132,7 +133,6 @@
   "languages": ["en", "am"],
   "enableMaxPayments": true,
   "enableScope": false,
-  "allowEmptyPhoneNumber": false,
   "programFspConfigurations": [
     {
       "fsp": "Commercial-bank-ethiopia",

--- a/services/121-service/src/seed-data/program/demo-program-excel.json
+++ b/services/121-service/src/seed-data/program/demo-program-excel.json
@@ -279,6 +279,7 @@
     },
     {
       "name": "phoneNumber",
+      "isRequired": true,
       "label": {
         "en": "Phone Number",
         "es": "Número de teléfono",
@@ -318,6 +319,5 @@
   "languages": ["en", "es", "fr"],
   "enableMaxPayments": true,
   "enableScope": true,
-  "allowEmptyPhoneNumber": false,
   "monitoringDashboardUrl": "https://app.powerbi.com/view?r=eyJrIjoiMzMwYzRiZTMtNmY1ZC00NDg2LWI1MWItMDEzZmJjOGQzMWJjIiwidCI6ImQzYWI5NzkwLTZhZTItNGJkOC1hYTVlLTAyODY0NDgzZTdjNyIsImMiOjh9"
 }

--- a/services/121-service/src/seed-data/program/demo-program-mobile-money.json
+++ b/services/121-service/src/seed-data/program/demo-program-mobile-money.json
@@ -258,6 +258,7 @@
     },
     {
       "name": "phoneNumber",
+      "isRequired": true,
       "label": {
         "en": "Phone Number",
         "es": "Número de teléfono",
@@ -297,6 +298,5 @@
   "languages": ["en", "es", "fr"],
   "enableMaxPayments": true,
   "enableScope": true,
-  "allowEmptyPhoneNumber": false,
   "monitoringDashboardUrl": "https://app.powerbi.com/view?r=eyJrIjoiMzMwYzRiZTMtNmY1ZC00NDg2LWI1MWItMDEzZmJjOGQzMWJjIiwidCI6ImQzYWI5NzkwLTZhZTItNGJkOC1hYTVlLTAyODY0NDgzZTdjNyIsImMiOjh9"
 }

--- a/services/121-service/src/seed-data/program/program-airtel.json
+++ b/services/121-service/src/seed-data/program/program-airtel.json
@@ -31,6 +31,7 @@
     },
     {
       "name": "phoneNumber",
+      "isRequired": true,
       "label": {
         "en": "Phone Number"
       },
@@ -47,7 +48,6 @@
   "languages": ["en"],
   "enableMaxPayments": true,
   "enableScope": false,
-  "allowEmptyPhoneNumber": false,
   "programFspConfigurations": [
     {
       "fsp": "Airtel"

--- a/services/121-service/src/seed-data/program/program-cbe.json
+++ b/services/121-service/src/seed-data/program/program-cbe.json
@@ -34,6 +34,7 @@
     },
     {
       "name": "phoneNumber",
+      "isRequired": true,
       "label": {
         "en": "Phone number",
         "am": "ስልክ ቁጥር"
@@ -130,7 +131,6 @@
   "languages": ["en", "am"],
   "enableMaxPayments": true,
   "enableScope": false,
-  "allowEmptyPhoneNumber": false,
   "programFspConfigurations": [
     {
       "fsp": "Commercial-bank-ethiopia",

--- a/services/121-service/src/seed-data/program/program-cooperative-bank-of-oromia.json
+++ b/services/121-service/src/seed-data/program/program-cooperative-bank-of-oromia.json
@@ -31,6 +31,7 @@
     },
     {
       "name": "phoneNumber",
+      "isRequired": true,
       "label": {
         "en": "Phone Number"
       },
@@ -61,7 +62,6 @@
   "languages": ["en"],
   "enableMaxPayments": true,
   "enableScope": false,
-  "allowEmptyPhoneNumber": false,
   "programFspConfigurations": [
     {
       "fsp": "Cooperative-bank-of-oromia",

--- a/services/121-service/src/seed-data/program/program-mtn.json
+++ b/services/121-service/src/seed-data/program/program-mtn.json
@@ -33,6 +33,7 @@
     },
     {
       "name": "phoneNumber",
+      "isRequired": true,
       "label": {
         "en": "Phone Number"
       },
@@ -62,7 +63,6 @@
   "languages": ["en"],
   "enableMaxPayments": true,
   "enableScope": false,
-  "allowEmptyPhoneNumber": false,
   "programFspConfigurations": [
     {
       "fsp": "MTN",

--- a/services/121-service/src/seed-data/program/program-nedbank.json
+++ b/services/121-service/src/seed-data/program/program-nedbank.json
@@ -52,7 +52,6 @@
   "languages": ["en", "nl"],
   "enableMaxPayments": true,
   "enableScope": true,
-  "allowEmptyPhoneNumber": true,
   "programFspConfigurations": [
     {
       "fsp": "Nedbank",

--- a/services/121-service/src/seed-data/program/program-nlrc-ocw.json
+++ b/services/121-service/src/seed-data/program/program-nlrc-ocw.json
@@ -31,6 +31,7 @@
     },
     {
       "name": "phoneNumber",
+      "isRequired": true,
       "label": {
         "en": "Phone Number"
       },
@@ -112,7 +113,6 @@
   "enableMaxPayments": false,
   "enableScope": false,
   "monitoringDashboardUrl": "https://app.powerbi.com/view?r=eyJrIjoiNDkxN2Q1NmEtOWIxOC00ZTYyLTkxMTMtYmI3MmE4YTVkMTE2IiwidCI6ImEyYjUzYmU1LTczNGUtNGU2Yy1hYjBkLWQxODRmNjBmZDkxNyIsImMiOjh9",
-  "allowEmptyPhoneNumber": false,
   "programFspConfigurations": [
     {
       "fsp": "Intersolve-voucher-whatsapp",

--- a/services/121-service/src/seed-data/program/program-nlrc-pv.json
+++ b/services/121-service/src/seed-data/program/program-nlrc-pv.json
@@ -126,7 +126,6 @@
   "languages": ["ar", "en", "es", "fr", "id", "nl", "pt", "tl", "uk"],
   "enableMaxPayments": true,
   "enableScope": true,
-  "allowEmptyPhoneNumber": true,
   "programFspConfigurations": [
     {
       "fsp": "Intersolve-voucher-whatsapp",

--- a/services/121-service/src/seed-data/program/program-onafriq.json
+++ b/services/121-service/src/seed-data/program/program-onafriq.json
@@ -42,6 +42,7 @@
     },
     {
       "name": "phoneNumber",
+      "isRequired": true,
       "label": {
         "en": "Phone Number for communication"
       },
@@ -71,7 +72,6 @@
   "languages": ["en"],
   "enableMaxPayments": true,
   "enableScope": false,
-  "allowEmptyPhoneNumber": false,
   "programFspConfigurations": [
     {
       "fsp": "Onafriq",

--- a/services/121-service/src/seed-data/program/program-safaricom.json
+++ b/services/121-service/src/seed-data/program/program-safaricom.json
@@ -129,6 +129,7 @@
     },
     {
       "name": "phoneNumber",
+      "isRequired": true,
       "label": {
         "en": "Phone Number"
       },
@@ -145,7 +146,6 @@
   "languages": ["en"],
   "enableMaxPayments": true,
   "enableScope": false,
-  "allowEmptyPhoneNumber": false,
   "programFspConfigurations": [
     {
       "fsp": "Safaricom"

--- a/services/121-service/src/seed-data/program/program-test.json
+++ b/services/121-service/src/seed-data/program/program-test.json
@@ -168,6 +168,7 @@
     },
     {
       "name": "phoneNumber",
+      "isRequired": true,
       "label": {
         "ar": "الهاتف.",
         "en": "Phone Nr.",
@@ -272,7 +273,6 @@
   "languages": ["ar", "en", "es", "fr", "nl"],
   "enableMaxPayments": false,
   "enableScope": false,
-  "allowEmptyPhoneNumber": false,
   "programFspConfigurations": [
     {
       "fsp": "Intersolve-voucher-whatsapp",

--- a/services/121-service/test/payment/fsp-integrations/do-payment-fsp-safaricom.test.ts
+++ b/services/121-service/test/payment/fsp-integrations/do-payment-fsp-safaricom.test.ts
@@ -3,14 +3,12 @@ import { HttpStatus } from '@nestjs/common';
 import { Fsps } from '@121-service/src/fsp-integrations/shared/enum/fsp-name.enum';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { TransactionEventDescription } from '@121-service/src/payments/transactions/transaction-events/enum/transaction-event-description.enum';
-import { UpdateProgramDto } from '@121-service/src/programs/dto/update-program.dto';
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { RegistrationPreferredLanguage } from '@121-service/src/shared/enum/registration-preferred-language.enum';
 import { waitFor } from '@121-service/src/utils/waitFor.helper';
 import {
   doPayment,
   getTransactionsByPaymentIdPaginated,
-  patchProgram,
   retryPayment,
   waitForPaymentAndTransactionsToComplete,
 } from '@121-service/test/helpers/program.helper';
@@ -49,15 +47,6 @@ describe('Do payment to 1 PA', () => {
     });
 
     it('should successfully pay-out', async () => {
-      // Arrange
-      const program = {
-        allowEmptyPhoneNumber: false,
-      };
-
-      // Act
-      // Call the update function
-      await patchProgram(2, program as UpdateProgramDto, accessToken);
-
       // Arrange
       registrationSafaricom.phoneNumber = '254708374149';
       await seedIncludedRegistrations(

--- a/services/121-service/test/program/__snapshots__/create-program.test.ts.snap
+++ b/services/121-service/test/program/__snapshots__/create-program.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`Create program should post a program: Create program response for program: CBE Program 1`] = `
 {
-  "allowEmptyPhoneNumber": false,
   "budget": null,
   "currency": "ETB",
   "description": {
@@ -56,7 +55,7 @@ exports[`Create program should post a program: Create program response for progr
       "type": "text",
     },
     {
-      "isRequired": false,
+      "isRequired": true,
       "label": {
         "am": "ስልክ ቁጥር",
         "en": "Phone number",
@@ -328,7 +327,7 @@ exports[`Create program should post a program: Create program response for progr
       "type": "text",
     },
     {
-      "isRequired": false,
+      "isRequired": true,
       "koboLabel": null,
       "label": {
         "am": "ስልክ ቁጥር",
@@ -461,7 +460,7 @@ exports[`Create program should post a program: Create program response for progr
       "editableInPortal": true,
       "id": 27,
       "includeInTransactionExport": true,
-      "isRequired": false,
+      "isRequired": true,
       "koboLabel": null,
       "label": {
         "am": "ስልክ ቁጥር",
@@ -487,7 +486,6 @@ exports[`Create program should post a program: Create program response for progr
 
 exports[`Create program should post a program: Create program response for program: NLRC OCW program 1`] = `
 {
-  "allowEmptyPhoneNumber": false,
   "budget": null,
   "currency": "EUR",
   "description": {
@@ -545,7 +543,7 @@ exports[`Create program should post a program: Create program response for progr
       "type": "text",
     },
     {
-      "isRequired": false,
+      "isRequired": true,
       "label": {
         "en": "Phone Number",
       },
@@ -829,7 +827,7 @@ exports[`Create program should post a program: Create program response for progr
       "type": "text",
     },
     {
-      "isRequired": false,
+      "isRequired": true,
       "koboLabel": null,
       "label": {
         "en": "Phone Number",
@@ -968,7 +966,7 @@ exports[`Create program should post a program: Create program response for progr
       "editableInPortal": false,
       "id": 19,
       "includeInTransactionExport": false,
-      "isRequired": false,
+      "isRequired": true,
       "koboLabel": null,
       "label": {
         "en": "Phone Number",

--- a/services/121-service/test/program/create-program.test.ts
+++ b/services/121-service/test/program/create-program.test.ts
@@ -215,7 +215,7 @@ describe('Create program', () => {
           expect.objectContaining({
             name: 'phoneNumber',
             label: expect.objectContaining({ en: 'Phone number' }),
-            type: 'text',
+            type: 'tel',
           }),
         ]),
       }),

--- a/services/121-service/test/program/duplicate-program.test.ts
+++ b/services/121-service/test/program/duplicate-program.test.ts
@@ -44,7 +44,6 @@ describe('Duplicate program', () => {
     validation: true,
     enableScope: false,
     enableMaxPayments: true,
-    allowEmptyPhoneNumber: false,
   };
 
   const sourceFspConfiguration: CreateProgramFspConfigurationDto = {
@@ -80,8 +79,8 @@ describe('Duplicate program', () => {
     });
 
     // Approval thresholds
-    const [lowThresholdApproverId, highThresholdApproverId] =
-      await Promise.all([
+    const [lowThresholdApproverId, highThresholdApproverId] = await Promise.all(
+      [
         createUserAssignedToProgram({
           programId: sourceProgramId,
           roles: [DefaultUserRole.View],
@@ -92,7 +91,8 @@ describe('Duplicate program', () => {
           roles: [DefaultUserRole.View],
           adminAccessToken: accessToken,
         }),
-      ]);
+      ],
+    );
     const sourceThresholds: CreateProgramApprovalThresholdDto[] = [
       {
         thresholdAmount: lowThresholdAmount,
@@ -219,10 +219,7 @@ describe('Duplicate program', () => {
     return new Map(
       [...users]
         .sort((a, b) => a.id - b.id)
-        .map((user) => [
-          user.id,
-          user.roles.map((role) => role.role).sort(),
-        ]),
+        .map((user) => [user.id, user.roles.map((role) => role.role).sort()]),
     );
   }
 

--- a/services/121-service/test/registrations/import-registration.test.ts
+++ b/services/121-service/test/registrations/import-registration.test.ts
@@ -13,7 +13,6 @@ import {
   registrationScopedTurkanaNorthPv,
 } from '@121-service/test/fixtures/scoped-registrations';
 import {
-  patchProgram,
   setAllProgramsRegistrationAttributesNonRequired,
   waitForMessagesToComplete,
 } from '@121-service/test/helpers/program.helper';
@@ -33,7 +32,6 @@ import {
   programIdOCW,
   programIdPV,
   programIdWesteros,
-  registrationPV5,
   registrationWesteros1,
 } from '@121-service/test/registrations/pagination/pagination-data';
 
@@ -199,37 +197,6 @@ describe('Import a registration', () => {
     expect(registration).toHaveLength(0);
   });
 
-  it('should import registrations with empty phoneNumber, when program allows this', async () => {
-    // Arrange
-    await resetDB({ seedScript: SeedScript.nlrcMultiple });
-    accessToken = await getAccessToken();
-    const registrationPVCopy = { ...registrationPV5 };
-    // @ts-expect-error "The operand of a 'delete' operator must be optional.ts(2790)"
-    delete registrationPVCopy.phoneNumber;
-    const programUpdate = {
-      allowEmptyPhoneNumber: true,
-    };
-    await patchProgram(programIdPV, programUpdate, accessToken);
-
-    // Act
-    const response = await importRegistrations(
-      programIdPV,
-      [registrationPVCopy],
-      accessToken,
-    );
-    expect(response.statusCode).toBe(HttpStatus.CREATED);
-
-    const result = await searchRegistrationByReferenceId(
-      registrationPVCopy.referenceId,
-      programIdPV,
-      accessToken,
-    );
-    const registration = result.body.data[0];
-    for (const key in registrationPVCopy) {
-      expect(registration[key]).toBe(registrationPVCopy[key]);
-    }
-  });
-
   it('should throw an error with a numeric registration atribute set to null', async () => {
     // Arrange
     await resetDB({ seedScript: SeedScript.nlrcMultiple });
@@ -374,11 +341,6 @@ describe('Import a registration', () => {
       referenceId: 'registrationWesterosEmpty',
       programFspConfigurationName: 'ironBank',
     };
-
-    const programUpdate = {
-      allowEmptyPhoneNumber: true,
-    };
-    await patchProgram(programIdWesteros, programUpdate, accessToken);
 
     // Patch all programRegistationAttributes to be non-required
     await setAllProgramsRegistrationAttributesNonRequired(

--- a/services/121-service/test/registrations/update-registration.test.ts
+++ b/services/121-service/test/registrations/update-registration.test.ts
@@ -5,7 +5,6 @@ import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { registrationVisa } from '@121-service/src/seed-data/mock/visa-card.data';
 import { PermissionEnum } from '@121-service/src/user/enum/permission.enum';
 import {
-  patchProgram,
   patchProgramRegistrationAttribute,
   setAllProgramsRegistrationAttributesNonRequired,
 } from '@121-service/test/helpers/program.helper';
@@ -350,11 +349,6 @@ describe('Update attribute of PA', () => {
       [registrationWesteros1],
       accessToken,
     );
-    const programUpdate = {
-      allowEmptyPhoneNumber: true,
-    };
-    await patchProgram(programIdWesteros, programUpdate, accessToken);
-
     await setAllProgramsRegistrationAttributesNonRequired(
       programIdWesteros,
       accessToken,


### PR DESCRIPTION
[AB#43768](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43768) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

- Program-level "allow empty phone number" toggle is removed entirely. Programs can no longer be configured to allow empty phone numbers via this setting.

Whether a phone number is required is now driven by two things instead of the program flag:

- The phoneNumber program registration attribute's own isRequired property (per-attribute), and
- The global TWILIO_MODE environment variable (instance-wide).
- Kobo form validation now keys off Twilio mode. A phoneNumber survey field is required when TWILIO_MODE !== DISABLED (previously it was required unless allowEmptyPhoneNumber was true).

Program creation auto-adds non-required phoneNumber attribute only when Twilio is enabled. 

Registration import/update phone-number validation is now generic. The dedicated validatePhoneNumberEmpty check was removed; the required-empty error is now emitted by the generic required-tel-attribute path. 

cleanCustomDataIfPhoneNr is removed. As this enforcment already happens in the input validator, this part was sort of double validation

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8638.westeurope.3.azurestaticapps.net
