### PR TITLE
BE for registration pauze/decline warning modal

### DIFF
--- a/e2e/portal/tests/ChangeRegistrationStatus/ChangeRegistrationStatusOfRegistrationsIncludedInPendingPayments.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/ChangeRegistrationStatusOfRegistrationsIncludedInPendingPayments.ts
@@ -1,0 +1,18 @@
+import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
+import {
+  programIdPV,
+  registrationPV5,
+  registrationPV6,
+} from '@121-service/test/registrations/pagination/pagination-data';
+
+import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
+
+test.describe('xxx', () => {
+  test.beforeAll(async ({ onlyResetAndSeedRegistrations }) => {
+    await onlyResetAndSeedRegistrations({
+      seedScript: SeedScript.nlrcMultiple,
+      registrations: [registrationPV5, registrationPV6],
+      programId: programIdPV,
+    });
+  });
+});

--- a/interfaces/portal/src/app/domains/registration/registration.helper.ts
+++ b/interfaces/portal/src/app/domains/registration/registration.helper.ts
@@ -17,6 +17,19 @@ export const REGISTRATION_STATUS_LABELS: Record<
   [RegistrationStatusEnum.paused]: $localize`:@@registration-status-paused:Paused`,
 };
 
+export const REGISTRATION_UPDATE_DIALOG_SUBMIT_BUTTON_LABELS: Record<
+  RegistrationStatusEnum,
+  string
+> = {
+  [RegistrationStatusEnum.included]: $localize`:@@registration-status-dialog-submit-button-labels-include:Include`,
+  [RegistrationStatusEnum.new]: $localize`:@@registration-status-dialog-submit-button-labels-register:Register`,
+  [RegistrationStatusEnum.validated]: $localize`:@@registration-status-dialog-submit-button-labels-validate:Validate`,
+  [RegistrationStatusEnum.declined]: $localize`:@@registration-status-dialog-submit-button-labels-decline:Decline`,
+  [RegistrationStatusEnum.completed]: $localize`:@@registration-status-dialog-submit-button-labels-complete:Complete`,
+  [RegistrationStatusEnum.deleted]: $localize`:@@registration-status-dialog-submit-button-labels-delete:Delete`,
+  [RegistrationStatusEnum.paused]: $localize`:@@registration-status-dialog-submit-button-labels-pause:Pause`,
+};
+
 export const REGISTRATION_STATUS_ICON: Record<RegistrationStatusEnum, string> =
   {
     [RegistrationStatusEnum.new]: '',

--- a/interfaces/portal/src/app/domains/registration/registration.helper.ts
+++ b/interfaces/portal/src/app/domains/registration/registration.helper.ts
@@ -30,6 +30,13 @@ export const REGISTRATION_UPDATE_DIALOG_SUBMIT_BUTTON_LABELS: Record<
   [RegistrationStatusEnum.paused]: $localize`:@@registration-status-dialog-submit-button-labels-pause:Pause registrations`,
 };
 
+export const REGISTRATION_STATUS_PENDING_APPROVAL_EXPLANATION: Partial<
+  Record<RegistrationStatusEnum, string>
+> = {
+  [RegistrationStatusEnum.declined]: $localize`:@@change-status-declined-pending-approval-explanation:Declining a registration included in a payment will exclude them from that payment. To ensure they still receive their transfer, cancel this action and decline them after payment.`,
+  [RegistrationStatusEnum.paused]: $localize`:@@change-status-paused-pending-approval-explanation:Pausing a registration that’s included in a payment will result in a failed transfer. If you include them in the future, you’ll be able to retry the failed payment.`,
+};
+
 export const REGISTRATION_STATUS_ICON: Record<RegistrationStatusEnum, string> =
   {
     [RegistrationStatusEnum.new]: '',

--- a/interfaces/portal/src/app/domains/registration/registration.helper.ts
+++ b/interfaces/portal/src/app/domains/registration/registration.helper.ts
@@ -50,6 +50,19 @@ export const REGISTRATION_STATUS_VERB: Record<RegistrationStatusEnum, string> =
     [RegistrationStatusEnum.deleted]: $localize`Delete`,
   };
 
+export const REGISTRATION_STATUS_GERUND: Record<
+  RegistrationStatusEnum,
+  string
+> = {
+  [RegistrationStatusEnum.new]: '',
+  [RegistrationStatusEnum.completed]: '',
+  [RegistrationStatusEnum.validated]: $localize`Validating`,
+  [RegistrationStatusEnum.included]: $localize`Including`,
+  [RegistrationStatusEnum.paused]: $localize`Pausing`,
+  [RegistrationStatusEnum.declined]: $localize`Declining`,
+  [RegistrationStatusEnum.deleted]: $localize`Deleting`,
+};
+
 export const DUPLICATE_STATUS_LABELS: Record<DuplicateStatus, string> = {
   [DuplicateStatus.duplicate]: $localize`:@@duplicate-status-duplicate:Duplicate`,
   [DuplicateStatus.unique]: $localize`:@@duplicate-status-unique:Unique`,

--- a/interfaces/portal/src/app/domains/registration/registration.helper.ts
+++ b/interfaces/portal/src/app/domains/registration/registration.helper.ts
@@ -18,16 +18,14 @@ export const REGISTRATION_STATUS_LABELS: Record<
 };
 
 export const REGISTRATION_UPDATE_DIALOG_SUBMIT_BUTTON_LABELS: Record<
-  RegistrationStatusEnum,
+  Exclude<RegistrationStatusEnum, 'completed' | 'new'>,
   string
 > = {
-  [RegistrationStatusEnum.included]: $localize`:@@registration-status-dialog-submit-button-labels-include:Include`,
-  [RegistrationStatusEnum.new]: $localize`:@@registration-status-dialog-submit-button-labels-register:Register`,
-  [RegistrationStatusEnum.validated]: $localize`:@@registration-status-dialog-submit-button-labels-validate:Validate`,
-  [RegistrationStatusEnum.declined]: $localize`:@@registration-status-dialog-submit-button-labels-decline:Decline`,
-  [RegistrationStatusEnum.completed]: $localize`:@@registration-status-dialog-submit-button-labels-complete:Complete`,
-  [RegistrationStatusEnum.deleted]: $localize`:@@registration-status-dialog-submit-button-labels-delete:Delete`,
-  [RegistrationStatusEnum.paused]: $localize`:@@registration-status-dialog-submit-button-labels-pause:Pause`,
+  [RegistrationStatusEnum.included]: $localize`:@@registration-status-dialog-submit-button-labels-include:Include registrations`,
+  [RegistrationStatusEnum.declined]: $localize`:@@registration-status-dialog-submit-button-labels-decline:Decline registrations`,
+  [RegistrationStatusEnum.validated]: $localize`:@@registration-status-dialog-submit-button-labels-validate:Validate registrations`,
+  [RegistrationStatusEnum.deleted]: $localize`:@@registration-status-dialog-submit-button-labels-delete:Delete registrations`,
+  [RegistrationStatusEnum.paused]: $localize`:@@registration-status-dialog-submit-button-labels-pause:Pause registrations`,
 };
 
 export const REGISTRATION_STATUS_ICON: Record<RegistrationStatusEnum, string> =

--- a/interfaces/portal/src/app/domains/registration/registration.helper.ts
+++ b/interfaces/portal/src/app/domains/registration/registration.helper.ts
@@ -18,9 +18,11 @@ export const REGISTRATION_STATUS_LABELS: Record<
 };
 
 export const REGISTRATION_UPDATE_DIALOG_SUBMIT_BUTTON_LABELS: Record<
-  Exclude<RegistrationStatusEnum, 'completed' | 'new'>,
+  RegistrationStatusEnum,
   string
 > = {
+  [RegistrationStatusEnum.new]: '',
+  [RegistrationStatusEnum.completed]: '',
   [RegistrationStatusEnum.included]: $localize`:@@registration-status-dialog-submit-button-labels-include:Include registrations`,
   [RegistrationStatusEnum.declined]: $localize`:@@registration-status-dialog-submit-button-labels-decline:Decline registrations`,
   [RegistrationStatusEnum.validated]: $localize`:@@registration-status-dialog-submit-button-labels-validate:Validate registrations`,

--- a/interfaces/portal/src/app/domains/registration/registration.helper.ts
+++ b/interfaces/portal/src/app/domains/registration/registration.helper.ts
@@ -17,17 +17,58 @@ export const REGISTRATION_STATUS_LABELS: Record<
   [RegistrationStatusEnum.paused]: $localize`:@@registration-status-paused:Paused`,
 };
 
