### PR TITLE
Fix for confusing wording in error-table

### DIFF
--- a/e2e/portal/pages/ProgramSettingsRegistrationDataPage.ts
+++ b/e2e/portal/pages/ProgramSettingsRegistrationDataPage.ts
@@ -190,8 +190,8 @@ class ProgramSettingsRegistrationDataPage extends BasePage {
     expect(columnHeaders).toEqual(['Reference ID', 'Column', 'Error']);
     expect(rows).toEqual([
       'failure-import-with-failure',
-      'programFspConfigurationName',
-      'FspConfigurationName undefined not found in program. Allowed values: Safaricom',
+      'fsp',
+      'Fsp undefined not found in program. Allowed values: Safaricom',
     ]);
   }
 

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -15,6 +15,8 @@ import {
 import { ButtonModule } from 'primeng/button';
 import { DialogModule } from 'primeng/dialog';
 
+import { GenericRegistrationAttributes } from '@121-service/src/registration/enum/registration-attribute.enum';
+
 import {
   ChipVariant,
   ColoredChipComponent,
@@ -142,10 +144,12 @@ export class KoboImportExistingRegistrationsDialogComponent {
         errors.map((error: ValidationError, index: number) => {
           // I'm sorry about this ugly 'fix'. Truly. If this code were a person, it would apologize too.
           // check AB#43075 for more context as to why we did this...
-          if (error.column === 'programFspConfigurationName') {
+          if (
+            error.column ===
+            GenericRegistrationAttributes.programFspConfigurationName.toString()
+          ) {
             return {
-              error: error.error.replace('FspConfigurationName', 'Fsp'),
-              referenceId: error.referenceId,
+              ...error,
               column: 'fsp',
               id: index,
             };

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -139,10 +139,18 @@ export class KoboImportExistingRegistrationsDialogComponent {
     if (errors?.length) {
       // We need to add a ID because the table expects it, without <app-query-table> throws a typescript error
       const detailedErrorsWithIndexedIds: ValidationErrorTableRow[] =
-        errors.map((error: ValidationError, index: number) => ({
-          ...error,
-          id: index,
-        }));
+        errors.map((error: ValidationError, index: number) => {
+          // I'm sorry about this ugly 'fix'. Truly. If this code were a person, it would apologize too.
+          // check AB#43075 for more context as to why we did this...
+          if (error.column === 'programFspConfigurationName') {
+            error.column = 'fsp';
+            error.error = error.error.replace('FspConfigurationName', 'Fsp');
+          }
+          return {
+            ...error,
+            id: index,
+          };
+        });
 
       return detailedErrorsWithIndexedIds;
     }

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-import-existing-registrations-dialog/kobo-import-existing-registration-dialog.component.ts
@@ -143,9 +143,14 @@ export class KoboImportExistingRegistrationsDialogComponent {
           // I'm sorry about this ugly 'fix'. Truly. If this code were a person, it would apologize too.
           // check AB#43075 for more context as to why we did this...
           if (error.column === 'programFspConfigurationName') {
-            error.column = 'fsp';
-            error.error = error.error.replace('FspConfigurationName', 'Fsp');
+            return {
+              error: error.error.replace('FspConfigurationName', 'Fsp'),
+              referenceId: error.referenceId,
+              column: 'fsp',
+              id: index,
+            };
           }
+
           return {
             ...error,
             id: index,

--- a/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
+++ b/services/121-service/src/kobo/services/kobo-submission.service.spec.ts
@@ -433,7 +433,7 @@ describe('KoboSubmissionService', () => {
           {
             referenceId: successSubmissionUuid,
             column: 'programFspConfigurationName',
-            error: 'FspConfigurationName Invalid-FSP not found in program.',
+            error: 'Fsp Invalid-FSP not found in program.',
           },
         ],
       };

--- a/services/121-service/src/registration/validators/registrations-input-validator.ts
+++ b/services/121-service/src/registration/validators/registrations-input-validator.ts
@@ -347,9 +347,7 @@ export class RegistrationsInputValidator {
             rowErrors.push(errorObj);
           } else if (row[att.name] !== undefined) {
             validatedRegistrationInput.data[att.name] = row[att.name] as
-              | string
-              | number
-              | boolean;
+              string | number | boolean;
           }
         }),
       );
@@ -468,7 +466,7 @@ export class RegistrationsInputValidator {
         index: i,
         value: programFspName,
         column: AdditionalAttributes.programFspConfigurationName,
-        error: `FspConfigurationName ${programFspName} not found in program. Allowed values: ${programFspConfigurations
+        error: `Fsp ${programFspName} not found in program. Allowed values: ${programFspConfigurations
           .map((fspConfig) => fspConfig.name)
           .join(', ')}`,
       };

--- a/services/121-service/test/kobo/kobo-incoming-submission.test.ts
+++ b/services/121-service/test/kobo/kobo-incoming-submission.test.ts
@@ -180,7 +180,7 @@ describe('Process incoming Kobo submission via webhook', () => {
     // The mock service returns the error it receives from 121-service, so we can test that the 121-service returns the correct error
     expect(triggerSubmissionResponse.status).toBe(HttpStatus.BAD_REQUEST);
     expect(triggerSubmissionResponse.body[0].error).toMatchInlineSnapshot(
-      `"FspConfigurationName Invalid-FSP not found in program. Allowed values: Safaricom"`,
+      `"Fsp Invalid-FSP not found in program. Allowed values: Safaricom"`,
     );
 
     //  no registration was created


### PR DESCRIPTION
[AB#43075](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43075)

## Describe your changes
Replacing a string in the error table to stop users from being confused by this unknown column.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] I have edited tests for my changes
- [x] I have made sure that all automated checks pass before requesting a review

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8655.westeurope.3.azurestaticapps.net
