### PR TITLE
[FE] Registration pauze/decline warning modal

### DIFF
--- a/interfaces/portal/src/app/domains/registration/registration.helper.ts
+++ b/interfaces/portal/src/app/domains/registration/registration.helper.ts
@@ -17,6 +17,67 @@ export const REGISTRATION_STATUS_LABELS: Record<
   [RegistrationStatusEnum.paused]: $localize`:@@registration-status-paused:Paused`,
 };
 
+export const getRegistrationUpdateDialogSubmitLabel = ({
+  status,
+  count,
+}: {
+  status: RegistrationStatusEnum | undefined;
+  count: number | undefined;
+}): string => {
+  switch (status) {
+    case RegistrationStatusEnum.included:
+      return count === 1
+        ? $localize`:@@registration-status-dialog-submit-button-labels-include:Include registration`
+        : $localize`:@@registration-status-dialog-submit-button-labels-include:Include registrations`;
+    case RegistrationStatusEnum.declined:
+      return count === 1
+        ? $localize`:@@registration-status-dialog-submit-button-labels-decline:Decline registration`
+        : $localize`:@@registration-status-dialog-submit-button-labels-decline:Decline registrations`;
+    case RegistrationStatusEnum.validated:
+      return count === 1
+        ? $localize`:@@registration-status-dialog-submit-button-labels-validate:Validate registration`
+        : $localize`:@@registration-status-dialog-submit-button-labels-validate:Validate registrations`;
+    case RegistrationStatusEnum.deleted:
+      return count === 1
+        ? $localize`:@@registration-status-dialog-submit-button-labels-delete:Delete registration`
+        : $localize`:@@registration-status-dialog-submit-button-labels-delete:Delete registrations`;
+    case RegistrationStatusEnum.paused:
+      return count === 1
+        ? $localize`:@@registration-status-dialog-submit-button-labels-pause:Pause registration`
+        : $localize`:@@registration-status-dialog-submit-button-labels-pause:Pause registrations`;
+    default:
+      return $localize`:@@generic-approve:Approve`;
+  }
+};
+
+export const getChangeStatusWarningMessage = ({
+  status,
+}: {
+  status: RegistrationStatusEnum | undefined;
+}): string => {
+  switch (status) {
+    case RegistrationStatusEnum.validated:
+      return $localize`:@@change-status-validate-warning:The action "Validate" can only be applied to registrations with the "New" status.`;
+    case RegistrationStatusEnum.included:
+      return $localize`:@@change-status-include-warning:The action "Include" can only be applied to registrations that do not have status "Included" and whose “Payments left” is larger than 0.`;
+    case RegistrationStatusEnum.paused:
+      return $localize`:@@change-status-pause-warning:The action "Pause" can only be applied to registrations with the "Included" status.`;
+    case RegistrationStatusEnum.declined:
+      return $localize`:@@change-status-decline-warning:The action "Decline" can not be applied to registrations with the "Declined" or "Completed" status.`;
+    case RegistrationStatusEnum.deleted:
+      return $localize`:@@change-status-delete-warning:The action "Delete" can not be applied to registrations with the "Completed" status.`;
+    default:
+      return $localize`:@@change-status-default-warning:This action can not be applied to registrations you have selected.`;
+  }
+};
+
+export const REGISTRATION_STATUS_PENDING_APPROVAL_EXPLANATION: Partial<
+  Record<RegistrationStatusEnum, string>
+> = {
+  [RegistrationStatusEnum.declined]: $localize`:@@change-status-declined-pending-approval-explanation:Declining a registration included in a payment will exclude them from that payment. To ensure they still receive their transfer, cancel this action and decline them after payment.`,
+  [RegistrationStatusEnum.paused]: $localize`:@@change-status-paused-pending-approval-explanation:Pausing a registration that’s included in a payment will result in a failed transfer. If you include them in the future, you’ll be able to retry the failed payment.`,
+};
+
 export const REGISTRATION_STATUS_ICON: Record<RegistrationStatusEnum, string> =
   {
     [RegistrationStatusEnum.new]: '',

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.html
@@ -58,5 +58,6 @@
   <app-change-status-submit-buttons
     [isMutating]="isMutating()"
     (cancelClick)="cancelClick()"
+    [submitButtonText]="submitButtonText()"
   />
 }

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-custom-message/change-status-contents-with-custom-message.component.ts
@@ -42,6 +42,7 @@ export class ChangeStatusContentsWithCustomMessageComponent implements OnInit {
   readonly isMutating = input(false);
   readonly cancelChangeStatus = output();
   readonly customMessageUpdated = output<string>();
+  readonly submitButtonText = input<string | undefined>();
 
   formGroup = new FormGroup({
     customMessage: new FormControl<string | undefined>(

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-templated-message/change-status-contents-with-templated-message.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-templated-message/change-status-contents-with-templated-message.component.html
@@ -12,6 +12,7 @@
   ></app-custom-message-preview>
 }
 <app-change-status-submit-buttons
+  [submitButtonText]="submitButtonText()"
   [isMutating]="isMutating()"
   (cancelClick)="cancelClick()"
 />

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-templated-message/change-status-contents-with-templated-message.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-with-templated-message/change-status-contents-with-templated-message.component.ts
@@ -30,6 +30,7 @@ export class ChangeStatusContentsWithTemplatedMessageComponent {
   readonly enableSendMessage = input.required<boolean>();
   readonly isMutating = input(false);
   readonly cancelChangeStatus = output();
+  readonly submitButtonText = input<string | undefined>();
 
   cancelClick() {
     this.cancelChangeStatus.emit();

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-without-message/change-status-contents-without-message.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-without-message/change-status-contents-without-message.component.html
@@ -20,5 +20,6 @@
     [isMutating]="isMutating()"
     (cancelClick)="cancelClick()"
     (approveClick)="validateFormGroupOrPreventSubmit($event)"
+    [submitButtonText]="submitButtonText()"
   />
 </div>

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-without-message/change-status-contents-without-message.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-contents-without-message/change-status-contents-without-message.component.ts
@@ -15,6 +15,8 @@ import {
 import { ButtonModule } from 'primeng/button';
 import { CheckboxModule } from 'primeng/checkbox';
 
+import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
+
 import { FormErrorComponent } from '~/components/form-error/form-error.component';
 import { ChangeStatusSubmitButtonsComponent } from '~/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component';
 import { generateFieldErrors } from '~/utils/form-validation';
@@ -37,6 +39,8 @@ export class ChangeStatusContentsWithoutMessageComponent {
   readonly isMutating = input(false);
   readonly cancelChangeStatus = output();
   readonly confirmChangeStatus = output();
+  readonly status = input<RegistrationStatusEnum | undefined>();
+  readonly submitButtonText = input<string | undefined>();
 
   formGroup = new FormGroup({
     confirmAction: new FormControl(false, {

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.html
@@ -3,6 +3,7 @@
   [closeOnEscape]="false"
   styleClass="md:min-inline-184"
   [(visible)]="dialogVisible"
+  data-testid="change-status-dialog"
   [modal]="true"
 >
   <ng-template pTemplate="header">
@@ -71,6 +72,7 @@
           (confirmChangeStatus)="onFormSubmit()"
           [showAreYouSureCheckbox]="status() === RegistrationStatusEnum.deleted"
           [isMutating]="changeStatusMutation.isPending()"
+          [submitButtonText]="submitButtonText()"
         />
       } @else {
         @if (messageTemplateKey.isLoading()) {
@@ -100,6 +102,7 @@
               [previewRegistration]="actionData()?.previewItem"
               [isMutating]="changeStatusMutation.isPending()"
               (cancelChangeStatus)="onChangeStatusCancel()"
+              [submitButtonText]="submitButtonText()"
             />
           } @else {
             <app-change-status-contents-with-custom-message
@@ -109,6 +112,7 @@
               [isMutating]="changeStatusMutation.isPending()"
               (cancelChangeStatus)="onChangeStatusCancel()"
               (customMessageUpdated)="customMessage.set($event)"
+              [submitButtonText]="submitButtonText()"
             />
           }
         }
@@ -116,7 +120,9 @@
     </div>
   </form>
 </p-dialog>
+
 <app-form-dialog
+  data-testid="change-status-dry-run-warning-dialog"
   #dryRunWarningDialog
   header="Warning"
   i18n-header="@@generic-warning"
@@ -129,27 +135,28 @@
     dryRun: false,
   }"
 >
-  <b i18n
-    >There are
-    {{ changeStatusMutation.data()?.nonApplicableCount }}
-    registration(s) that don't support this action</b
-  >
-  <p class="pbs-2">
-    {{ changeStatusWarningMessage() }}
-  </p>
-  <p
-    class="pbs-2"
-    i18n
-  >
-    Registrations that do not support this action will remain in their current
-    status.
-  </p>
+  @let dryRunData = changeStatusMutation.data();
+
+  @if (dryRunData && (dryRunData.pendingApprovalCount ?? 0) > 0) {
+    <p>
+      <strong i18n>
+        You're about to {{ statusVerb() | lowercase }}
+        {{ dryRunData.pendingApprovalCount }} registration(s) that are included
+        in a payment that's waiting for approval.
+      </strong>
+    </p>
+
+    @if (pendingApprovalExplanation(); as explanation) {
+      <p>{{ explanation }}</p>
+    }
+  }
+
   <p
     i18n
     class="pbs-2"
   >
     Would you like to proceed with
-    {{ changeStatusMutation.data()?.applicableCount }}
+    {{ dryRunData?.applicableCount }}
     registration(s)?
   </p>
 </app-form-dialog>

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-dialog/change-status-dialog.component.ts
@@ -28,8 +28,11 @@ import { FormDialogComponent } from '~/components/form-dialog/form-dialog.compon
 import { FormErrorComponent } from '~/components/form-error/form-error.component';
 import { RegistrationApiService } from '~/domains/registration/registration.api.service';
 import {
+  getChangeStatusWarningMessage,
+  getRegistrationUpdateDialogSubmitLabel,
   REGISTRATION_STATUS_ICON,
   REGISTRATION_STATUS_LABELS,
+  REGISTRATION_STATUS_PENDING_APPROVAL_EXPLANATION,
   REGISTRATION_STATUS_VERB,
 } from '~/domains/registration/registration.helper';
 import { Registration } from '~/domains/registration/registration.model';
@@ -103,6 +106,7 @@ export class ChangeStatusDialogComponent implements IActionDataHandler<Registrat
     }
     return REGISTRATION_STATUS_ICON[status];
   });
+
   readonly statusLabel = computed(() => {
     const status = this.status();
     if (!status) {
@@ -110,6 +114,7 @@ export class ChangeStatusDialogComponent implements IActionDataHandler<Registrat
     }
     return REGISTRATION_STATUS_LABELS[status];
   });
+
   readonly statusVerb = computed(() => {
     const status = this.status();
     if (!status) {
@@ -117,22 +122,26 @@ export class ChangeStatusDialogComponent implements IActionDataHandler<Registrat
     }
     return REGISTRATION_STATUS_VERB[status];
   });
-  readonly changeStatusWarningMessage = computed(() => {
-    switch (this.status()) {
-      case RegistrationStatusEnum.validated:
-        return $localize`:@@change-status-validate-warning:The action "Validate" can only be applied to registrations with the "New" status.`;
-      case RegistrationStatusEnum.included:
-        return $localize`:@@change-status-include-warning:The action "Include" can only be applied to registrations that do not have status "Included" and whose “Payments left” is larger than 0.`;
-      case RegistrationStatusEnum.paused:
-        return $localize`:@@change-status-pause-warning:The action "Pause" can only be applied to registrations with the "Included" status.`;
-      case RegistrationStatusEnum.declined:
-        return $localize`:@@change-status-decline-warning:The action "Decline" can not be applied to registrations with the "Declined" or "Completed" status.`;
-      case RegistrationStatusEnum.deleted:
-        return $localize`:@@change-status-delete-warning:The action "Delete" can not be applied to registrations with the "Completed" status.`;
-      default:
-        return $localize`:@@change-status-default-warning:This action can not be applied to registrations you have selected.`;
+
+  readonly pendingApprovalExplanation = computed(() => {
+    const status = this.status();
+    if (!status) {
+      return undefined;
     }
+    return REGISTRATION_STATUS_PENDING_APPROVAL_EXPLANATION[status];
   });
+
+  readonly submitButtonText = computed(() => {
+    return getRegistrationUpdateDialogSubmitLabel({
+      status: this.status(),
+      count: this.changeStatusMutation.data()?.applicableCount,
+    });
+  });
+
+  readonly changeStatusWarningMessage = computed(() => {
+    return getChangeStatusWarningMessage({ status: this.status() });
+  });
+
   readonly canSendMessage = computed(() => {
     const status = this.status();
     if (!status) {
@@ -213,8 +222,12 @@ export class ChangeStatusDialogComponent implements IActionDataHandler<Registrat
       invalidateCacheAgainAfterDelay: 500,
     },
     onSuccess: (data, variables) => {
-      if (data.nonApplicableCount === 0) {
-        // case #1: the change can be applied to all registrations
+      // Registrations with a pending-approval payment also need explicit confirmation, not just non-applicable ones
+      const needsConfirmation =
+        data.nonApplicableCount > 0 || (data.pendingApprovalCount ?? 0) > 0;
+
+      if (!needsConfirmation) {
+        // case #1: the change can be applied to all registrations, without any pending-approval payments
         if (variables.dryRun) {
           this.changeStatusMutation.mutate({ dryRun: false });
           return;
@@ -237,7 +250,7 @@ export class ChangeStatusDialogComponent implements IActionDataHandler<Registrat
         return;
       }
 
-      // case #3: the change can be applied to only some of the registrations
+      // case #3: some registrations are non-applicable and/or have a payment pending approval
       this.dialogVisible.set(false);
       this.dryRunWarningDialog().show({
         resetMutation: false,

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.html
@@ -9,8 +9,7 @@
     (click)="cancelClick.emit()"
   />
   <p-button
-    label="Approve"
-    i18n-label="@@generic-approve"
+    [label]="submitButtonText()"
     rounded
     [disabled]="isMutating()"
     [loading]="isMutating()"

--- a/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.ts
+++ b/interfaces/portal/src/app/pages/program-registrations/components/change-status-submit-buttons/change-status-submit-buttons.component.ts
@@ -7,6 +7,8 @@ import {
 
 import { ButtonModule } from 'primeng/button';
 
+import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
+
 @Component({
   selector: 'app-change-status-submit-buttons',
   imports: [ButtonModule],
@@ -18,4 +20,6 @@ export class ChangeStatusSubmitButtonsComponent {
   readonly isMutating = input(false);
   readonly cancelClick = output();
   readonly approveClick = output<MouseEvent>();
+  readonly status = input<RegistrationStatusEnum | undefined>();
+  readonly submitButtonText = input<string | undefined>();
 }

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -816,7 +816,7 @@
         <source>Amount sent per payment</source>
       </trans-unit>
       <trans-unit id="428968768517674095" datatype="html">
-        <source>Would you like to proceed with <x equiv-text="{{ changeStatusMutation.data()?.applicableCount }}" id="INTERPOLATION"/> registration(s)?</source>
+        <source>Would you like to proceed with <x equiv-text="{{ dryRunData?.applicableCount }}" id="INTERPOLATION"/> registration(s)?</source>
       </trans-unit>
       <trans-unit id="4309697217076303455" datatype="html">
         <source><x equiv-text="paymentCount.toString()" id="count"/> (out of <x equiv-text="maxPayments.toString()" id="totalCount"/>)</source>
@@ -983,6 +983,9 @@
       <trans-unit id="5004550577313573215" datatype="html">
         <source>Total amount</source>
       </trans-unit>
+      <trans-unit id="501769714612198671" datatype="html">
+        <source>You&apos;re about to <x equiv-text="{{ statusVerb() | lowercase }}" id="INTERPOLATION"/> <x equiv-text="{{ dryRunData.pendingApprovalCount }}" id="INTERPOLATION_1"/> registration(s) that are included in a payment that&apos;s waiting for approval.</source>
+      </trans-unit>
       <trans-unit id="5028251453651641459" datatype="html">
         <source>Update the relevant details in the next steps, then link a registration form to complete the setup.</source>
       </trans-unit>
@@ -1141,9 +1144,6 @@
       </trans-unit>
       <trans-unit id="5595826100350402634" datatype="html">
         <source>Use the arrow keys or W A S D to play the game</source>
-      </trans-unit>
-      <trans-unit id="561353031255604069" datatype="html">
-        <source>There are <x equiv-text="{{ changeStatusMutation.data()?.nonApplicableCount }}" id="INTERPOLATION"/> registration(s) that don&apos;t support this action</source>
       </trans-unit>
       <trans-unit id="5641945527911431559" datatype="html">
         <source>Error: <x equiv-text="{{ versionInfo.error()?.message }}" id="INTERPOLATION"/></source>
@@ -1851,9 +1851,6 @@
       <trans-unit id="8733206904097373941" datatype="html">
         <source>This will download an Excel file with all unused voucher(s).</source>
       </trans-unit>
-      <trans-unit id="8735352957921555136" datatype="html">
-        <source>Registrations that do not support this action will remain in their current status.</source>
-      </trans-unit>
       <trans-unit id="8747826357702572054" datatype="html">
         <source>Financial service providers:</source>
       </trans-unit>
@@ -2058,6 +2055,9 @@
       <trans-unit id="change-status-decline-warning" datatype="html">
         <source>The action &quot;Decline&quot; can not be applied to registrations with the &quot;Declined&quot; or &quot;Completed&quot; status.</source>
       </trans-unit>
+      <trans-unit id="change-status-declined-pending-approval-explanation" datatype="html">
+        <source>Declining a registration included in a payment will exclude them from that payment. To ensure they still receive their transfer, cancel this action and decline them after payment.</source>
+      </trans-unit>
       <trans-unit id="change-status-default-warning" datatype="html">
         <source>This action can not be applied to registrations you have selected.</source>
       </trans-unit>
@@ -2069,6 +2069,9 @@
       </trans-unit>
       <trans-unit id="change-status-pause-warning" datatype="html">
         <source>The action &quot;Pause&quot; can only be applied to registrations with the &quot;Included&quot; status.</source>
+      </trans-unit>
+      <trans-unit id="change-status-paused-pending-approval-explanation" datatype="html">
+        <source>Pausing a registration that’s included in a payment will result in a failed transfer. If you include them in the future, you’ll be able to retry the failed payment.</source>
       </trans-unit>
       <trans-unit id="change-status-validate-warning" datatype="html">
         <source>The action &quot;Validate&quot; can only be applied to registrations with the &quot;New&quot; status.</source>
@@ -2666,6 +2669,21 @@
       </trans-unit>
       <trans-unit id="registration-status-deleted" datatype="html">
         <source>Deleted</source>
+      </trans-unit>
+      <trans-unit id="registration-status-dialog-submit-button-labels-decline" datatype="html">
+        <source>Decline registration</source>
+      </trans-unit>
+      <trans-unit id="registration-status-dialog-submit-button-labels-delete" datatype="html">
+        <source>Delete registration</source>
+      </trans-unit>
+      <trans-unit id="registration-status-dialog-submit-button-labels-include" datatype="html">
+        <source>Include registration</source>
+      </trans-unit>
+      <trans-unit id="registration-status-dialog-submit-button-labels-pause" datatype="html">
+        <source>Pause registration</source>
+      </trans-unit>
+      <trans-unit id="registration-status-dialog-submit-button-labels-validate" datatype="html">
+        <source>Validate registration</source>
       </trans-unit>
       <trans-unit id="registration-status-included" datatype="html">
         <source>Included</source>


### PR DESCRIPTION
[AB#43905](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43905) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

FE for registration pauze/decline warning modal

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [ ] I have addressed all Copilot comments
- [ ] I have asked the design team to review these changes
- [x] Adding tests will be in seperate PR
- [ ] I have made sure that all automated checks pass before requesting a review

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8671.westeurope.3.azurestaticapps.net