-export const REGISTRATION_UPDATE_DIALOG_SUBMIT_BUTTON_LABELS: Record<
-  RegistrationStatusEnum,
-  string
-> = {
-  [RegistrationStatusEnum.new]: '',
-  [RegistrationStatusEnum.completed]: '',
-  [RegistrationStatusEnum.included]: $localize`:@@registration-status-dialog-submit-button-labels-include:Include registrations`,
-  [RegistrationStatusEnum.declined]: $localize`:@@registration-status-dialog-submit-button-labels-decline:Decline registrations`,
-  [RegistrationStatusEnum.validated]: $localize`:@@registration-status-dialog-submit-button-labels-validate:Validate registrations`,
-  [RegistrationStatusEnum.deleted]: $localize`:@@registration-status-dialog-submit-button-labels-delete:Delete registrations`,
-  [RegistrationStatusEnum.paused]: $localize`:@@registration-status-dialog-submit-button-labels-pause:Pause registrations`,
+export const getRegistrationUpdateDialogSubmitLabel = ({
+  status,
+  count,
+}: {
+  status: RegistrationStatusEnum | undefined;
+  count: number | undefined;
+}): string => {
+  switch (status) {
+    case RegistrationStatusEnum.included:
+      return count === 1
+        ? $localize`:@@registration-status-dialog-submit-button-labels-include:Include registration`
+        : $localize`:@@registration-status-dialog-submit-button-labels-include:Include registrations`;
+    case RegistrationStatusEnum.declined:
+      return count === 1
+        ? $localize`:@@registration-status-dialog-submit-button-labels-decline:Decline registration`
+        : $localize`:@@registration-status-dialog-submit-button-labels-decline:Decline registrations`;
+    case RegistrationStatusEnum.validated:
+      return count === 1
+        ? $localize`:@@registration-status-dialog-submit-button-labels-validate:Validate registration`
+        : $localize`:@@registration-status-dialog-submit-button-labels-validate:Validate registrations`;
+    case RegistrationStatusEnum.deleted:
+      return count === 1
+        ? $localize`:@@registration-status-dialog-submit-button-labels-delete:Delete registration`
+        : $localize`:@@registration-status-dialog-submit-button-labels-delete:Delete registrations`;
+    case RegistrationStatusEnum.paused:
+      return count === 1
+        ? $localize`:@@registration-status-dialog-submit-button-labels-pause:Pause registration`
+        : $localize`:@@registration-status-dialog-submit-button-labels-pause:Pause registrations`;
+    default:
+      return $localize`:@@generic-approve:Approve`;
+  }
+};
+
+export const getChangeStatusWarningMessage = ({
+  status,
+}: {
+  status: RegistrationStatusEnum | undefined;
+}): string => {
+  switch (status) {
+    case RegistrationStatusEnum.validated:
+      return $localize`:@@change-status-validate-warning:The action "Validate" can only be applied to registrations with the "New" status.`;
+    case RegistrationStatusEnum.included:
+      return $localize`:@@change-status-include-warning:The action "Include" can only be applied to registrations that do not have status "Included" and whose “Payments left” is larger than 0.`;
+    case RegistrationStatusEnum.paused:
+      return $localize`:@@change-status-pause-warning:The action "Pause" can only be applied to registrations with the "Included" status.`;
+    case RegistrationStatusEnum.declined:
+      return $localize`:@@change-status-decline-warning:The action "Decline" can not be applied to registrations with the "Declined" or "Completed" status.`;
+    case RegistrationStatusEnum.deleted:
+      return $localize`:@@change-status-delete-warning:The action "Delete" can not be applied to registrations with the "Completed" status.`;
+    default:
+      return $localize`:@@change-status-default-warning:This action can not be applied to registrations you have selected.`;
+  }
 };
 
 export const REGISTRATION_STATUS_PENDING_APPROVAL_EXPLANATION: Partial<

--- a/interfaces/portal/src/app/domains/registration/registration.helper.ts
+++ b/interfaces/portal/src/app/domains/registration/registration.helper.ts
@@ -50,19 +50,6 @@ export const REGISTRATION_STATUS_VERB: Record<RegistrationStatusEnum, string> =
     [RegistrationStatusEnum.deleted]: $localize`Delete`,
   };
 
-export const REGISTRATION_STATUS_GERUND: Record<
-  RegistrationStatusEnum,
-  string
-> = {
-  [RegistrationStatusEnum.new]: '',
-  [RegistrationStatusEnum.completed]: '',
-  [RegistrationStatusEnum.validated]: $localize`Validating`,
-  [RegistrationStatusEnum.included]: $localize`Including`,
-  [RegistrationStatusEnum.paused]: $localize`Pausing`,
-  [RegistrationStatusEnum.declined]: $localize`Declining`,
-  [RegistrationStatusEnum.deleted]: $localize`Deleting`,
-};
-
 export const DUPLICATE_STATUS_LABELS: Record<DuplicateStatus, string> = {
   [DuplicateStatus.duplicate]: $localize`:@@duplicate-status-duplicate:Duplicate`,
   [DuplicateStatus.unique]: $localize`:@@duplicate-status-unique:Unique`,

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.html
@@ -58,5 +58,6 @@
   <app-change-status-submit-buttons
     [isMutating]="isMutating()"
     (cancelClick)="cancelClick()"
+    [status]="status()"
   />
 }

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.html
@@ -58,6 +58,6 @@
   <app-change-status-submit-buttons
     [isMutating]="isMutating()"
     (cancelClick)="cancelClick()"
