### PR TITLE
Hotfix for tracking service module shuffle bug

### DIFF
--- a/interfaces/portal/src/app/services/tracking.service.ts
+++ b/interfaces/portal/src/app/services/tracking.service.ts
@@ -1,4 +1,10 @@
-import { inject, Injectable, isDevMode } from '@angular/core';
+import {
+  EnvironmentProviders,
+  inject,
+  Injectable,
+  isDevMode,
+  Provider,
+} from '@angular/core';
 
 import { MatomoTracker, provideMatomo, withRouter } from 'ngx-matomo-client';
 import { parseMatomoConnectionString } from 'scripts/lib/matomo.utils.mjs';
@@ -109,27 +115,31 @@ const IS_MATOMO_ENABLED = () =>
   providedIn: 'root',
 })
 export class TrackingService {
-  public static APP_PROVIDERS = IS_MATOMO_ENABLED()
-    ? [
-        provideMatomo(
-          {
-            siteId: MATOMO_CONNECTION_INFO.id,
-            trackerUrl: MATOMO_CONNECTION_INFO.api,
-            trackerUrlSuffix: '', // Should be included in `connectionInfo.api` used as `trackerUrl`
-            scriptUrl: MATOMO_CONNECTION_INFO.sdk,
-            acceptDoNotTrack: true, // Prevent unnecessary requests to the Matomo API
-            requireConsent: 'none', // Will change with AB#33767
-            runOutsideAngularZone: true,
-            enableJSErrorTracking: false, // We use ApplicationInsights for this
-            enableLinkTracking: 'enable-pseudo', // Enable tracking of right/middle-clicks
-            trackAppInitialLoad: false,
-          },
-          withRouter({
-            exclude: [new RegExp(AppRoutes.authCallback)],
-          }),
-        ),
-      ]
-    : [];
+  // Lazy getter to avoid reading `AppRoutes` at module-load time, which can be
+  // `undefined` due to circular imports and crash app bootstrap.
+  public static get APP_PROVIDERS(): (EnvironmentProviders | Provider)[] {
+    return IS_MATOMO_ENABLED()
+      ? [
+          provideMatomo(
+            {
+              siteId: MATOMO_CONNECTION_INFO.id,
+              trackerUrl: MATOMO_CONNECTION_INFO.api,
+              trackerUrlSuffix: '', // Should be included in `connectionInfo.api` used as `trackerUrl`
+              scriptUrl: MATOMO_CONNECTION_INFO.sdk,
+              acceptDoNotTrack: true, // Prevent unnecessary requests to the Matomo API
+              requireConsent: 'none', // Will change with AB#33767
+              runOutsideAngularZone: true,
+              enableJSErrorTracking: false, // We use ApplicationInsights for this
+              enableLinkTracking: 'enable-pseudo', // Enable tracking of right/middle-clicks
+              trackAppInitialLoad: false,
+            },
+            withRouter({
+              exclude: [new RegExp(AppRoutes.authCallback)],
+            }),
+          ),
+        ]
+      : [];
+  }
 
   private readonly tracker = IS_MATOMO_ENABLED()
     ? inject(MatomoTracker)


### PR DESCRIPTION
[AB#43882](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43882) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Culprit

**File:** tracking.service.ts

`TrackingService.APP_PROVIDERS` was an **eager `static` class field** that read `AppRoutes.authCallback` at **module-load time**:

```ts
public static APP_PROVIDERS = IS_MATOMO_ENABLED()
  ? [ provideMatomo(/* ... */, withRouter({
      exclude: [new RegExp(AppRoutes.authCallback)], // ← evaluated when the class is defined
    })) ]
  : [];
```

- `AppRoutes` is an enum in app.routes.ts, which sits in a **circular import chain** (`app.routes` ↔ `auth.service`, plus `tracking.service` → `app.routes`).
- Because the field initializes at class-definition time, if `TrackingService`'s module runs before app.routes.ts has assigned the enum, `AppRoutes` is still `undefined`.
- Reading `.authCallback` on `undefined` throws during app bootstrap → the exact production error:

  ```
  Uncaught TypeError: Cannot read properties of undefined (reading 'authCallback')
      at <static_initializer> (chunk-IW5CE2JU.js:...)
  ```

**Why it surfaced in this release (`v26.8-1...v26.8-2`):** the static initializer is old, but this release added `TrackingService` imports to **widely-used components** (`card-editable`, `info-tooltip`, and the `program-form-*` components). That changed esbuild's chunking/module-evaluation order, causing `TrackingService` to initialize before the `AppRoutes` enum — exposing the latent bug.

> Note: `AuthService.APP_PROVIDERS` was already a lazy `static get` "to avoid circular dependency chain." `TrackingService` was the remaining service still using the fragile eager pattern. (The `Permissions-Policy` console warnings are unrelated hosting noise.)

## Fix

Convert `TrackingService.APP_PROVIDERS` from an eager `static` field to a lazy `static get`, mirroring `AuthService`. `AppRoutes.authCallback` is now read only when app.config.ts runs — after all modules are fully loaded — breaking the module-load-time coupling regardless of bundle ordering.

```ts
export class TrackingService {
  // Lazy getter to avoid reading `AppRoutes` at module-load time, which can be
  // `undefined` due to circular imports and crash app bootstrap.
  public static get APP_PROVIDERS(): (EnvironmentProviders | Provider)[] {
    return IS_MATOMO_ENABLED()
      ? [ provideMatomo(/* ... */, withRouter({
          exclude: [new RegExp(AppRoutes.authCallback)],
        })) ]
      : [];
  }
```

Added `EnvironmentProviders` and `Provider` to the `@angular/core` import for the getter's return type.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
