### PR TITLE
Log incoming webhook calls

### DIFF
--- a/services/121-service/src/fsp-integrations/reconciliation/onafriq/onafriq-reconciliation.module.ts
+++ b/services/121-service/src/fsp-integrations/reconciliation/onafriq/onafriq-reconciliation.module.ts
@@ -12,6 +12,7 @@ import { ProgramFspConfigurationsModule } from '@121-service/src/program-fsp-con
 import { ProgramModule } from '@121-service/src/programs/programs.module';
 import { QueuesRegistryModule } from '@121-service/src/queues-registry/queues-registry.module';
 import { AzureLoggerMiddleware } from '@121-service/src/shared/middleware/azure-logger.middleware';
+import { AzureLogService } from '@121-service/src/shared/services/azure-log.service';
 import { createScopedRepositoryProvider } from '@121-service/src/utils/scope/createScopedRepositoryProvider.helper';
 
 @Module({
@@ -28,6 +29,7 @@ import { createScopedRepositoryProvider } from '@121-service/src/utils/scope/cre
     TransactionCallbackJobProcessorOnafriq,
     createScopedRepositoryProvider(OnafriqTransactionEntity),
     createScopedRepositoryProvider(TransactionEventEntity),
+    AzureLogService,
   ],
   controllers: [OnafriqReconciliationController],
   exports: [OnafriqReconciliationService],

--- a/services/121-service/src/fsp-integrations/reconciliation/onafriq/onafriq-reconciliation.service.ts
+++ b/services/121-service/src/fsp-integrations/reconciliation/onafriq/onafriq-reconciliation.service.ts
@@ -28,6 +28,7 @@ import { ProgramRepository } from '@121-service/src/programs/repositories/progra
 import { QueuesRegistryService } from '@121-service/src/queues-registry/queues-registry.service';
 import { ScopedRepository } from '@121-service/src/scoped.repository';
 import { JobNames } from '@121-service/src/shared/enum/job-names.enum';
+import { AzureLogService } from '@121-service/src/shared/services/azure-log.service';
 import { getScopedRepositoryProviderName } from '@121-service/src/utils/scope/createScopedRepositoryProvider.helper';
 
 @Injectable()
@@ -43,11 +44,16 @@ export class OnafriqReconciliationService {
     private readonly redisClient: Redis,
     private readonly programFspConfigurationRepository: ProgramFspConfigurationRepository,
     private readonly programRepository: ProgramRepository,
+    private readonly azureLogService: AzureLogService,
   ) {}
 
   public async processTransactionCallback(
     onafriqTransactionCallback: OnafriqTransactionCallbackDto,
   ): Promise<void> {
+    this.azureLogService.traceAzure(
+      `Incoming Onafriq transaction callback received: thirdPartyTransId=${onafriqTransactionCallback.thirdPartyTransId}, mfsTransId=${onafriqTransactionCallback.mfsTransId}`,
+    );
+
     const onafriqTransactionCallbackJob: OnafriqTransactionCallbackJobDto = {
       thirdPartyTransId: onafriqTransactionCallback.thirdPartyTransId,
       mfsTransId: onafriqTransactionCallback.mfsTransId,

--- a/services/121-service/src/fsp-integrations/reconciliation/safaricom/safaricom-reconciliation.module.ts
+++ b/services/121-service/src/fsp-integrations/reconciliation/safaricom/safaricom-reconciliation.module.ts
@@ -10,6 +10,7 @@ import { TransactionEventsModule } from '@121-service/src/payments/transactions/
 import { TransactionsModule } from '@121-service/src/payments/transactions/transactions.module';
 import { QueuesRegistryModule } from '@121-service/src/queues-registry/queues-registry.module';
 import { AzureLoggerMiddleware } from '@121-service/src/shared/middleware/azure-logger.middleware';
+import { AzureLogService } from '@121-service/src/shared/services/azure-log.service';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { AzureLoggerMiddleware } from '@121-service/src/shared/middleware/azure-
     SafaricomReconciliationService,
     TransferCallbackJobProcessorSafaricom,
     TimeoutCallbackJobProcessorSafaricom,
+    AzureLogService,
   ],
   controllers: [SafaricomReconciliationController],
   exports: [SafaricomReconciliationService],

--- a/services/121-service/src/fsp-integrations/reconciliation/safaricom/safaricom-reconciliation.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/reconciliation/safaricom/safaricom-reconciliation.service.spec.ts
@@ -12,6 +12,7 @@ import {
 import { TransactionsService } from '@121-service/src/payments/transactions/transactions.service';
 import { QueuesRegistryService } from '@121-service/src/queues-registry/queues-registry.service';
 import { JobNames } from '@121-service/src/shared/enum/job-names.enum';
+import { AzureLogService } from '@121-service/src/shared/services/azure-log.service';
 
 describe('SafaricomReconciliationService', () => {
   let safaricomReconciliationService: SafaricomReconciliationService;
@@ -47,6 +48,10 @@ describe('SafaricomReconciliationService', () => {
           useValue: {
             sadd: jest.fn(),
           },
+        },
+        {
+          provide: AzureLogService,
+          useValue: { traceAzure: jest.fn(), logError: jest.fn() },
         },
       ],
     }).compile();

--- a/services/121-service/src/fsp-integrations/reconciliation/safaricom/safaricom-reconciliation.service.ts
+++ b/services/121-service/src/fsp-integrations/reconciliation/safaricom/safaricom-reconciliation.service.ts
@@ -15,6 +15,7 @@ import { TransactionEventDescription } from '@121-service/src/payments/transacti
 import { TransactionsService } from '@121-service/src/payments/transactions/transactions.service';
 import { QueuesRegistryService } from '@121-service/src/queues-registry/queues-registry.service';
 import { JobNames } from '@121-service/src/shared/enum/job-names.enum';
+import { AzureLogService } from '@121-service/src/shared/services/azure-log.service';
 
 @Injectable()
 export class SafaricomReconciliationService {
@@ -24,11 +25,16 @@ export class SafaricomReconciliationService {
     private readonly queuesService: QueuesRegistryService,
     @Inject(REDIS_CLIENT)
     private readonly redisClient: Redis,
+    private readonly azureLogService: AzureLogService,
   ) {}
 
   public async processTransferCallback(
     safaricomTransferCallback: SafaricomTransferCallbackDto,
   ): Promise<void> {
+    this.azureLogService.traceAzure(
+      `Incoming Safaricom transfer callback received: originatorConversationId=${safaricomTransferCallback.Result.OriginatorConversationID}, mpesaTransactionId=${safaricomTransferCallback.Result.TransactionID}`,
+    );
+
     const safaricomTransferCallbackJob: SafaricomTransferCallbackJobDto = {
       originatorConversationId:
         safaricomTransferCallback.Result.OriginatorConversationID,
@@ -62,6 +68,11 @@ export class SafaricomReconciliationService {
         `Safaricom Timeout Callback does not contain OriginatorConversationID.`,
       );
     }
+
+    this.azureLogService.traceAzure(
+      `Incoming Safaricom timeout callback received: originatorConversationId=${safaricomTimeoutCallback.OriginatorConversationID}`,
+    );
+
     const safaricomTimeoutCallbackJob: SafaricomTimeoutCallbackJobDto = {
       originatorConversationId:
         safaricomTimeoutCallback.OriginatorConversationID,

--- a/services/121-service/src/notifications/message-incoming/message-incoming.service.ts
+++ b/services/121-service/src/notifications/message-incoming/message-incoming.service.ts
@@ -33,6 +33,7 @@ import { RegistrationEntity } from '@121-service/src/registration/entities/regis
 import { DefaultRegistrationDataAttributeNames } from '@121-service/src/registration/enum/registration-attribute.enum';
 import { RegistrationsService } from '@121-service/src/registration/services/registrations.service';
 import { RegistrationPreferredLanguage } from '@121-service/src/shared/enum/registration-preferred-language.enum';
+import { AzureLogService } from '@121-service/src/shared/services/azure-log.service';
 import { UserEntity } from '@121-service/src/user/entities/user.entity';
 import { isSameAsString } from '@121-service/src/utils/comparison.helper';
 import { maskValueKeepEnd } from '@121-service/src/utils/mask-value.helper';
@@ -64,6 +65,7 @@ export class MessageIncomingService {
     private readonly transactionRepository: TransactionRepository,
     private readonly transactionViewScopedRepository: TransactionViewScopedRepository,
     private readonly registrationsService: RegistrationsService,
+    private readonly azureLogService: AzureLogService,
   ) {}
 
   public async getGenericNotificationText(
@@ -129,6 +131,9 @@ export class MessageIncomingService {
   public async addIncomingWhatsappToQueue(
     callbackData: TwilioIncomingCallbackDto,
   ): Promise<void> {
+    this.azureLogService.traceAzure(
+      `Incoming WhatsApp message received: sid=${callbackData.MessageSid}, from=${callbackData.From}`,
+    );
     await this.queuesService.messageIncomingCallbackQueue.add(
       ProcessNameMessage.whatsapp,
       callbackData,


### PR DESCRIPTION
[AB#43831](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43831) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

I recently investigated a delayed WhatsApp voucher payment [incident](https://teams.microsoft.com/l/message/19:937a9d9d03bc4c528b8017ff4697c3ad@thread.tacv2/1785852979335?tenantId=d3ab9790-6ae2-4bd8-aa5e-02864483e7c7&groupId=e5361b0b-9aa5-47ef-ad77-29532b8e9903&parentMessageId=1785852979335&teamName=NRK%20Thema%20Voedsel%20-%20510%20Support&channelName=121%20bugs%20-%20Nederlandse%20Rode%20Kruis&createdTime=1785852979335&ngc=true) 

I found we had no visibility into when incoming Twilio and FSP callback webhooks actually arrived, making it hard to distinguish between an external delay (Twilio/FSP side) and a processing delay on our side. This adds minimal trackTrace logging to Application Insights at the point each external callback is received (WhatsApp incoming messages, Onafriq transaction callbacks, and Safaricom transfer/timeout callbacks), so future incidents can be diagnosed by querying arrival timestamps in the traces table instead of relying on guesswork. 

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