-    [status]="status()"
+    [submitButtonText]="submitButtonText()"
   />
 }

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.ts
@@ -15,8 +15,6 @@ import {
 
 import { ButtonModule } from 'primeng/button';
 
-import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
-
 import { Registration } from '~/domains/registration/registration.model';
 import { ChangeStatusSubmitButtonsComponent } from '~/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component';
 import { CustomMessageControlComponent } from '~/pages/program-registrations/components/custom-message-control/custom-message-control.component';
@@ -44,7 +42,7 @@ export class ChangeStatusContentsWithCustomMessageComponent implements OnInit {
   readonly isMutating = input(false);
   readonly cancelChangeStatus = output();
   readonly customMessageUpdated = output<string>();
-  readonly status = input<RegistrationStatusEnum | undefined>();
+  readonly submitButtonText = input<string | undefined>();
 
   formGroup = new FormGroup({
     customMessage: new FormControl<string | undefined>(

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.ts
@@ -15,6 +15,8 @@ import {
 
 import { ButtonModule } from 'primeng/button';
 
+import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
+
 import { Registration } from '~/domains/registration/registration.model';
 import { ChangeStatusSubmitButtonsComponent } from '~/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component';
 import { CustomMessageControlComponent } from '~/pages/program-registrations/components/custom-message-control/custom-message-control.component';
@@ -42,6 +44,7 @@ export class ChangeStatusContentsWithCustomMessageComponent implements OnInit {
   readonly isMutating = input(false);
   readonly cancelChangeStatus = output();
   readonly customMessageUpdated = output<string>();
+  readonly status = input<RegistrationStatusEnum | undefined>();
 
   formGroup = new FormGroup({
     customMessage: new FormControl<string | undefined>(

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-templated-message/change-status-contents-with-templated-message.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-templated-message/change-status-contents-with-templated-message.component.html
@@ -12,7 +12,7 @@
   ></app-custom-message-preview>
 }
 <app-change-status-submit-buttons
-  [status]="status()"
+  [submitButtonText]="submitButtonText()"
   [isMutating]="isMutating()"
   (cancelClick)="cancelClick()"
 />

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-templated-message/change-status-contents-with-templated-message.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-templated-message/change-status-contents-with-templated-message.component.html
@@ -12,6 +12,7 @@
   ></app-custom-message-preview>
 }
 <app-change-status-submit-buttons
+  [status]="status()"
   [isMutating]="isMutating()"
   (cancelClick)="cancelClick()"
 />

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-templated-message/change-status-contents-with-templated-message.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-templated-message/change-status-contents-with-templated-message.component.ts
@@ -7,8 +7,6 @@ import {
 
 import { ButtonModule } from 'primeng/button';
 
-import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
-
 import { Registration } from '~/domains/registration/registration.model';
 import { ChangeStatusSubmitButtonsComponent } from '~/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component';
 import { CustomMessagePreviewComponent } from '~/pages/program-registrations/components/custom-message-preview/custom-message-preview.component';
@@ -32,7 +30,7 @@ export class ChangeStatusContentsWithTemplatedMessageComponent {
   readonly enableSendMessage = input.required<boolean>();
   readonly isMutating = input(false);
   readonly cancelChangeStatus = output();
-  readonly status = input<RegistrationStatusEnum | undefined>();
+  readonly submitButtonText = input<string | undefined>();
 
   cancelClick() {
     this.cancelChangeStatus.emit();

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-templated-message/change-status-contents-with-templated-message.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-templated-message/change-status-contents-with-templated-message.component.ts
@@ -7,6 +7,8 @@ import {
 
 import { ButtonModule } from 'primeng/button';
 
+import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
+
 import { Registration } from '~/domains/registration/registration.model';
 import { ChangeStatusSubmitButtonsComponent } from '~/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component';
 import { CustomMessagePreviewComponent } from '~/pages/program-registrations/components/custom-message-preview/custom-message-preview.component';
@@ -30,6 +32,7 @@ export class ChangeStatusContentsWithTemplatedMessageComponent {
   readonly enableSendMessage = input.required<boolean>();
   readonly isMutating = input(false);
   readonly cancelChangeStatus = output();
+  readonly status = input<RegistrationStatusEnum | undefined>();
 
   cancelClick() {
     this.cancelChangeStatus.emit();

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-without-message/change-status-contents-without-message.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-without-message/change-status-contents-without-message.component.html
@@ -20,6 +20,6 @@
     [isMutating]="isMutating()"
     (cancelClick)="cancelClick()"
     (approveClick)="validateFormGroupOrPreventSubmit($event)"
-    [status]="status()"
+    [submitButtonText]="submitButtonText()"
   />
 </div>

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-without-message/change-status-contents-without-message.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-without-message/change-status-contents-without-message.component.html
@@ -20,5 +20,6 @@
     [isMutating]="isMutating()"
     (cancelClick)="cancelClick()"
     (approveClick)="validateFormGroupOrPreventSubmit($event)"
+    [status]="status()"
   />
 </div>

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-without-message/change-status-contents-without-message.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-without-message/change-status-contents-without-message.component.ts
@@ -15,6 +15,8 @@ import {
 import { ButtonModule } from 'primeng/button';
 import { CheckboxModule } from 'primeng/checkbox';
 
+import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
+
 import { FormErrorComponent } from '~/components/form-error/form-error.component';
 import { ChangeStatusSubmitButtonsComponent } from '~/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component';
 import { generateFieldErrors } from '~/utils/form-validation';
@@ -37,6 +39,7 @@ export class ChangeStatusContentsWithoutMessageComponent {
   readonly isMutating = input(false);
   readonly cancelChangeStatus = output();
   readonly confirmChangeStatus = output();
+  readonly status = input<RegistrationStatusEnum | undefined>();
 
   formGroup = new FormGroup({
     confirmAction: new FormControl(false, {

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-without-message/change-status-contents-without-message.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-without-message/change-status-contents-without-message.component.ts
@@ -40,6 +40,7 @@ export class ChangeStatusContentsWithoutMessageComponent {
   readonly cancelChangeStatus = output();
   readonly confirmChangeStatus = output();
   readonly status = input<RegistrationStatusEnum | undefined>();
+  readonly submitButtonText = input<string | undefined>();
 
   formGroup = new FormGroup({
     confirmAction: new FormControl(false, {

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
@@ -71,6 +71,7 @@
           (confirmChangeStatus)="onFormSubmit()"
           [showAreYouSureCheckbox]="status() === RegistrationStatusEnum.deleted"
           [isMutating]="changeStatusMutation.isPending()"
+          [status]="status()"
         />
       } @else {
         @if (messageTemplateKey.isLoading()) {
@@ -100,6 +101,7 @@
               [previewRegistration]="actionData()?.previewItem"
               [isMutating]="changeStatusMutation.isPending()"
               (cancelChangeStatus)="onChangeStatusCancel()"
+              [status]="status()"
             />
           } @else {
             <app-change-status-contents-with-custom-message
@@ -109,6 +111,7 @@
               [isMutating]="changeStatusMutation.isPending()"
               (cancelChangeStatus)="onChangeStatusCancel()"
               (customMessageUpdated)="customMessage.set($event)"
+              [status]="status()"
             />
           }
         }

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
@@ -135,63 +135,28 @@
 >
   @let dryRunData = changeStatusMutation.data();
 
-  @if (dryRunData && dryRunData.nonApplicableCount > 0) {
-    <b i18n
-      >There are
-      {{ dryRunData.nonApplicableCount }}
-      registration(s) that don't support this action</b
-    >
-    <p class="pbs-2">
-      {{ changeStatusWarningMessage() }}
-    </p>
-    <p
-      class="pbs-2"
-      i18n
-    >
-      Registrations that do not support this action will remain in their current
-      status.
-    </p>
-  }
-
   @if (dryRunData && (dryRunData.pendingApprovalCount ?? 0) > 0) {
-    <strong>
-      <p i18n>
-        You're about to <strong>{{ statusVerb() | lowercase }}</strong>
+    <p>
+      <strong i18n>
+        You're about to {{ statusVerb() | lowercase }}
         {{ dryRunData.pendingApprovalCount }} registration(s) that are included
         in a payment that's waiting for approval.
-      </p>
-    </strong>
-
-    @if (status() === RegistrationStatusEnum.declined) {
-      <p i18n>
-        Declining a registration included in a payment will exclude them from
-        that payment. To ensure they still receive their transfer, cancel this
-        action and decline them after payment.
-      </p>
-    }
-
-    @if (status() === RegistrationStatusEnum.paused) {
-      <p i18n>
-        Pausing a registration that’s included in a payment will result in a
-        failed transfer, if you include them in the future you’d be able to
-        retry failed payment.
-      </p>
-    }
-
-    <p i18n>
-      Would you like to "{{ statusVerb() | lowercase }}" these
-      {{ dryRunData.pendingApprovalCount }} registration(s)?
+      </strong>
     </p>
-  } @else {
-    <p
-      i18n
-      class="pbs-2"
-    >
-      Would you like to proceed with
-      {{ dryRunData?.applicableCount }}
-      registration(s)?
-    </p>
+
+    @if (pendingApprovalExplanation(); as explanation) {
+      <p>{{ explanation }}</p>
+    }
   }
+
+  <p
+    i18n
+    class="pbs-2"
+  >
+    Would you like to proceed with
+    {{ dryRunData?.applicableCount }}
+    registration(s)?
+  </p>
 </app-form-dialog>
 
 <p-dialog

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
@@ -116,6 +116,7 @@
     </div>
   </form>
 </p-dialog>
+
 <app-form-dialog
   #dryRunWarningDialog
   header="Warning"
@@ -129,27 +130,44 @@
     dryRun: false,
   }"
 >
-  <b i18n
-    >There are
-    {{ changeStatusMutation.data()?.nonApplicableCount }}
-    registration(s) that don't support this action</b
-  >
-  <p class="pbs-2">
-    {{ changeStatusWarningMessage() }}
-  </p>
-  <p
-    class="pbs-2"
-    i18n
-  >
-    Registrations that do not support this action will remain in their current
-    status.
-  </p>
+  @let dryRunData = changeStatusMutation.data();
+  @if (dryRunData && dryRunData.nonApplicableCount > 0) {
+    <b i18n
+      >There are
+      {{ dryRunData.nonApplicableCount }}
+      registration(s) that don't support this action</b
+    >
+    <p class="pbs-2">
+      {{ changeStatusWarningMessage() }}
+    </p>
+    <p
+      class="pbs-2"
+      i18n
+    >
+      Registrations that do not support this action will remain in their current
+      status.
+    </p>
+  }
+  @if (dryRunData && (dryRunData.pendingApprovalCount ?? 0) > 0) {
+    <b i18n
+      >There are
+      {{ dryRunData.pendingApprovalCount }}
+      registration(s) with a payment pending approval</b
+    >
+    <p
+      class="pbs-2"
+      i18n
+    >
+      Their status will still be changed to "{{ statusLabel() | lowercase }}" if
+      you proceed.
+    </p>
+  }
   <p
     i18n
     class="pbs-2"
   >
     Would you like to proceed with
-    {{ changeStatusMutation.data()?.applicableCount }}
+    {{ dryRunData?.applicableCount }}
     registration(s)?
   </p>
 </app-form-dialog>

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
@@ -3,6 +3,7 @@
   [closeOnEscape]="false"
   styleClass="md:min-inline-184"
   [(visible)]="dialogVisible"
+  data-testid="change-status-dialog"
   [modal]="true"
 >
   <ng-template pTemplate="header">
@@ -121,6 +122,7 @@
 </p-dialog>
 
 <app-form-dialog
+  data-testid="change-status-dry-run-warning-dialog"
   #dryRunWarningDialog
   header="Warning"
   i18n-header="@@generic-warning"

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
@@ -154,31 +154,44 @@
   }
 
   @if (dryRunData && (dryRunData.pendingApprovalCount ?? 0) > 0) {
-    <p i18n>
-      You're about to "{{ statusVerb() }}"
-      {{ dryRunData.pendingApprovalCount }} registration(s) that are included in
-      a payment that's waiting for approval.
-    </p>
-    <p i18n>
-      {{ statusGerund() }} a registration that's included in a payment will
-      result in a failed transfer, if you include them in the future you'd be
-      able to retry failed payment.
-    </p>
+    <strong>
+      <p i18n>
+        You're about to <strong>{{ statusVerb() | lowercase }}</strong>
+        {{ dryRunData.pendingApprovalCount }} registration(s) that are included
+        in a payment that's waiting for approval.
+      </p>
+    </strong>
+
+    @if (status() === RegistrationStatusEnum.declined) {
+      <p i18n>
+        Declining a registration included in a payment will exclude them from
+        that payment. To ensure they still receive their transfer, cancel this
+        action and decline them after payment.
+      </p>
+    }
+
+    @if (status() === RegistrationStatusEnum.paused) {
+      <p i18n>
+        Pausing a registration that’s included in a payment will result in a
+        failed transfer, if you include them in the future you’d be able to
+        retry failed payment.
+      </p>
+    }
 
     <p i18n>
-      Would you like to "{{ statusVerb() }}" these
+      Would you like to "{{ statusVerb() | lowercase }}" these
       {{ dryRunData.pendingApprovalCount }} registration(s)?
     </p>
+  } @else {
+    <p
+      i18n
+      class="pbs-2"
+    >
+      Would you like to proceed with
+      {{ dryRunData?.applicableCount }}
+      registration(s)?
+    </p>
   }
-
-  <p
-    i18n
-    class="pbs-2"
-  >
-    Would you like to proceed with
-    {{ dryRunData?.applicableCount }}
-    registration(s)?
-  </p>
 </app-form-dialog>
 
 <p-dialog

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
@@ -134,6 +134,7 @@
   }"
 >
   @let dryRunData = changeStatusMutation.data();
+
   @if (dryRunData && dryRunData.nonApplicableCount > 0) {
     <b i18n
       >There are
@@ -151,20 +152,25 @@
       status.
     </p>
   }
+
   @if (dryRunData && (dryRunData.pendingApprovalCount ?? 0) > 0) {
-    <b i18n
-      >There are
-      {{ dryRunData.pendingApprovalCount }}
-      registration(s) with a payment pending approval</b
-    >
-    <p
-      class="pbs-2"
-      i18n
-    >
-      Their status will still be changed to "{{ statusLabel() | lowercase }}" if
-      you proceed.
+    <p i18n>
+      You're about to "{{ statusVerb() }}"
+      {{ dryRunData.pendingApprovalCount }} registration(s) that are included in
+      a payment that's waiting for approval.
+    </p>
+    <p i18n>
+      {{ statusGerund() }} a registration that's included in a payment will
+      result in a failed transfer, if you include them in the future you'd be
+      able to retry failed payment.
+    </p>
+
+    <p i18n>
+      Would you like to "{{ statusVerb() }}" these
+      {{ dryRunData.pendingApprovalCount }} registration(s)?
     </p>
   }
+
   <p
     i18n
     class="pbs-2"

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
@@ -71,7 +71,7 @@
           (confirmChangeStatus)="onFormSubmit()"
           [showAreYouSureCheckbox]="status() === RegistrationStatusEnum.deleted"
           [isMutating]="changeStatusMutation.isPending()"
-          [status]="status()"
+          [submitButtonText]="submitButtonText()"
         />
       } @else {
         @if (messageTemplateKey.isLoading()) {
@@ -101,7 +101,7 @@
               [previewRegistration]="actionData()?.previewItem"
               [isMutating]="changeStatusMutation.isPending()"
               (cancelChangeStatus)="onChangeStatusCancel()"
-              [status]="status()"
+              [submitButtonText]="submitButtonText()"
             />
           } @else {
             <app-change-status-contents-with-custom-message
@@ -111,7 +111,7 @@
               [isMutating]="changeStatusMutation.isPending()"
               (cancelChangeStatus)="onChangeStatusCancel()"
               (customMessageUpdated)="customMessage.set($event)"
-              [status]="status()"
+              [submitButtonText]="submitButtonText()"
             />
           }
         }

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
@@ -30,6 +30,7 @@ import { RegistrationApiService } from '~/domains/registration/registration.api.
 import {
   REGISTRATION_STATUS_ICON,
   REGISTRATION_STATUS_LABELS,
+  REGISTRATION_STATUS_PENDING_APPROVAL_EXPLANATION,
   REGISTRATION_STATUS_VERB,
 } from '~/domains/registration/registration.helper';
 import { Registration } from '~/domains/registration/registration.model';
@@ -118,6 +119,14 @@ export class ChangeStatusDialogComponent implements IActionDataHandler<Registrat
       return '';
     }
     return REGISTRATION_STATUS_VERB[status];
+  });
+
+  readonly pendingApprovalExplanation = computed(() => {
+    const status = this.status();
+    if (!status) {
+      return undefined;
+    }
+    return REGISTRATION_STATUS_PENDING_APPROVAL_EXPLANATION[status];
   });
 
   readonly changeStatusWarningMessage = computed(() => {

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
@@ -28,6 +28,7 @@ import { FormDialogComponent } from '~/components/form-dialog/form-dialog.compon
 import { FormErrorComponent } from '~/components/form-error/form-error.component';
 import { RegistrationApiService } from '~/domains/registration/registration.api.service';
 import {
+  REGISTRATION_STATUS_GERUND,
   REGISTRATION_STATUS_ICON,
   REGISTRATION_STATUS_LABELS,
   REGISTRATION_STATUS_VERB,
@@ -118,6 +119,14 @@ export class ChangeStatusDialogComponent implements IActionDataHandler<Registrat
       return '';
     }
     return REGISTRATION_STATUS_VERB[status];
+  });
+
+  readonly statusGerund = computed(() => {
+    const status = this.status();
+    if (!status) {
+      return '';
+    }
+    return REGISTRATION_STATUS_GERUND[status];
   });
 
   readonly changeStatusWarningMessage = computed(() => {

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
@@ -28,7 +28,6 @@ import { FormDialogComponent } from '~/components/form-dialog/form-dialog.compon
 import { FormErrorComponent } from '~/components/form-error/form-error.component';
 import { RegistrationApiService } from '~/domains/registration/registration.api.service';
 import {
-  REGISTRATION_STATUS_GERUND,
   REGISTRATION_STATUS_ICON,
   REGISTRATION_STATUS_LABELS,
   REGISTRATION_STATUS_VERB,
@@ -119,14 +118,6 @@ export class ChangeStatusDialogComponent implements IActionDataHandler<Registrat
       return '';
     }
     return REGISTRATION_STATUS_VERB[status];
-  });
-
-  readonly statusGerund = computed(() => {
-    const status = this.status();
-    if (!status) {
-      return '';
-    }
-    return REGISTRATION_STATUS_GERUND[status];
   });
 
   readonly changeStatusWarningMessage = computed(() => {

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
@@ -103,6 +103,7 @@ export class ChangeStatusDialogComponent implements IActionDataHandler<Registrat
     }
     return REGISTRATION_STATUS_ICON[status];
   });
+
   readonly statusLabel = computed(() => {
     const status = this.status();
     if (!status) {
@@ -110,6 +111,7 @@ export class ChangeStatusDialogComponent implements IActionDataHandler<Registrat
     }
     return REGISTRATION_STATUS_LABELS[status];
   });
+
   readonly statusVerb = computed(() => {
     const status = this.status();
     if (!status) {
@@ -117,6 +119,7 @@ export class ChangeStatusDialogComponent implements IActionDataHandler<Registrat
     }
     return REGISTRATION_STATUS_VERB[status];
   });
+
   readonly changeStatusWarningMessage = computed(() => {
     switch (this.status()) {
       case RegistrationStatusEnum.validated:
@@ -133,6 +136,7 @@ export class ChangeStatusDialogComponent implements IActionDataHandler<Registrat
         return $localize`:@@change-status-default-warning:This action can not be applied to registrations you have selected.`;
     }
   });
+
   readonly canSendMessage = computed(() => {
     const status = this.status();
     if (!status) {

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
@@ -213,8 +213,12 @@ export class ChangeStatusDialogComponent implements IActionDataHandler<Registrat
       invalidateCacheAgainAfterDelay: 500,
     },
     onSuccess: (data, variables) => {
-      if (data.nonApplicableCount === 0) {
-        // case #1: the change can be applied to all registrations
+      // Registrations with a pending-approval payment also need explicit confirmation, not just non-applicable ones
+      const needsConfirmation =
+        data.nonApplicableCount > 0 || (data.pendingApprovalCount ?? 0) > 0;
+
+      if (!needsConfirmation) {
+        // case #1: the change can be applied to all registrations, without any pending-approval payments
         if (variables.dryRun) {
           this.changeStatusMutation.mutate({ dryRun: false });
           return;
@@ -237,7 +241,7 @@ export class ChangeStatusDialogComponent implements IActionDataHandler<Registrat
         return;
       }
 
-      // case #3: the change can be applied to only some of the registrations
+      // case #3: some registrations are non-applicable and/or have a payment pending approval
       this.dialogVisible.set(false);
       this.dryRunWarningDialog().show({
         resetMutation: false,

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
@@ -28,6 +28,8 @@ import { FormDialogComponent } from '~/components/form-dialog/form-dialog.compon
 import { FormErrorComponent } from '~/components/form-error/form-error.component';
 import { RegistrationApiService } from '~/domains/registration/registration.api.service';
 import {
+  getChangeStatusWarningMessage,
+  getRegistrationUpdateDialogSubmitLabel,
   REGISTRATION_STATUS_ICON,
   REGISTRATION_STATUS_LABELS,
   REGISTRATION_STATUS_PENDING_APPROVAL_EXPLANATION,
@@ -129,21 +131,15 @@ export class ChangeStatusDialogComponent implements IActionDataHandler<Registrat
     return REGISTRATION_STATUS_PENDING_APPROVAL_EXPLANATION[status];
   });
 
+  readonly submitButtonText = computed(() => {
+    return getRegistrationUpdateDialogSubmitLabel({
+      status: this.status(),
+      count: this.changeStatusMutation.data()?.applicableCount,
+    });
+  });
+
   readonly changeStatusWarningMessage = computed(() => {
-    switch (this.status()) {
-      case RegistrationStatusEnum.validated:
-        return $localize`:@@change-status-validate-warning:The action "Validate" can only be applied to registrations with the "New" status.`;
-      case RegistrationStatusEnum.included:
-        return $localize`:@@change-status-include-warning:The action "Include" can only be applied to registrations that do not have status "Included" and whose “Payments left” is larger than 0.`;
-      case RegistrationStatusEnum.paused:
-        return $localize`:@@change-status-pause-warning:The action "Pause" can only be applied to registrations with the "Included" status.`;
-      case RegistrationStatusEnum.declined:
-        return $localize`:@@change-status-decline-warning:The action "Decline" can not be applied to registrations with the "Declined" or "Completed" status.`;
-      case RegistrationStatusEnum.deleted:
-        return $localize`:@@change-status-delete-warning:The action "Delete" can not be applied to registrations with the "Completed" status.`;
-      default:
-        return $localize`:@@change-status-default-warning:This action can not be applied to registrations you have selected.`;
-    }
+    return getChangeStatusWarningMessage({ status: this.status() });
   });
 
   readonly canSendMessage = computed(() => {

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.html
@@ -9,7 +9,7 @@
     (click)="cancelClick.emit()"
   />
   <p-button
-    [label]="buttonText()"
+    [label]="submitButtonText()"
     rounded
     [disabled]="isMutating()"
     [loading]="isMutating()"

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.html
@@ -9,8 +9,7 @@
     (click)="cancelClick.emit()"
   />
   <p-button
-    label="Approve"
-    i18n-label="@@generic-approve"
+    [label]="buttonText()"
     rounded
     [disabled]="isMutating()"
     [loading]="isMutating()"

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.ts
@@ -1,11 +1,16 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   input,
   output,
 } from '@angular/core';
 
 import { ButtonModule } from 'primeng/button';
+
+import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
+
+import { REGISTRATION_UPDATE_DIALOG_SUBMIT_BUTTON_LABELS } from '~/domains/registration/registration.helper';
 
 @Component({
   selector: 'app-change-status-submit-buttons',
@@ -18,4 +23,14 @@ export class ChangeStatusSubmitButtonsComponent {
   readonly isMutating = input(false);
   readonly cancelClick = output();
   readonly approveClick = output<MouseEvent>();
+  readonly status = input<RegistrationStatusEnum | undefined>();
+
+  readonly buttonText = computed(() => {
+    const status = this.status();
+    console.log('ChangeStatusSubmitButtonsComponent: status =', status);
+    if (!status) {
+      return '';
+    }
+    return REGISTRATION_UPDATE_DIALOG_SUBMIT_BUTTON_LABELS[status];
+  });
 }

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.ts
@@ -28,7 +28,7 @@ export class ChangeStatusSubmitButtonsComponent {
   readonly buttonText = computed(() => {
     const status = this.status();
     if (!status) {
-      return '';
+      return $localize`:@@generic-approve:Approve`;
     }
     return REGISTRATION_UPDATE_DIALOG_SUBMIT_BUTTON_LABELS[status];
   });

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.ts
@@ -27,7 +27,6 @@ export class ChangeStatusSubmitButtonsComponent {
 
   readonly buttonText = computed(() => {
     const status = this.status();
-    console.log('ChangeStatusSubmitButtonsComponent: status =', status);
     if (!status) {
       return '';
     }

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  computed,
   input,
   output,
 } from '@angular/core';
@@ -9,8 +8,6 @@ import {
 import { ButtonModule } from 'primeng/button';
 
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
-
-import { REGISTRATION_UPDATE_DIALOG_SUBMIT_BUTTON_LABELS } from '~/domains/registration/registration.helper';
 
 @Component({
   selector: 'app-change-status-submit-buttons',
@@ -24,12 +21,5 @@ export class ChangeStatusSubmitButtonsComponent {
   readonly cancelClick = output();
   readonly approveClick = output<MouseEvent>();
   readonly status = input<RegistrationStatusEnum | undefined>();
-
-  readonly buttonText = computed(() => {
-    const status = this.status();
-    if (!status) {
-      return $localize`:@@generic-approve:Approve`;
-    }
-    return REGISTRATION_UPDATE_DIALOG_SUBMIT_BUTTON_LABELS[status];
-  });
+  readonly submitButtonText = input<string | undefined>();
 }

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -2673,26 +2673,20 @@
       <trans-unit id="registration-status-deleted" datatype="html">
         <source>Deleted</source>
       </trans-unit>
-      <trans-unit id="registration-status-dialog-submit-button-labels-complete" datatype="html">
-        <source>Complete</source>
-      </trans-unit>
       <trans-unit id="registration-status-dialog-submit-button-labels-decline" datatype="html">
-        <source>Decline</source>
+        <source>Decline registrations</source>
       </trans-unit>
       <trans-unit id="registration-status-dialog-submit-button-labels-delete" datatype="html">
-        <source>Delete</source>
+        <source>Delete registrations</source>
       </trans-unit>
       <trans-unit id="registration-status-dialog-submit-button-labels-include" datatype="html">
-        <source>Include</source>
+        <source>Include registrations</source>
       </trans-unit>
       <trans-unit id="registration-status-dialog-submit-button-labels-pause" datatype="html">
-        <source>Pause</source>
-      </trans-unit>
-      <trans-unit id="registration-status-dialog-submit-button-labels-register" datatype="html">
-        <source>Register</source>
+        <source>Pause registrations</source>
       </trans-unit>
       <trans-unit id="registration-status-dialog-submit-button-labels-validate" datatype="html">
-        <source>Validate</source>
+        <source>Validate registrations</source>
       </trans-unit>
       <trans-unit id="registration-status-included" datatype="html">
         <source>Included</source>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -2673,6 +2673,27 @@
       <trans-unit id="registration-status-deleted" datatype="html">
         <source>Deleted</source>
       </trans-unit>
+      <trans-unit id="registration-status-dialog-submit-button-labels-complete" datatype="html">
+        <source>Complete</source>
+      </trans-unit>
+      <trans-unit id="registration-status-dialog-submit-button-labels-decline" datatype="html">
+        <source>Decline</source>
+      </trans-unit>
+      <trans-unit id="registration-status-dialog-submit-button-labels-delete" datatype="html">
+        <source>Delete</source>
+      </trans-unit>
+      <trans-unit id="registration-status-dialog-submit-button-labels-include" datatype="html">
+        <source>Include</source>
+      </trans-unit>
+      <trans-unit id="registration-status-dialog-submit-button-labels-pause" datatype="html">
+        <source>Pause</source>
+      </trans-unit>
+      <trans-unit id="registration-status-dialog-submit-button-labels-register" datatype="html">
+        <source>Register</source>
+      </trans-unit>
+      <trans-unit id="registration-status-dialog-submit-button-labels-validate" datatype="html">
+        <source>Validate</source>
+      </trans-unit>
       <trans-unit id="registration-status-included" datatype="html">
         <source>Included</source>
       </trans-unit>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -2671,19 +2671,19 @@
         <source>Deleted</source>
       </trans-unit>
       <trans-unit id="registration-status-dialog-submit-button-labels-decline" datatype="html">
-        <source>Decline registrations</source>
+        <source>Decline registration</source>
       </trans-unit>
       <trans-unit id="registration-status-dialog-submit-button-labels-delete" datatype="html">
-        <source>Delete registrations</source>
+        <source>Delete registration</source>
       </trans-unit>
       <trans-unit id="registration-status-dialog-submit-button-labels-include" datatype="html">
-        <source>Include registrations</source>
+        <source>Include registration</source>
       </trans-unit>
       <trans-unit id="registration-status-dialog-submit-button-labels-pause" datatype="html">
-        <source>Pause registrations</source>
+        <source>Pause registration</source>
       </trans-unit>
       <trans-unit id="registration-status-dialog-submit-button-labels-validate" datatype="html">
-        <source>Validate registrations</source>
+        <source>Validate registration</source>
       </trans-unit>
       <trans-unit id="registration-status-included" datatype="html">
         <source>Included</source>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -62,6 +62,9 @@
       <trans-unit id="1297402576657440154" datatype="html">
         <source>Transactions per payment</source>
       </trans-unit>
+      <trans-unit id="1302184832753381211" datatype="html">
+        <source>Including</source>
+      </trans-unit>
       <trans-unit id="1307602065632249368" datatype="html">
         <source>Export the FSP instructions and save the exported XLSX-file in the format required by the Financial Service Provider.</source>
       </trans-unit>
@@ -390,6 +393,9 @@
       <trans-unit id="2560790823235400386" datatype="html">
         <source>No debit cards found</source>
       </trans-unit>
+      <trans-unit id="2564986692899370666" datatype="html">
+        <source><x equiv-text="{{ statusGerund() }}" id="INTERPOLATION"/> a registration that&apos;s included in a payment will result in a failed transfer, if you include them in the future you&apos;d be able to retry failed payment.</source>
+      </trans-unit>
       <trans-unit id="2569607511969570423" datatype="html">
         <source>Export selected registrations</source>
       </trans-unit>
@@ -440,6 +446,9 @@
       </trans-unit>
       <trans-unit id="2818334334996550834" datatype="html">
         <source>Kobo form refresh errors</source>
+      </trans-unit>
+      <trans-unit id="28184998386226894" datatype="html">
+        <source>Pausing</source>
       </trans-unit>
       <trans-unit id="2832894421278390919" datatype="html">
         <source>Invalid email or password. Double-check your credentials and try again.</source>
@@ -518,6 +527,9 @@
       </trans-unit>
       <trans-unit id="3099882906994173432" datatype="html">
         <source>Linked</source>
+      </trans-unit>
+      <trans-unit id="3141301060598402455" datatype="html">
+        <source>Deleting</source>
       </trans-unit>
       <trans-unit id="3142649024295180156" datatype="html">
         <source>Choose file</source>
@@ -851,6 +863,9 @@
       <trans-unit id="4421433274861560863" datatype="html">
         <source>Add a user to the 121 platform. Fill in the fields below to create a new user account.</source>
       </trans-unit>
+      <trans-unit id="4465385057621611056" datatype="html">
+        <source>Validating</source>
+      </trans-unit>
       <trans-unit id="4478569469579904965" datatype="html">
         <source>The note will be visible to other 121 users who are permitted to view personal profiles.</source>
       </trans-unit>
@@ -988,9 +1003,6 @@
       </trans-unit>
       <trans-unit id="5035732150329518917" datatype="html">
         <source>You&apos;re about to download an Excel file for all status &amp; data changes.</source>
-      </trans-unit>
-      <trans-unit id="5060288231641087708" datatype="html">
-        <source>There are <x equiv-text="{{ dryRunData.pendingApprovalCount }}" id="INTERPOLATION"/> registration(s) with a payment pending approval</source>
       </trans-unit>
       <trans-unit id="5061826209151408276" datatype="html">
         <source>This privacy notice tells you what to expect us to do with your personal information when you use the 121 Platform.</source>
@@ -1157,6 +1169,9 @@
       <trans-unit id="566208731639813177" datatype="html">
         <source>Scope allows you to control which team members have access to specific registrations, based on the scope they are assigned to in the program team&apos;s page. To use this feature, make sure scope is defined in your integrated Kobo form or Excel table.</source>
       </trans-unit>
+      <trans-unit id="5667836214859665218" datatype="html">
+        <source>Declining</source>
+      </trans-unit>
       <trans-unit id="5670622821110743398" datatype="html">
         <source>Program information</source>
       </trans-unit>
@@ -1317,6 +1332,9 @@
       <trans-unit id="6430223777327451722" datatype="html">
         <source>Total payment amount</source>
       </trans-unit>
+      <trans-unit id="6438873380402957093" datatype="html">
+        <source>Would you like to &quot;<x equiv-text="{{ statusVerb() }}" id="INTERPOLATION"/>&quot; these <x equiv-text="{{ dryRunData.pendingApprovalCount }}" id="INTERPOLATION_1"/> registration(s)?</source>
+      </trans-unit>
       <trans-unit id="6456009373504868195" datatype="html">
         <source>Please correct the errors in the form.</source>
       </trans-unit>
@@ -1451,6 +1469,9 @@
       </trans-unit>
       <trans-unit id="7006682445961797483" datatype="html">
         <source><x equiv-text="this.approvalsGiven()" id="PH"/> of <x equiv-text="this.approvalsRequired()" id="PH_1"/> approved</source>
+      </trans-unit>
+      <trans-unit id="7013426431142913192" datatype="html">
+        <source>You&apos;re about to &quot;<x equiv-text="{{ statusVerb() }}" id="INTERPOLATION"/>&quot; <x equiv-text="{{ dryRunData.pendingApprovalCount }}" id="INTERPOLATION_1"/> registration(s) that are included in a payment that&apos;s waiting for approval.</source>
       </trans-unit>
       <trans-unit id="7014051207286040747" datatype="html">
         <source>Data column name</source>
@@ -1697,9 +1718,6 @@
       </trans-unit>
       <trans-unit id="8066608938393600549" datatype="html">
         <source>Message</source>
-      </trans-unit>
-      <trans-unit id="8069376225853843957" datatype="html">
-        <source>Their status will still be changed to &quot;<x equiv-text="{{ statusLabel() | lowercase }}" id="INTERPOLATION"/>&quot; if you proceed.</source>
       </trans-unit>
       <trans-unit id="8089925871034232084" datatype="html">
         <source>The data column name of the question.</source>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -86,9 +86,6 @@
       <trans-unit id="138735154290622738" datatype="html">
         <source>yourname@example.org</source>
       </trans-unit>
-      <trans-unit id="1395032276253887547" datatype="html">
-        <source>Pausing a registration that’s included in a payment will result in a failed transfer, if you include them in the future you’d be able to retry failed payment.</source>
-      </trans-unit>
       <trans-unit id="1403545532790809587" datatype="html">
         <source>Reconfigure <x equiv-text="this.fspLabel()" id="fspName"/></source>
       </trans-unit>
@@ -923,9 +920,6 @@
       <trans-unit id="471816275243265264" datatype="html">
         <source>Location</source>
       </trans-unit>
-      <trans-unit id="4736973860327687161" datatype="html">
-        <source>You&apos;re about to <x ctype="x-strong" equiv-text="&lt;strong&gt;" id="START_TAG_STRONG"/><x equiv-text="{{ statusVerb() | lowercase }}" id="INTERPOLATION"/><x ctype="x-strong" equiv-text="&lt;/strong&gt;" id="CLOSE_TAG_STRONG"/> <x equiv-text="{{ dryRunData.pendingApprovalCount }}" id="INTERPOLATION_1"/> registration(s) that are included in a payment that&apos;s waiting for approval.</source>
-      </trans-unit>
       <trans-unit id="4746344653872488527" datatype="html">
         <source>Export payment list</source>
       </trans-unit>
@@ -988,6 +982,9 @@
       </trans-unit>
       <trans-unit id="5004550577313573215" datatype="html">
         <source>Total amount</source>
+      </trans-unit>
+      <trans-unit id="501769714612198671" datatype="html">
+        <source>You&apos;re about to <x equiv-text="{{ statusVerb() | lowercase }}" id="INTERPOLATION"/> <x equiv-text="{{ dryRunData.pendingApprovalCount }}" id="INTERPOLATION_1"/> registration(s) that are included in a payment that&apos;s waiting for approval.</source>
       </trans-unit>
       <trans-unit id="5028251453651641459" datatype="html">
         <source>Update the relevant details in the next steps, then link a registration form to complete the setup.</source>
@@ -1147,9 +1144,6 @@
       </trans-unit>
       <trans-unit id="5595826100350402634" datatype="html">
         <source>Use the arrow keys or W A S D to play the game</source>
-      </trans-unit>
-      <trans-unit id="561353031255604069" datatype="html">
-        <source>There are <x equiv-text="{{ dryRunData.nonApplicableCount }}" id="INTERPOLATION"/> registration(s) that don&apos;t support this action</source>
       </trans-unit>
       <trans-unit id="5641945527911431559" datatype="html">
         <source>Error: <x equiv-text="{{ versionInfo.error()?.message }}" id="INTERPOLATION"/></source>
@@ -1319,9 +1313,6 @@
       </trans-unit>
       <trans-unit id="6430223777327451722" datatype="html">
         <source>Total payment amount</source>
-      </trans-unit>
-      <trans-unit id="6438873380402957093" datatype="html">
-        <source>Would you like to &quot;<x equiv-text="{{ statusVerb() | lowercase }}" id="INTERPOLATION"/>&quot; these <x equiv-text="{{ dryRunData.pendingApprovalCount }}" id="INTERPOLATION_1"/> registration(s)?</source>
       </trans-unit>
       <trans-unit id="6456009373504868195" datatype="html">
         <source>Please correct the errors in the form.</source>
@@ -1605,9 +1596,6 @@
       <trans-unit id="7585826646011739428" datatype="html">
         <source>Edit</source>
       </trans-unit>
-      <trans-unit id="7599211658353827397" datatype="html">
-        <source>Declining a registration included in a payment will exclude them from that payment. To ensure they still receive their transfer, cancel this action and decline them after payment.</source>
-      </trans-unit>
       <trans-unit id="7613791439001735010" datatype="html">
         <source>Template message</source>
       </trans-unit>
@@ -1863,9 +1851,6 @@
       <trans-unit id="8733206904097373941" datatype="html">
         <source>This will download an Excel file with all unused voucher(s).</source>
       </trans-unit>
-      <trans-unit id="8735352957921555136" datatype="html">
-        <source>Registrations that do not support this action will remain in their current status.</source>
-      </trans-unit>
       <trans-unit id="8747826357702572054" datatype="html">
         <source>Financial service providers:</source>
       </trans-unit>
@@ -2070,6 +2055,9 @@
       <trans-unit id="change-status-decline-warning" datatype="html">
         <source>The action &quot;Decline&quot; can not be applied to registrations with the &quot;Declined&quot; or &quot;Completed&quot; status.</source>
       </trans-unit>
+      <trans-unit id="change-status-declined-pending-approval-explanation" datatype="html">
+        <source>Declining a registration included in a payment will exclude them from that payment. To ensure they still receive their transfer, cancel this action and decline them after payment.</source>
+      </trans-unit>
       <trans-unit id="change-status-default-warning" datatype="html">
         <source>This action can not be applied to registrations you have selected.</source>
       </trans-unit>
@@ -2081,6 +2069,9 @@
       </trans-unit>
       <trans-unit id="change-status-pause-warning" datatype="html">
         <source>The action &quot;Pause&quot; can only be applied to registrations with the &quot;Included&quot; status.</source>
+      </trans-unit>
+      <trans-unit id="change-status-paused-pending-approval-explanation" datatype="html">
+        <source>Pausing a registration that’s included in a payment will result in a failed transfer. If you include them in the future, you’ll be able to retry the failed payment.</source>
       </trans-unit>
       <trans-unit id="change-status-validate-warning" datatype="html">
         <source>The action &quot;Validate&quot; can only be applied to registrations with the &quot;New&quot; status.</source>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -816,7 +816,7 @@
         <source>Amount sent per payment</source>
       </trans-unit>
       <trans-unit id="428968768517674095" datatype="html">
-        <source>Would you like to proceed with <x equiv-text="{{ changeStatusMutation.data()?.applicableCount }}" id="INTERPOLATION"/> registration(s)?</source>
+        <source>Would you like to proceed with <x equiv-text="{{ dryRunData?.applicableCount }}" id="INTERPOLATION"/> registration(s)?</source>
       </trans-unit>
       <trans-unit id="4309697217076303455" datatype="html">
         <source><x equiv-text="paymentCount.toString()" id="count"/> (out of <x equiv-text="maxPayments.toString()" id="totalCount"/>)</source>
@@ -989,6 +989,9 @@
       <trans-unit id="5035732150329518917" datatype="html">
         <source>You&apos;re about to download an Excel file for all status &amp; data changes.</source>
       </trans-unit>
+      <trans-unit id="5060288231641087708" datatype="html">
+        <source>There are <x equiv-text="{{ dryRunData.pendingApprovalCount }}" id="INTERPOLATION"/> registration(s) with a payment pending approval</source>
+      </trans-unit>
       <trans-unit id="5061826209151408276" datatype="html">
         <source>This privacy notice tells you what to expect us to do with your personal information when you use the 121 Platform.</source>
       </trans-unit>
@@ -1143,7 +1146,7 @@
         <source>Use the arrow keys or W A S D to play the game</source>
       </trans-unit>
       <trans-unit id="561353031255604069" datatype="html">
-        <source>There are <x equiv-text="{{ changeStatusMutation.data()?.nonApplicableCount }}" id="INTERPOLATION"/> registration(s) that don&apos;t support this action</source>
+        <source>There are <x equiv-text="{{ dryRunData.nonApplicableCount }}" id="INTERPOLATION"/> registration(s) that don&apos;t support this action</source>
       </trans-unit>
       <trans-unit id="5641945527911431559" datatype="html">
         <source>Error: <x equiv-text="{{ versionInfo.error()?.message }}" id="INTERPOLATION"/></source>
@@ -1694,6 +1697,9 @@
       </trans-unit>
       <trans-unit id="8066608938393600549" datatype="html">
         <source>Message</source>
+      </trans-unit>
+      <trans-unit id="8069376225853843957" datatype="html">
+        <source>Their status will still be changed to &quot;<x equiv-text="{{ statusLabel() | lowercase }}" id="INTERPOLATION"/>&quot; if you proceed.</source>
       </trans-unit>
       <trans-unit id="8089925871034232084" datatype="html">
         <source>The data column name of the question.</source>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -62,9 +62,6 @@
       <trans-unit id="1297402576657440154" datatype="html">
         <source>Transactions per payment</source>
       </trans-unit>
-      <trans-unit id="1302184832753381211" datatype="html">
-        <source>Including</source>
-      </trans-unit>
       <trans-unit id="1307602065632249368" datatype="html">
         <source>Export the FSP instructions and save the exported XLSX-file in the format required by the Financial Service Provider.</source>
       </trans-unit>
@@ -88,6 +85,9 @@
       </trans-unit>
       <trans-unit id="138735154290622738" datatype="html">
         <source>yourname@example.org</source>
+      </trans-unit>
+      <trans-unit id="1395032276253887547" datatype="html">
+        <source>Pausing a registration that’s included in a payment will result in a failed transfer, if you include them in the future you’d be able to retry failed payment.</source>
       </trans-unit>
       <trans-unit id="1403545532790809587" datatype="html">
         <source>Reconfigure <x equiv-text="this.fspLabel()" id="fspName"/></source>
@@ -393,9 +393,6 @@
       <trans-unit id="2560790823235400386" datatype="html">
         <source>No debit cards found</source>
       </trans-unit>
-      <trans-unit id="2564986692899370666" datatype="html">
-        <source><x equiv-text="{{ statusGerund() }}" id="INTERPOLATION"/> a registration that&apos;s included in a payment will result in a failed transfer, if you include them in the future you&apos;d be able to retry failed payment.</source>
-      </trans-unit>
       <trans-unit id="2569607511969570423" datatype="html">
         <source>Export selected registrations</source>
       </trans-unit>
@@ -446,9 +443,6 @@
       </trans-unit>
       <trans-unit id="2818334334996550834" datatype="html">
         <source>Kobo form refresh errors</source>
-      </trans-unit>
-      <trans-unit id="28184998386226894" datatype="html">
-        <source>Pausing</source>
       </trans-unit>
       <trans-unit id="2832894421278390919" datatype="html">
         <source>Invalid email or password. Double-check your credentials and try again.</source>
@@ -527,9 +521,6 @@
       </trans-unit>
       <trans-unit id="3099882906994173432" datatype="html">
         <source>Linked</source>
-      </trans-unit>
-      <trans-unit id="3141301060598402455" datatype="html">
-        <source>Deleting</source>
       </trans-unit>
       <trans-unit id="3142649024295180156" datatype="html">
         <source>Choose file</source>
@@ -863,9 +854,6 @@
       <trans-unit id="4421433274861560863" datatype="html">
         <source>Add a user to the 121 platform. Fill in the fields below to create a new user account.</source>
       </trans-unit>
-      <trans-unit id="4465385057621611056" datatype="html">
-        <source>Validating</source>
-      </trans-unit>
       <trans-unit id="4478569469579904965" datatype="html">
         <source>The note will be visible to other 121 users who are permitted to view personal profiles.</source>
       </trans-unit>
@@ -934,6 +922,9 @@
       </trans-unit>
       <trans-unit id="471816275243265264" datatype="html">
         <source>Location</source>
+      </trans-unit>
+      <trans-unit id="4736973860327687161" datatype="html">
+        <source>You&apos;re about to <x ctype="x-strong" equiv-text="&lt;strong&gt;" id="START_TAG_STRONG"/><x equiv-text="{{ statusVerb() | lowercase }}" id="INTERPOLATION"/><x ctype="x-strong" equiv-text="&lt;/strong&gt;" id="CLOSE_TAG_STRONG"/> <x equiv-text="{{ dryRunData.pendingApprovalCount }}" id="INTERPOLATION_1"/> registration(s) that are included in a payment that&apos;s waiting for approval.</source>
       </trans-unit>
       <trans-unit id="4746344653872488527" datatype="html">
         <source>Export payment list</source>
@@ -1169,9 +1160,6 @@
       <trans-unit id="566208731639813177" datatype="html">
         <source>Scope allows you to control which team members have access to specific registrations, based on the scope they are assigned to in the program team&apos;s page. To use this feature, make sure scope is defined in your integrated Kobo form or Excel table.</source>
       </trans-unit>
-      <trans-unit id="5667836214859665218" datatype="html">
-        <source>Declining</source>
-      </trans-unit>
       <trans-unit id="5670622821110743398" datatype="html">
         <source>Program information</source>
       </trans-unit>
@@ -1333,7 +1321,7 @@
         <source>Total payment amount</source>
       </trans-unit>
       <trans-unit id="6438873380402957093" datatype="html">
-        <source>Would you like to &quot;<x equiv-text="{{ statusVerb() }}" id="INTERPOLATION"/>&quot; these <x equiv-text="{{ dryRunData.pendingApprovalCount }}" id="INTERPOLATION_1"/> registration(s)?</source>
+        <source>Would you like to &quot;<x equiv-text="{{ statusVerb() | lowercase }}" id="INTERPOLATION"/>&quot; these <x equiv-text="{{ dryRunData.pendingApprovalCount }}" id="INTERPOLATION_1"/> registration(s)?</source>
       </trans-unit>
       <trans-unit id="6456009373504868195" datatype="html">
         <source>Please correct the errors in the form.</source>
@@ -1469,9 +1457,6 @@
       </trans-unit>
       <trans-unit id="7006682445961797483" datatype="html">
         <source><x equiv-text="this.approvalsGiven()" id="PH"/> of <x equiv-text="this.approvalsRequired()" id="PH_1"/> approved</source>
-      </trans-unit>
-      <trans-unit id="7013426431142913192" datatype="html">
-        <source>You&apos;re about to &quot;<x equiv-text="{{ statusVerb() }}" id="INTERPOLATION"/>&quot; <x equiv-text="{{ dryRunData.pendingApprovalCount }}" id="INTERPOLATION_1"/> registration(s) that are included in a payment that&apos;s waiting for approval.</source>
       </trans-unit>
       <trans-unit id="7014051207286040747" datatype="html">
         <source>Data column name</source>
@@ -1619,6 +1604,9 @@
       </trans-unit>
       <trans-unit id="7585826646011739428" datatype="html">
         <source>Edit</source>
+      </trans-unit>
+      <trans-unit id="7599211658353827397" datatype="html">
+        <source>Declining a registration included in a payment will exclude them from that payment. To ensure they still receive their transfer, cancel this action and decline them after payment.</source>
       </trans-unit>
       <trans-unit id="7613791439001735010" datatype="html">
         <source>Template message</source>

--- a/services/121-service/src/registration/dto/bulk-action-result.dto.ts
+++ b/services/121-service/src/registration/dto/bulk-action-result.dto.ts
@@ -13,6 +13,9 @@ export class BulkActionResultDto {
 
   @ApiProperty({ example: 2 })
   public readonly nonApplicableCount: number;
+
+  @ApiProperty({ example: 1 })
+  public readonly pendingApprovalCount?: number;
 }
 
 export class BulkActionResultPaymentDto extends BulkActionResultDto {

--- a/services/121-service/src/registration/services/registrations-bulk.service.spec.ts
+++ b/services/121-service/src/registration/services/registrations-bulk.service.spec.ts
@@ -3,11 +3,13 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { MessageQueuesService } from '@121-service/src/notifications/message-queues/message-queues.service';
 import { MessageTemplateEntity } from '@121-service/src/notifications/message-template/message-template.entity';
+import { TransactionEntity } from '@121-service/src/payments/transactions/entities/transaction.entity';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { RegistrationViewScopedRepository } from '@121-service/src/registration/repositories/registration-view-scoped.repository';
 import { RegistrationsBulkService } from '@121-service/src/registration/services/registrations-bulk.service';
 import { RegistrationsPaginationService } from '@121-service/src/registration/services/registrations-pagination.service';
 import { RegistrationPreferredLanguage } from '@121-service/src/shared/enum/registration-preferred-language.enum';
+import { getScopedRepositoryProviderName } from '@121-service/src/utils/scope/createScopedRepositoryProvider.helper';
 import { generateMockCreateQueryBuilder } from '@121-service/src/utils/test-helpers/createQueryBuilderMock.helper';
 
 describe('RegistrationBulkService', () => {
@@ -19,6 +21,7 @@ describe('RegistrationBulkService', () => {
 
   let registrationsBulkService: RegistrationsBulkService;
   let queueMessageService: MessageQueuesService;
+  let transactionScopedRepository: any;
 
   const registrationMock = {
     namePartnerOrganization: 'testname',
@@ -110,6 +113,10 @@ describe('RegistrationBulkService', () => {
     jest
       .spyOn(queueMessageService as any, 'addMessageToQueue')
       .mockImplementation();
+
+    transactionScopedRepository = unitRef.get(
+      getScopedRepositoryProviderName(TransactionEntity),
+    );
   });
 
   it('should be defined', () => {
@@ -182,6 +189,85 @@ describe('RegistrationBulkService', () => {
 
       // Assert
       expect(queueMessageService.addMessageJob).toHaveBeenCalled();
+    });
+  });
+
+  describe('pending approval count on status change dry run', () => {
+    const messageContentDetails = {
+      message: undefined,
+      messageTemplateKey: undefined,
+      messageContentType: undefined,
+    };
+
+    it('does not compute pendingApprovalCount for statuses outside declined/paused', async () => {
+      // Act
+      const result =
+        await registrationsBulkService.updateRegistrationStatusOrDryRun({
+          paginateQuery,
+          programId,
+          registrationStatus: RegistrationStatusEnum.included,
+          dryRun: true,
+          userId,
+          messageContentDetails,
+        });
+
+      // Assert
+      expect(result.pendingApprovalCount).toBeUndefined();
+      expect(
+        transactionScopedRepository.createQueryBuilder,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('returns 0 when no applicable registrations have a payment pending approval', async () => {
+      // Arrange
+      jest
+        .spyOn(transactionScopedRepository, 'createQueryBuilder')
+        .mockImplementation(() =>
+          generateMockCreateQueryBuilder(
+            { count: '0' },
+            { useGetRawOne: true },
+          ),
+        );
+
+      // Act
+      const result =
+        await registrationsBulkService.updateRegistrationStatusOrDryRun({
+          paginateQuery,
+          programId,
+          registrationStatus: RegistrationStatusEnum.declined,
+          dryRun: true,
+          userId,
+          messageContentDetails,
+        });
+
+      // Assert
+      expect(result.pendingApprovalCount).toBe(0);
+    });
+
+    it('returns the count of applicable registrations that have a payment pending approval', async () => {
+      // Arrange
+      jest
+        .spyOn(transactionScopedRepository, 'createQueryBuilder')
+        .mockImplementation(() =>
+          generateMockCreateQueryBuilder(
+            { count: '2' },
+            { useGetRawOne: true },
+          ),
+        );
+
+      // Act
+      const result =
+        await registrationsBulkService.updateRegistrationStatusOrDryRun({
+          paginateQuery,
+          programId,
+          registrationStatus: RegistrationStatusEnum.paused,
+          dryRun: true,
+          userId,
+          messageContentDetails,
+        });
+
+      // Assert
+      expect(result.pendingApprovalCount).toBe(2);
     });
   });
 });

--- a/services/121-service/src/registration/services/registrations-bulk.service.ts
+++ b/services/121-service/src/registration/services/registrations-bulk.service.ts
@@ -126,7 +126,7 @@ export class RegistrationsBulkService {
     }
     // Get the referenceIds for the update separately as running a query with no limit is slower
     // so you show the result of the applicable registrations earlier
-    return { ...resultDto, pendingApprovalCount };
+    return resultDto;
   }
 
   public async deleteRegistrations({
@@ -167,7 +167,7 @@ export class RegistrationsBulkService {
         this.azureLogService.logError(error, true);
       });
     }
-    return { ...resultDto, pendingApprovalCount };
+    return resultDto;
   }
 
   public async sendMessagesOrDryRun(

--- a/services/121-service/src/registration/services/registrations-bulk.service.ts
+++ b/services/121-service/src/registration/services/registrations-bulk.service.ts
@@ -15,6 +15,8 @@ import { MessageQueuesService } from '@121-service/src/notifications/message-que
 import { MessageTemplateEntity } from '@121-service/src/notifications/message-template/message-template.entity';
 import { MessageSenderUserId } from '@121-service/src/notifications/types/message-sender-user-id.type';
 import { WhatsappPendingMessageEntity } from '@121-service/src/notifications/whatsapp/whatsapp-pending-message.entity';
+import { TransactionEntity } from '@121-service/src/payments/transactions/entities/transaction.entity';
+import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { BulkActionResultDto } from '@121-service/src/registration/dto/bulk-action-result.dto';
 import { RegistrationViewEntity } from '@121-service/src/registration/entities/registration-view.entity';
 import {
@@ -59,7 +61,15 @@ export class RegistrationsBulkService {
     private readonly registrationDataScopedRepository: RegistrationDataScopedRepository,
     @Inject(getScopedRepositoryProviderName(NoteEntity))
     private readonly noteScopedRepository: ScopedRepository<NoteEntity>,
+    @Inject(getScopedRepositoryProviderName(TransactionEntity))
+    private readonly transactionScopedRepository: ScopedRepository<TransactionEntity>,
   ) {}
+
+  // Only these target statuses can affect registrations with a payment pending approval
+  private static readonly statusesRequiringPendingApprovalCheck = [
+    RegistrationStatusEnum.declined,
+    RegistrationStatusEnum.paused,
+  ];
 
   public async updateRegistrationStatusOrDryRun({
     paginateQuery,
@@ -81,11 +91,26 @@ export class RegistrationsBulkService {
     const allowedCurrentStatuses =
       this.getAllowedCurrentStatusesForNewStatus(registrationStatus);
 
-    const resultDto = await this.getBulkActionResult(
+    const bulkActionResult = await this.getBulkActionResult(
       paginateQuery,
       programId,
       this.getStatusUpdateBaseQuery(allowedCurrentStatuses, registrationStatus),
     );
+
+    const pendingApprovalCount = await this.getPendingApprovalCountIfApplicable(
+      {
+        registrationStatus,
+        allowedCurrentStatuses,
+        paginateQuery,
+        programId,
+      },
+    );
+
+    const resultDto =
+      pendingApprovalCount === undefined
+        ? bulkActionResult
+        : { ...bulkActionResult, pendingApprovalCount };
+
     if (!dryRun) {
       this.applyRegistrationStatusUpdate({
         paginateQuery,
@@ -131,6 +156,7 @@ export class RegistrationsBulkService {
       programId,
       this.getStatusUpdateBaseQuery(allowedCurrentStatuses),
     );
+
     if (!dryRun) {
       this.deleteBatch({
         paginateQuery,
@@ -500,6 +526,68 @@ export class RegistrationsBulkService {
       });
 
     return data.map((r) => r.referenceId);
+  }
+
+  // Only computed for status changes that can affect registrations with a payment pending approval
+  private async getPendingApprovalCountIfApplicable({
+    registrationStatus,
+    allowedCurrentStatuses,
+    paginateQuery,
+    programId,
+  }: {
+    registrationStatus: RegistrationStatusEnum;
+    allowedCurrentStatuses: RegistrationStatusEnum[];
+    paginateQuery: PaginateQuery;
+    programId: number;
+  }): Promise<number | undefined> {
+    if (
+      !RegistrationsBulkService.statusesRequiringPendingApprovalCheck.includes(
+        registrationStatus,
+      )
+    ) {
+      return undefined;
+    }
+
+    // Clone the query so mutating `.select` here does not affect the caller's later use of paginateQuery
+    const applicableReferenceIds =
+      await this.getReferenceIdsForWhichStatusChangeIsApplicable(
+        programId,
+        allowedCurrentStatuses,
+        registrationStatus,
+        { ...paginateQuery },
+      );
+
+    return await this.getPendingApprovalCount({
+      referenceIds: applicableReferenceIds,
+      programId,
+    });
+  }
+
+  private async getPendingApprovalCount({
+    referenceIds,
+    programId,
+  }: {
+    referenceIds: string[];
+    programId: number;
+  }): Promise<number> {
+    if (referenceIds.length === 0) {
+      return 0;
+    }
+
+    const result = await this.transactionScopedRepository
+      .createQueryBuilder('transaction')
+      .leftJoin('transaction.registration', 'registration')
+      .andWhere('registration."programId" = :programId', { programId })
+      .andWhere('registration."referenceId" IN (:...referenceIds)', {
+        referenceIds,
+      })
+      .andWhere('transaction.status = :status', {
+        status: TransactionStatusEnum.pendingApproval,
+      })
+      .select('COUNT(DISTINCT transaction."registrationId")', 'count')
+      .getRawOne<{ count: string }>();
+
+    return Number(result?.count ?? 0);
   }
 
   private async updateRegistrationStatusPerChunk({

--- a/services/121-service/src/registration/services/registrations-bulk.service.ts
+++ b/services/121-service/src/registration/services/registrations-bulk.service.ts
@@ -126,7 +126,7 @@ export class RegistrationsBulkService {
     }
     // Get the referenceIds for the update separately as running a query with no limit is slower
     // so you show the result of the applicable registrations earlier
-    return resultDto;
+    return { ...resultDto, pendingApprovalCount };
   }
 
   public async deleteRegistrations({
@@ -167,7 +167,7 @@ export class RegistrationsBulkService {
         this.azureLogService.logError(error, true);
       });
     }
-    return resultDto;
+    return { ...resultDto, pendingApprovalCount };
   }
 
   public async sendMessagesOrDryRun(

--- a/services/121-service/src/utils/test-helpers/createQueryBuilderMock.helper.ts
+++ b/services/121-service/src/utils/test-helpers/createQueryBuilderMock.helper.ts
@@ -6,13 +6,14 @@ interface QueryBuilderMock {
   leftJoin: () => QueryBuilderMock;
   getMany?: () => any;
   getRawMany?: () => any;
+  getRawOne?: () => any;
   distinct?: () => QueryBuilderMock;
   orderBy?: () => QueryBuilderMock;
 }
 
 export function generateMockCreateQueryBuilder(
-  dbQueryResult?: any[] | null,
-  options: { useGetMany?: boolean } = {},
+  dbQueryResult?: any,
+  options: { useGetMany?: boolean; useGetRawOne?: boolean } = {},
 ): QueryBuilderMock {
   const mock: QueryBuilderMock = {
     select: () => mock,
@@ -26,6 +27,8 @@ export function generateMockCreateQueryBuilder(
 
   if (options.useGetMany) {
     mock.getMany = () => dbQueryResult;
+  } else if (options.useGetRawOne) {
+    mock.getRawOne = () => dbQueryResult;
   } else {
     mock.getRawMany = () => dbQueryResult;
   }


### PR DESCRIPTION
[AB#43906](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43906)

## Describe your changes

Extends the `updateRegistrationStatusOrDryRun` call to return the `pendingApprovalCount` for that status change update.

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have addressed all Copilot comments
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [ ] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [ ] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8666.westeurope.3.azurestaticapps.net
