### PR TITLE
[BE] Registration pauze/decline warning modal

### DIFF
--- a/services/121-service/src/registration/dto/bulk-action-result.dto.ts
+++ b/services/121-service/src/registration/dto/bulk-action-result.dto.ts
@@ -13,6 +13,9 @@ export class BulkActionResultDto {
 
   @ApiProperty({ example: 2 })
   public readonly nonApplicableCount: number;
+
+  @ApiProperty({ example: 1 })
+  public readonly pendingApprovalCount?: number;
 }
 
 export class BulkActionResultPaymentDto extends BulkActionResultDto {

--- a/services/121-service/src/registration/services/registrations-bulk.service.spec.ts
+++ b/services/121-service/src/registration/services/registrations-bulk.service.spec.ts
@@ -3,11 +3,13 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { MessageQueuesService } from '@121-service/src/notifications/message-queues/message-queues.service';
 import { MessageTemplateEntity } from '@121-service/src/notifications/message-template/message-template.entity';
+import { TransactionEntity } from '@121-service/src/payments/transactions/entities/transaction.entity';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { RegistrationViewScopedRepository } from '@121-service/src/registration/repositories/registration-view-scoped.repository';
 import { RegistrationsBulkService } from '@121-service/src/registration/services/registrations-bulk.service';
 import { RegistrationsPaginationService } from '@121-service/src/registration/services/registrations-pagination.service';
 import { RegistrationPreferredLanguage } from '@121-service/src/shared/enum/registration-preferred-language.enum';
+import { getScopedRepositoryProviderName } from '@121-service/src/utils/scope/createScopedRepositoryProvider.helper';
 import { generateMockCreateQueryBuilder } from '@121-service/src/utils/test-helpers/createQueryBuilderMock.helper';
 
 describe('RegistrationBulkService', () => {
@@ -19,6 +21,7 @@ describe('RegistrationBulkService', () => {
 
   let registrationsBulkService: RegistrationsBulkService;
   let queueMessageService: MessageQueuesService;
+  let transactionScopedRepository: any;
 
   const registrationMock = {
     namePartnerOrganization: 'testname',
@@ -110,6 +113,10 @@ describe('RegistrationBulkService', () => {
     jest
       .spyOn(queueMessageService as any, 'addMessageToQueue')
       .mockImplementation();
+
+    transactionScopedRepository = unitRef.get(
+      getScopedRepositoryProviderName(TransactionEntity),
+    );
   });
 
   it('should be defined', () => {
@@ -182,6 +189,85 @@ describe('RegistrationBulkService', () => {
 
       // Assert
       expect(queueMessageService.addMessageJob).toHaveBeenCalled();
+    });
+  });
+
+  describe('pending approval count on status change dry run', () => {
+    const messageContentDetails = {
+      message: undefined,
+      messageTemplateKey: undefined,
+      messageContentType: undefined,
+    };
+
+    it('does not compute pendingApprovalCount for statuses outside declined/paused', async () => {
+      // Act
+      const result =
+        await registrationsBulkService.updateRegistrationStatusOrDryRun({
+          paginateQuery,
+          programId,
+          registrationStatus: RegistrationStatusEnum.included,
+          dryRun: true,
+          userId,
+          messageContentDetails,
+        });
+
+      // Assert
+      expect(result.pendingApprovalCount).toBeUndefined();
+      expect(
+        transactionScopedRepository.createQueryBuilder,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('returns 0 when no applicable registrations have a payment pending approval', async () => {
+      // Arrange
+      jest
+        .spyOn(transactionScopedRepository, 'createQueryBuilder')
+        .mockImplementation(() =>
+          generateMockCreateQueryBuilder(
+            { count: '0' },
+            { useGetRawOne: true },
+          ),
+        );
+
+      // Act
+      const result =
+        await registrationsBulkService.updateRegistrationStatusOrDryRun({
+          paginateQuery,
+          programId,
+          registrationStatus: RegistrationStatusEnum.declined,
+          dryRun: true,
+          userId,
+          messageContentDetails,
+        });
+
+      // Assert
+      expect(result.pendingApprovalCount).toBe(0);
+    });
+
+    it('returns the count of applicable registrations that have a payment pending approval', async () => {
+      // Arrange
+      jest
+        .spyOn(transactionScopedRepository, 'createQueryBuilder')
+        .mockImplementation(() =>
+          generateMockCreateQueryBuilder(
+            { count: '2' },
+            { useGetRawOne: true },
+          ),
+        );
+
+      // Act
+      const result =
+        await registrationsBulkService.updateRegistrationStatusOrDryRun({
+          paginateQuery,
+          programId,
+          registrationStatus: RegistrationStatusEnum.paused,
+          dryRun: true,
+          userId,
+          messageContentDetails,
+        });
+
+      // Assert
+      expect(result.pendingApprovalCount).toBe(2);
     });
   });
 });

--- a/services/121-service/src/registration/services/registrations-bulk.service.ts
+++ b/services/121-service/src/registration/services/registrations-bulk.service.ts
@@ -15,6 +15,8 @@ import { MessageQueuesService } from '@121-service/src/notifications/message-que
 import { MessageTemplateEntity } from '@121-service/src/notifications/message-template/message-template.entity';
 import { MessageSenderUserId } from '@121-service/src/notifications/types/message-sender-user-id.type';
 import { WhatsappPendingMessageEntity } from '@121-service/src/notifications/whatsapp/whatsapp-pending-message.entity';
+import { TransactionEntity } from '@121-service/src/payments/transactions/entities/transaction.entity';
+import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';
 import { BulkActionResultDto } from '@121-service/src/registration/dto/bulk-action-result.dto';
 import { RegistrationViewEntity } from '@121-service/src/registration/entities/registration-view.entity';
 import {
@@ -59,7 +61,15 @@ export class RegistrationsBulkService {
     private readonly registrationDataScopedRepository: RegistrationDataScopedRepository,
     @Inject(getScopedRepositoryProviderName(NoteEntity))
     private readonly noteScopedRepository: ScopedRepository<NoteEntity>,
+    @Inject(getScopedRepositoryProviderName(TransactionEntity))
+    private readonly transactionScopedRepository: ScopedRepository<TransactionEntity>,
   ) {}
+
+  // Only these target statuses can affect registrations with a payment pending approval
+  private static readonly statusesRequiringPendingApprovalCheck = [
+    RegistrationStatusEnum.declined,
+    RegistrationStatusEnum.paused,
+  ];
 
   public async updateRegistrationStatusOrDryRun({
     paginateQuery,
@@ -81,11 +91,26 @@ export class RegistrationsBulkService {
     const allowedCurrentStatuses =
       this.getAllowedCurrentStatusesForNewStatus(registrationStatus);
 
-    const resultDto = await this.getBulkActionResult(
+    const bulkActionResult = await this.getBulkActionResult(
       paginateQuery,
       programId,
       this.getStatusUpdateBaseQuery(allowedCurrentStatuses, registrationStatus),
     );
+
+    const pendingApprovalCount = await this.getPendingApprovalCountIfApplicable(
+      {
+        registrationStatus,
+        allowedCurrentStatuses,
+        paginateQuery,
+        programId,
+      },
+    );
+
+    const resultDto =
+      pendingApprovalCount === undefined
+        ? bulkActionResult
+        : { ...bulkActionResult, pendingApprovalCount };
+
     if (!dryRun) {
       this.applyRegistrationStatusUpdate({
         paginateQuery,
@@ -131,6 +156,7 @@ export class RegistrationsBulkService {
       programId,
       this.getStatusUpdateBaseQuery(allowedCurrentStatuses),
     );
+
     if (!dryRun) {
       this.deleteBatch({
         paginateQuery,
@@ -500,6 +526,68 @@ export class RegistrationsBulkService {
       });
 
     return data.map((r) => r.referenceId);
+  }
+
+  // Only computed for status changes that can affect registrations with a payment pending approval
+  private async getPendingApprovalCountIfApplicable({
+    registrationStatus,
+    allowedCurrentStatuses,
+    paginateQuery,
+    programId,
+  }: {
+    registrationStatus: RegistrationStatusEnum;
+    allowedCurrentStatuses: RegistrationStatusEnum[];
+    paginateQuery: PaginateQuery;
+    programId: number;
+  }): Promise<number | undefined> {
+    if (
+      !RegistrationsBulkService.statusesRequiringPendingApprovalCheck.includes(
+        registrationStatus,
+      )
+    ) {
+      return undefined;
+    }
+
+    // Clone the query so mutating `.select` here does not affect the caller's later use of paginateQuery
+    const applicableReferenceIds =
+      await this.getReferenceIdsForWhichStatusChangeIsApplicable(
+        programId,
+        allowedCurrentStatuses,
+        registrationStatus,
+        { ...paginateQuery },
+      );
+
+    return await this.getPendingApprovalCount({
+      referenceIds: applicableReferenceIds,
+      programId,
+    });
+  }
+
+  private async getPendingApprovalCount({
+    referenceIds,
+    programId,
+  }: {
+    referenceIds: string[];
+    programId: number;
+  }): Promise<number> {
+    if (referenceIds.length === 0) {
+      return 0;
+    }
+
+    const result = await this.transactionScopedRepository
+      .createQueryBuilder('transaction')
+      .leftJoin('transaction.registration', 'registration')
+      .andWhere('registration."programId" = :programId', { programId })
+      .andWhere('registration."referenceId" IN (:...referenceIds)', {
+        referenceIds,
+      })
+      .andWhere('transaction.status = :status', {
+        status: TransactionStatusEnum.pendingApproval,
+      })
+      .select('COUNT(DISTINCT transaction."registrationId")', 'count')
+      .getRawOne<{ count: string }>();
+
+    return Number(result?.count ?? 0);
   }
 
   private async updateRegistrationStatusPerChunk({

--- a/services/121-service/src/utils/test-helpers/createQueryBuilderMock.helper.ts
+++ b/services/121-service/src/utils/test-helpers/createQueryBuilderMock.helper.ts
@@ -6,13 +6,14 @@ interface QueryBuilderMock {
   leftJoin: () => QueryBuilderMock;
   getMany?: () => any;
   getRawMany?: () => any;
+  getRawOne?: () => any;
   distinct?: () => QueryBuilderMock;
   orderBy?: () => QueryBuilderMock;
 }
 
 export function generateMockCreateQueryBuilder(
-  dbQueryResult?: any[] | null,
-  options: { useGetMany?: boolean } = {},
+  dbQueryResult?: any,
+  options: { useGetMany?: boolean; useGetRawOne?: boolean } = {},
 ): QueryBuilderMock {
   const mock: QueryBuilderMock = {
     select: () => mock,
@@ -26,6 +27,8 @@ export function generateMockCreateQueryBuilder(
 
   if (options.useGetMany) {
     mock.getMany = () => dbQueryResult;
+  } else if (options.useGetRawOne) {
+    mock.getRawOne = () => dbQueryResult;
   } else {
     mock.getRawMany = () => dbQueryResult;
   }


### PR DESCRIPTION
[AB#43906](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43906)

## Describe your changes

BE changes for registration pauze/decline warning modal

## Checklist before requesting a code review

- [ ] I have performed a self-review of my code
- [ ] I have addressed all Copilot comments
- [ ] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [ ] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [ ] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [ ] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [ ] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
