### PR TITLE
[E2E] Registration pauze/decline warning modal

### DIFF
--- a/e2e/portal/components/TableComponent.ts
+++ b/e2e/portal/components/TableComponent.ts
@@ -418,7 +418,7 @@ class TableComponent {
     await checkbox.click();
   }
 
-  async changeRegistrationStatusByNameWithOptions({
+  async changeRegistrationStatusByNamesWithOptions({
     registrationNames,
     status,
     sendMessage = false,

--- a/e2e/portal/components/TableComponent.ts
+++ b/e2e/portal/components/TableComponent.ts
@@ -419,15 +419,16 @@ class TableComponent {
   }
 
   async changeRegistrationStatusByNameWithOptions({
-    registrationName,
+    registrationNames,
     status,
     sendMessage = false,
     sendCustomMessage = false,
     sendTemplatedMessage = false,
     customMessage,
   }: {
-    registrationName: string;
-    status: string;
+    registrationNames: string[];
+    status:
+      'Pause' | 'Decline' | 'Delete' | 'Include' | 'Validate' | 'Complete';
     sendMessage?: boolean;
     sendCustomMessage?: boolean;
     sendTemplatedMessage?: boolean;
@@ -436,7 +437,10 @@ class TableComponent {
     const statusButton = this.page.getByRole('button', { name: status });
     const reasonField = this.page.getByPlaceholder('Enter reason');
 
-    await this.selectRowByTextContent(registrationName);
+    for (const registrationName of registrationNames) {
+      await this.selectRowByTextContent(registrationName);
+    }
+
     await statusButton.click();
 
     // Check for delete confirmation

--- a/e2e/portal/pages/PaymentPage.ts
+++ b/e2e/portal/pages/PaymentPage.ts
@@ -159,24 +159,17 @@ class PaymentPage extends BasePage {
 
   async validateBadgeIsPresentByLabel({
     badgeName,
-    isVisible = true,
     count,
   }: {
     badgeName: string;
-    isVisible?: boolean;
-    count?: number;
+    count: number;
   }) {
     const badge = this.page.locator('app-colored-chip').getByLabel(badgeName);
-    const allBadges = await badge.all();
-    const badgeCount = allBadges.length;
 
-    if (isVisible) {
-      for (const badgeElement of allBadges) {
-        await expect(badgeElement).toBeVisible();
-      }
-      expect(badgeCount).toBe(count);
-    } else {
-      await expect(badge).toBeHidden();
+    await expect(badge).toHaveCount(count);
+
+    for (const badgeElement of await badge.all()) {
+      await expect(badgeElement).toBeVisible();
     }
   }
 

--- a/e2e/portal/pages/PaymentPage.ts
+++ b/e2e/portal/pages/PaymentPage.ts
@@ -159,11 +159,11 @@ class PaymentPage extends BasePage {
 
   async validateBadgeIsPresentByLabel({
     badgeName,
-    isVisible,
+    isVisible = true,
     count,
   }: {
     badgeName: string;
-    isVisible: boolean;
+    isVisible?: boolean;
     count?: number;
   }) {
     const badge = this.page.locator('app-colored-chip').getByLabel(badgeName);

--- a/e2e/portal/pages/PaymentsPage.ts
+++ b/e2e/portal/pages/PaymentsPage.ts
@@ -101,25 +101,40 @@ class PaymentsPage extends BasePage {
     name,
     note,
     onlyStep1 = false,
+    names,
   }: {
     name?: string;
     note?: string;
     onlyStep1?: boolean;
+    names?: string[];
   }) {
     await this.createNewPaymentButton.click();
+
     if (name !== undefined) {
       await this.paymentNameInput.clear();
       await this.paymentNameInput.fill(name);
     }
+
     await this.continueToRegistrationButton.click();
-    await this.selectAllRegistrations();
+
+    if (names) {
+      for (const registrationName of names) {
+        await this.table.selectRowByName(registrationName);
+      }
+    } else {
+      await this.selectAllRegistrations();
+    }
+
     await this.addToPaymentButton.click();
+
     if (onlyStep1) {
       return;
     }
+
     if (note) {
       await this.addPaymentNote(note);
     }
+
     await this.createPaymentButton.click();
   }
 

--- a/e2e/portal/pages/PaymentsPage.ts
+++ b/e2e/portal/pages/PaymentsPage.ts
@@ -101,12 +101,12 @@ class PaymentsPage extends BasePage {
     name,
     note,
     onlyStep1 = false,
-    names,
+    includeRegistrationsByNames,
   }: {
     name?: string;
     note?: string;
     onlyStep1?: boolean;
-    names?: string[];
+    includeRegistrationsByNames?: string[];
   }) {
     await this.createNewPaymentButton.click();
 
@@ -117,8 +117,8 @@ class PaymentsPage extends BasePage {
 
     await this.continueToRegistrationButton.click();
 
-    if (names) {
-      for (const registrationName of names) {
+    if (includeRegistrationsByNames) {
+      for (const registrationName of includeRegistrationsByNames) {
         await this.table.selectRowByName(registrationName);
       }
     } else {

--- a/e2e/portal/pages/RegistrationsPage.ts
+++ b/e2e/portal/pages/RegistrationsPage.ts
@@ -431,6 +431,27 @@ class RegistrationsPage extends BasePage {
       timeout: 10000,
     });
   }
+
+  async validateStatusChangeWarningModal({
+    warningMessage,
+    proceedMessage,
+    submit,
+  }: {
+    warningMessage: string;
+    proceedMessage: string;
+    submit?: boolean;
+  }) {
+    const modal = this.page.getByTestId('change-status-dry-run-warning-dialog');
+    await expect(modal).toBeVisible();
+    await expect(modal.getByText(warningMessage)).toBeVisible();
+    await expect(modal.getByText(proceedMessage)).toBeVisible();
+
+    if (submit) {
+      await modal
+        .getByTestId('change-status-dry-run-warning-dialog-submit')
+        .click();
+    }
+  }
 }
 
 export default RegistrationsPage;

--- a/e2e/portal/tests/ChangeRegistrationStatus/ChangeRegistrationStatusOfRegistrationsIncludedInPendingPayments.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/ChangeRegistrationStatusOfRegistrationsIncludedInPendingPayments.spec.ts
@@ -42,7 +42,7 @@ test('Pause registrations included in pending payments', async ({
   await test.step('Create a payment with 3 registrations', async () => {
     await page.goto(`/en-GB/program/${programIdOCW}/payments`);
     await paymentsPage.createPayment({
-      names: [
+      includeRegistrationsByNames: [
         registrations[0].fullName,
         registrations[1].fullName,
         registrations[2].fullName,
@@ -55,7 +55,7 @@ test('Pause registrations included in pending payments', async ({
   // Act
   await test.step('Pause 3 registrations, 2 included in a pending payment', async () => {
     await page.goto(`/en-GB/program/${programIdOCW}/registrations`);
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [
         registrations[1].fullName,
         registrations[2].fullName,
@@ -79,7 +79,7 @@ test('Pause registrations included in pending payments', async ({
     );
   });
 
-  await test.step('Validate payment table shows 2 registrations are declined', async () => {
+  await test.step('Validate payment table shows 2 registrations are pauzed', async () => {
     await page.goto(paymentUrl);
     await page.waitForURL((url) => url.pathname.startsWith(paymentUrl));
     await paymentPage.validatePaymentDetailsPageTitle();
@@ -111,7 +111,7 @@ test('Decline registrations included in pending payments', async ({
   await test.step('Create a payment with 3 registrations', async () => {
     await page.goto(`/en-GB/program/${programIdOCW}/payments`);
     await paymentsPage.createPayment({
-      names: [
+      includeRegistrationsByNames: [
         registrations[0].fullName,
         registrations[1].fullName,
         registrations[2].fullName,
@@ -125,7 +125,7 @@ test('Decline registrations included in pending payments', async ({
   // Act
   await test.step('Decline 3 registrations, 2 included in a pending payment', async () => {
     await page.goto(`/en-GB/program/${programIdOCW}/registrations`);
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [
         registrations[1].fullName,
         registrations[2].fullName,
@@ -149,7 +149,7 @@ test('Decline registrations included in pending payments', async ({
     );
   });
 
-  await test.step('Validate payment table shows 2 registrations are paused', async () => {
+  await test.step('Validate payment table shows 2 registrations are declined', async () => {
     await page.goto(paymentUrl);
     await page.waitForURL((url) => url.pathname.startsWith(paymentUrl));
     await paymentPage.validatePaymentDetailsPageTitle();

--- a/e2e/portal/tests/ChangeRegistrationStatus/ChangeRegistrationStatusOfRegistrationsIncludedInPendingPayments.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/ChangeRegistrationStatusOfRegistrationsIncludedInPendingPayments.spec.ts
@@ -1,0 +1,169 @@
+import { Fsps } from '@121-service/src/fsp-integrations/shared/enum/fsp-name.enum';
+import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
+import { RegistrationPreferredLanguage } from '@121-service/src/shared/enum/registration-preferred-language.enum';
+import { programIdOCW } from '@121-service/test/registrations/pagination/pagination-data';
+
+import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
+
+// I'd rather throw in fakerjs and create a general registration-generation fn() but this is it for now.
+const registrations = Array.from({ length: 4 }).map((_, i) => ({
+  referenceId: `63e62864557597e${i + 1}d`,
+  preferredLanguage: RegistrationPreferredLanguage.en,
+  paymentAmountMultiplier: 1,
+  fullName: ['Emma Smith', 'Liam Brown', 'Noah Taylor', 'Ava Jones'][i],
+  phoneNumber: `1415523666${i + 1}`,
+  programFspConfigurationName: Fsps.intersolveVisa,
+  whatsappPhoneNumber: `1415523888${i + 1}`,
+  addressStreet: 'Teststraat',
+  addressHouseNumber: `${i + 1}`,
+  addressHouseNumberAddition: '',
+  addressPostalCode: `123${i + 1}AB`,
+  addressCity: 'Stad',
+}));
+
+test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
+  await resetDBAndSeedRegistrations({
+    seedScript: SeedScript.nlrcMultiple,
+    programId: programIdOCW,
+    registrations,
+  });
+});
+
+test('Pause registrations included in pending payments', async ({
+  registrationsPage,
+  tableComponent,
+  paymentsPage,
+  paymentPage,
+  page,
+}) => {
+  const paymentUrl = `/en-GB/program/${programIdOCW}/payments/1`;
+
+  // Prepare
+  await test.step('Create a payment with 3 registrations', async () => {
+    await page.goto(`/en-GB/program/${programIdOCW}/payments`);
+    await paymentsPage.createPayment({
+      names: [
+        registrations[0].fullName,
+        registrations[1].fullName,
+        registrations[2].fullName,
+      ],
+    });
+    await page.waitForURL((url) => url.pathname.startsWith(paymentUrl));
+    await paymentPage.validatePaymentDetailsPageTitle();
+  });
+
+  // Act
+  await test.step('Pause 3 registrations, 2 included in a pending payment', async () => {
+    await page.goto(`/en-GB/program/${programIdOCW}/registrations`);
+    await tableComponent.changeRegistrationStatusByNameWithOptions({
+      registrationNames: [
+        registrations[1].fullName,
+        registrations[2].fullName,
+        registrations[3].fullName,
+      ],
+      status: 'Pause',
+    });
+  });
+
+  // Assert
+  await test.step('Validate warning modal is shown with correct numbers', async () => {
+    await registrationsPage.validateStatusChangeWarningModal({
+      warningMessage:
+        "You're about to pause 2 registration(s) that are included in a payment that's waiting for approval.",
+      proceedMessage: 'Would you like to proceed with 3 registration(s)?',
+      submit: true,
+    });
+
+    await registrationsPage.validateToastMessage(
+      `The status of 3 registration(s) is being changed to "Paused" successfully. The status change can take up to a minute to process.`,
+    );
+  });
+
+  await test.step('Validate payment table shows 2 registrations are declined', async () => {
+    await page.goto(paymentUrl);
+    await page.waitForURL((url) => url.pathname.startsWith(paymentUrl));
+    await paymentPage.validatePaymentDetailsPageTitle();
+
+    // NOTE: The payment table currently has no stable row identifiers (no registration name/id/referenceId),
+    // so this assertion relies on counting status chips on the page. This is not ideal, but it works for now.
+    await paymentPage.validateBadgeIsPresentByLabel({
+      badgeName: 'Paused',
+      count: 2,
+    });
+
+    await paymentPage.validateBadgeIsPresentByLabel({
+      badgeName: 'Included',
+      count: 1,
+    });
+  });
+});
+
+test('Decline registrations included in pending payments', async ({
+  registrationsPage,
+  tableComponent,
+  paymentsPage,
+  paymentPage,
+  page,
+}) => {
+  const paymentUrl = `/en-GB/program/${programIdOCW}/payments/1`;
+
+  // Prepare
+  await test.step('Create a payment with 3 registrations', async () => {
+    await page.goto(`/en-GB/program/${programIdOCW}/payments`);
+    await paymentsPage.createPayment({
+      names: [
+        registrations[0].fullName,
+        registrations[1].fullName,
+        registrations[2].fullName,
+      ],
+    });
+
+    await page.waitForURL((url) => url.pathname.startsWith(paymentUrl));
+    await paymentPage.validatePaymentDetailsPageTitle();
+  });
+
+  // Act
+  await test.step('Decline 3 registrations, 2 included in a pending payment', async () => {
+    await page.goto(`/en-GB/program/${programIdOCW}/registrations`);
+    await tableComponent.changeRegistrationStatusByNameWithOptions({
+      registrationNames: [
+        registrations[1].fullName,
+        registrations[2].fullName,
+        registrations[3].fullName,
+      ],
+      status: 'Decline',
+    });
+  });
+
+  // Assert
+  await test.step('Validate warning modal is shown with correct numbers', async () => {
+    await registrationsPage.validateStatusChangeWarningModal({
+      warningMessage:
+        "You're about to decline 2 registration(s) that are included in a payment that's waiting for approval.",
+      proceedMessage: 'Would you like to proceed with 3 registration(s)?',
+      submit: true,
+    });
+
+    await registrationsPage.validateToastMessage(
+      `The status of 3 registration(s) is being changed to "Declined" successfully. The status change can take up to a minute to process.`,
+    );
+  });
+
+  await test.step('Validate payment table shows 2 registrations are paused', async () => {
+    await page.goto(paymentUrl);
+    await page.waitForURL((url) => url.pathname.startsWith(paymentUrl));
+    await paymentPage.validatePaymentDetailsPageTitle();
+
+    // NOTE: The payment table currently has no stable row identifiers (no registration name/id/referenceId),
+    // so this assertion relies on counting status chips on the page.
+    await paymentPage.validateBadgeIsPresentByLabel({
+      badgeName: 'Declined',
+      count: 2,
+    });
+
+    await paymentPage.validateBadgeIsPresentByLabel({
+      badgeName: 'Included',
+      count: 1,
+    });
+  });
+});

--- a/e2e/portal/tests/ChangeRegistrationStatus/ChangeStatusWithCustomMessageCombination.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/ChangeStatusWithCustomMessageCombination.spec.ts
@@ -33,7 +33,7 @@ test.describe('Change status of registration with and without templated message'
   }) => {
     await test.step('Change status of first selected registration and write a custom message', async () => {
       await tableComponent.changeRegistrationStatusByNameWithOptions({
-        registrationName: registrationPV5.fullName,
+        registrationNames: [registrationPV5.fullName],
         status: 'Decline',
         sendMessage: true,
         sendCustomMessage: true,
@@ -60,7 +60,7 @@ test.describe('Change status of registration with and without templated message'
   }) => {
     await test.step('Change status of first selected registration and write a custom message', async () => {
       await tableComponent.changeRegistrationStatusByNameWithOptions({
-        registrationName: registrationPV6.fullName,
+        registrationNames: [registrationPV6.fullName],
         status: 'Decline',
         sendMessage: false,
       });

--- a/e2e/portal/tests/ChangeRegistrationStatus/ChangeStatusWithCustomMessageCombination.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/ChangeStatusWithCustomMessageCombination.spec.ts
@@ -32,7 +32,7 @@ test.describe('Change status of registration with and without templated message'
     tableComponent,
   }) => {
     await test.step('Change status of first selected registration and write a custom message', async () => {
-      await tableComponent.changeRegistrationStatusByNameWithOptions({
+      await tableComponent.changeRegistrationStatusByNamesWithOptions({
         registrationNames: [registrationPV5.fullName],
         status: 'Decline',
         sendMessage: true,
@@ -59,7 +59,7 @@ test.describe('Change status of registration with and without templated message'
     tableComponent,
   }) => {
     await test.step('Change status of first selected registration and write a custom message', async () => {
-      await tableComponent.changeRegistrationStatusByNameWithOptions({
+      await tableComponent.changeRegistrationStatusByNamesWithOptions({
         registrationNames: [registrationPV6.fullName],
         status: 'Decline',
         sendMessage: false,

--- a/e2e/portal/tests/ChangeRegistrationStatus/ChangeStatusWithTemplatedMessageCombination.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/ChangeStatusWithTemplatedMessageCombination.spec.ts
@@ -34,7 +34,7 @@ test.describe('Change status of registration with and without templated message'
   }) => {
     await test.step('Change status of first selected registration and send templated message', async () => {
       await tableComponent.changeRegistrationStatusByNameWithOptions({
-        registrationName: registrationPV5.fullName,
+        registrationNames: [registrationPV5.fullName],
         status: 'Include',
         sendMessage: true,
         sendTemplatedMessage: true,
@@ -61,7 +61,7 @@ test.describe('Change status of registration with and without templated message'
     // Act
     await test.step('Change status of first selected registration without templated message', async () => {
       await tableComponent.changeRegistrationStatusByNameWithOptions({
-        registrationName: registrationPV6.fullName,
+        registrationNames: [registrationPV6.fullName],
         status: 'Include',
         sendMessage: false,
       });

--- a/e2e/portal/tests/ChangeRegistrationStatus/ChangeStatusWithTemplatedMessageCombination.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/ChangeStatusWithTemplatedMessageCombination.spec.ts
@@ -33,7 +33,7 @@ test.describe('Change status of registration with and without templated message'
     tableComponent,
   }) => {
     await test.step('Change status of first selected registration and send templated message', async () => {
-      await tableComponent.changeRegistrationStatusByNameWithOptions({
+      await tableComponent.changeRegistrationStatusByNamesWithOptions({
         registrationNames: [registrationPV5.fullName],
         status: 'Include',
         sendMessage: true,
@@ -60,7 +60,7 @@ test.describe('Change status of registration with and without templated message'
   }) => {
     // Act
     await test.step('Change status of first selected registration without templated message', async () => {
-      await tableComponent.changeRegistrationStatusByNameWithOptions({
+      await tableComponent.changeRegistrationStatusByNamesWithOptions({
         registrationNames: [registrationPV6.fullName],
         status: 'Include',
         sendMessage: false,

--- a/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusCompleted.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusCompleted.spec.ts
@@ -36,7 +36,7 @@ test('Delete registration with status "Completed"', async ({
 }) => {
   // Act
   await test.step('Delete registration with status "Completed"', async () => {
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [registrationPvMaxPayment.fullName],
       status: 'Delete',
     });

--- a/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusCompleted.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusCompleted.spec.ts
@@ -37,7 +37,7 @@ test('Delete registration with status "Completed"', async ({
   // Act
   await test.step('Delete registration with status "Completed"', async () => {
     await tableComponent.changeRegistrationStatusByNameWithOptions({
-      registrationName: registrationPvMaxPayment.fullName,
+      registrationNames: [registrationPvMaxPayment.fullName],
       status: 'Delete',
     });
     await registrationsPage.validateToastMessageAndClose(toastMessage);

--- a/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusDeclined.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusDeclined.spec.ts
@@ -27,7 +27,7 @@ test('Delete registration with status "Declined"', async ({
   // Act
   await test.step('Delete registration with status "Declined"', async () => {
     await tableComponent.changeRegistrationStatusByNameWithOptions({
-      registrationName: registrationPV5.fullName,
+      registrationNames: [registrationPV5.fullName],
       status: 'Delete',
     });
     await registrationsPage.validateToastMessageAndClose(toastMessage);

--- a/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusDeclined.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusDeclined.spec.ts
@@ -26,7 +26,7 @@ test('Delete registration with status "Declined"', async ({
 }) => {
   // Act
   await test.step('Delete registration with status "Declined"', async () => {
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [registrationPV5.fullName],
       status: 'Delete',
     });

--- a/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusIncluded.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusIncluded.spec.ts
@@ -24,7 +24,7 @@ test('Delete registration with status "Included"', async ({
 }) => {
   // Act
   await test.step('Delete registration with status "Included"', async () => {
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [registrationPV5.fullName],
       status: 'Delete',
     });

--- a/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusIncluded.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusIncluded.spec.ts
@@ -25,7 +25,7 @@ test('Delete registration with status "Included"', async ({
   // Act
   await test.step('Delete registration with status "Included"', async () => {
     await tableComponent.changeRegistrationStatusByNameWithOptions({
-      registrationName: registrationPV5.fullName,
+      registrationNames: [registrationPV5.fullName],
       status: 'Delete',
     });
     await registrationsPage.validateToastMessageAndClose(toastMessage);

--- a/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusNew.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusNew.spec.ts
@@ -27,7 +27,7 @@ test('Delete registration with status "New"', async ({
   // Act
   await test.step('Delete registration with status "New"', async () => {
     await tableComponent.changeRegistrationStatusByNameWithOptions({
-      registrationName: registrationPV5.fullName,
+      registrationNames: [registrationPV5.fullName],
       status: 'Delete',
     });
     await registrationsPage.validateToastMessageAndClose(toastMessage);

--- a/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusNew.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusNew.spec.ts
@@ -26,7 +26,7 @@ test('Delete registration with status "New"', async ({
 }) => {
   // Act
   await test.step('Delete registration with status "New"', async () => {
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [registrationPV5.fullName],
       status: 'Delete',
     });

--- a/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusPaused.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusPaused.spec.ts
@@ -26,7 +26,7 @@ test('Delete registration with status "Paused"', async ({
 }) => {
   // Act
   await test.step('Delete registration with status "Paused"', async () => {
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [registrationPV5.fullName],
       status: 'Delete',
     });

--- a/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusPaused.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusPaused.spec.ts
@@ -27,7 +27,7 @@ test('Delete registration with status "Paused"', async ({
   // Act
   await test.step('Delete registration with status "Paused"', async () => {
     await tableComponent.changeRegistrationStatusByNameWithOptions({
-      registrationName: registrationPV5.fullName,
+      registrationNames: [registrationPV5.fullName],
       status: 'Delete',
     });
     await registrationsPage.validateToastMessageAndClose(toastMessage);

--- a/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusValidated.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusValidated.spec.ts
@@ -27,7 +27,7 @@ test('Delete registration with status "Validated"', async ({
   // Act
   await test.step('Delete registration with status "Validated"', async () => {
     await tableComponent.changeRegistrationStatusByNameWithOptions({
-      registrationName: registrationPV5.fullName,
+      registrationNames: [registrationPV5.fullName],
       status: 'Delete',
     });
     await registrationsPage.validateToastMessageAndClose(toastMessage);

--- a/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusValidated.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/DeleteRegistrationWithStatusValidated.spec.ts
@@ -26,7 +26,7 @@ test('Delete registration with status "Validated"', async ({
 }) => {
   // Act
   await test.step('Delete registration with status "Validated"', async () => {
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [registrationPV5.fullName],
       status: 'Delete',
     });

--- a/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromCompletedToDeclined.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromCompletedToDeclined.spec.ts
@@ -44,7 +44,7 @@ test('Move PA(s) from status "Completed" to "Declined"', async ({
   });
 
   await test.step('Change status of registration to "Declined"', async () => {
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [registrationPvMaxPayment.fullName],
       status: 'Decline',
     });

--- a/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromCompletedToDeclined.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromCompletedToDeclined.spec.ts
@@ -45,7 +45,7 @@ test('Move PA(s) from status "Completed" to "Declined"', async ({
 
   await test.step('Change status of registration to "Declined"', async () => {
     await tableComponent.changeRegistrationStatusByNameWithOptions({
-      registrationName: registrationPvMaxPayment.fullName,
+      registrationNames: [registrationPvMaxPayment.fullName],
       status: 'Decline',
     });
     await registrationsPage.validateToastMessageAndClose(toastMessage);

--- a/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromCompletedToIncluded.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromCompletedToIncluded.spec.ts
@@ -52,7 +52,7 @@ test('Move PA(s) from status "Completed" to "Included"', async ({
 
   await test.step('Change status of registration to "Included"', async () => {
     await tableComponent.changeRegistrationStatusByNameWithOptions({
-      registrationName: registrationPvMaxPayment.fullName,
+      registrationNames: [registrationPvMaxPayment.fullName],
       status: 'Include',
     });
     await registrationsPage.validateToastMessageAndClose(toastMessage);

--- a/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromCompletedToIncluded.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromCompletedToIncluded.spec.ts
@@ -51,7 +51,7 @@ test('Move PA(s) from status "Completed" to "Included"', async ({
   });
 
   await test.step('Change status of registration to "Included"', async () => {
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [registrationPvMaxPayment.fullName],
       status: 'Include',
     });

--- a/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromDeclinedToIncluded.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromDeclinedToIncluded.spec.ts
@@ -33,7 +33,7 @@ test('Move PA(s) from status "Declined" to "Included"', async ({
   });
 
   await test.step('Change status of first selected registration to "Included"', async () => {
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [registrationPV5.fullName],
       status: 'Include',
     });

--- a/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromDeclinedToIncluded.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromDeclinedToIncluded.spec.ts
@@ -34,7 +34,7 @@ test('Move PA(s) from status "Declined" to "Included"', async ({
 
   await test.step('Change status of first selected registration to "Included"', async () => {
     await tableComponent.changeRegistrationStatusByNameWithOptions({
-      registrationName: registrationPV5.fullName,
+      registrationNames: [registrationPV5.fullName],
       status: 'Include',
     });
     await registrationsPage.validateToastMessageAndClose(toastMessage);

--- a/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromIncludedToDeclined.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromIncludedToDeclined.spec.ts
@@ -27,7 +27,7 @@ test('Move PA(s) from status "Included" to "Declined"', async ({
   // Act
   await test.step('Change status of first selected registration to "Declined"', async () => {
     await tableComponent.changeRegistrationStatusByNameWithOptions({
-      registrationName: registrationPV5.fullName,
+      registrationNames: [registrationPV5.fullName],
       status: 'Decline',
     });
     await registrationsPage.validateToastMessageAndClose(toastMessage);

--- a/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromIncludedToDeclined.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromIncludedToDeclined.spec.ts
@@ -26,7 +26,7 @@ test('Move PA(s) from status "Included" to "Declined"', async ({
 }) => {
   // Act
   await test.step('Change status of first selected registration to "Declined"', async () => {
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [registrationPV5.fullName],
       status: 'Decline',
     });

--- a/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromIncludedToPaused.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromIncludedToPaused.spec.ts
@@ -27,7 +27,7 @@ test('Move PA(s) from status "Included" to "Paused"', async ({
   // Act
   await test.step('Change status of first selected registration to "Paused"', async () => {
     await tableComponent.changeRegistrationStatusByNameWithOptions({
-      registrationName: registrationPV5.fullName,
+      registrationNames: [registrationPV5.fullName],
       status: 'Pause',
     });
     await registrationsPage.validateToastMessageAndClose(toastMessage);

--- a/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromIncludedToPaused.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromIncludedToPaused.spec.ts
@@ -26,7 +26,7 @@ test('Move PA(s) from status "Included" to "Paused"', async ({
 }) => {
   // Act
   await test.step('Change status of first selected registration to "Paused"', async () => {
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [registrationPV5.fullName],
       status: 'Pause',
     });

--- a/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromNewToValidated.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromNewToValidated.spec.ts
@@ -26,7 +26,7 @@ test('Move PA(s) from status "New" to "Validated"', async ({
 }) => {
   // Act
   await test.step('Change status of first selected registration to "Validated"', async () => {
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [registrationPV5.fullName],
       status: 'Validate',
     });

--- a/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromNewToValidated.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/MovePasFromNewToValidated.spec.ts
@@ -27,7 +27,7 @@ test('Move PA(s) from status "New" to "Validated"', async ({
   // Act
   await test.step('Change status of first selected registration to "Validated"', async () => {
     await tableComponent.changeRegistrationStatusByNameWithOptions({
-      registrationName: registrationPV5.fullName,
+      registrationNames: [registrationPV5.fullName],
       status: 'Validate',
     });
     await registrationsPage.validateToastMessageAndClose(toastMessage);

--- a/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithCbe.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithCbe.spec.ts
@@ -55,6 +55,7 @@ test('Do successful payment for Cbe fsp', async ({
       url.pathname.startsWith(`/en-GB/program/${programIdCbe}/payments/1`),
     );
     // Assert payment overview page by payment date/ title
+    // @TODO: Does this really validate anything? I don't think checking if a H1 renders validates anything tbh
     await paymentPage.validatePaymentDetailsPageTitle();
   });
 

--- a/e2e/portal/tests/UpdateRegistrations/BulkUpdateVisibleInActivityLog.spec.ts
+++ b/e2e/portal/tests/UpdateRegistrations/BulkUpdateVisibleInActivityLog.spec.ts
@@ -27,7 +27,7 @@ test('Data should be updated according to selected columns and registrations', a
   await test.step('Select all registrations and open "Update registrations" dialog', async () => {
     // adding this extra step to ensure that deleted registrations are excluded from exports
     // for more info: AB#37336
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [registrationPV6.fullName],
       status: 'Delete',
       sendMessage: false,

--- a/e2e/portal/tests/UpdateRegistrations/BulkUpdateVisibleInActivityLog.spec.ts
+++ b/e2e/portal/tests/UpdateRegistrations/BulkUpdateVisibleInActivityLog.spec.ts
@@ -28,9 +28,9 @@ test('Data should be updated according to selected columns and registrations', a
     // adding this extra step to ensure that deleted registrations are excluded from exports
     // for more info: AB#37336
     await tableComponent.changeRegistrationStatusByNameWithOptions({
-      registrationName: registrationPV6.fullName,
-      sendMessage: false,
+      registrationNames: [registrationPV6.fullName],
       status: 'Delete',
+      sendMessage: false,
     });
     await registrationsPage.dismissToast();
 

--- a/e2e/portal/tests/ViewFilterAndSortRegistrations/FilterRegistrationsByDropdownSelection.spec.ts
+++ b/e2e/portal/tests/ViewFilterAndSortRegistrations/FilterRegistrationsByDropdownSelection.spec.ts
@@ -37,7 +37,7 @@ test('Filter registrations by dropdown selection', async ({
 
   await test.step('Update status and filter by "Paused" status', async () => {
     await tableComponent.changeRegistrationStatusByNameWithOptions({
-      registrationName: registrationsPV[0].fullName,
+      registrationNames: [registrationsPV[0].fullName],
       status: 'Pause',
     });
     await registrations.validateToastMessageAndClose(toastMessage);

--- a/e2e/portal/tests/ViewFilterAndSortRegistrations/FilterRegistrationsByDropdownSelection.spec.ts
+++ b/e2e/portal/tests/ViewFilterAndSortRegistrations/FilterRegistrationsByDropdownSelection.spec.ts
@@ -36,7 +36,7 @@ test('Filter registrations by dropdown selection', async ({
   });
 
   await test.step('Update status and filter by "Paused" status', async () => {
-    await tableComponent.changeRegistrationStatusByNameWithOptions({
+    await tableComponent.changeRegistrationStatusByNamesWithOptions({
       registrationNames: [registrationsPV[0].fullName],
       status: 'Pause',
     });

--- a/e2e/portal/tests/ViewPayment/PaymentInProgressVisible.spec.ts
+++ b/e2e/portal/tests/ViewPayment/PaymentInProgressVisible.spec.ts
@@ -38,7 +38,6 @@ test('Show in progress banner and chip when payment is in progress', async ({
   await test.step('Validate payment in progress in Payment overview', async () => {
     await paymentPage.validateBadgeIsPresentByLabel({
       badgeName: 'In progress',
-      isVisible: true,
       count: 1,
     });
   });

--- a/e2e/portal/tests/ViewPayment/ViewPaymentPageDuringPaymentPhases.spec.ts
+++ b/e2e/portal/tests/ViewPayment/ViewPaymentPageDuringPaymentPhases.spec.ts
@@ -205,7 +205,6 @@ test('Payment page should display correctly during all phases of payment with 2 
   await test.step('Validate payment-page in "Approved" state', async () => {
     await paymentPage.validateBadgeIsPresentByLabel({
       badgeName: approvedBadgeLabel,
-      isVisible: true,
       count: 9, // 1 top of the chart + 8 transactions
     });
     await paymentPage.validateGraphStatus({

--- a/e2e/portal/tests/ViewPayment/ViewPaymentPageDuringPaymentPhases.spec.ts
+++ b/e2e/portal/tests/ViewPayment/ViewPaymentPageDuringPaymentPhases.spec.ts
@@ -109,12 +109,10 @@ test('Payment page should display correctly during all phases of payment with 2 
   await test.step('Validate payment-page in "Pending approval" state', async () => {
     await paymentPage.validateBadgeIsPresentByLabel({
       badgeName: '0 of 2 approved',
-      isVisible: true,
       count: 1,
     });
     await paymentPage.validateBadgeIsPresentByLabel({
       badgeName: pendingApprovalTransactionLabel,
-      isVisible: true,
       count: 8, // 1 per transaction
     });
 
@@ -167,12 +165,10 @@ test('Payment page should display correctly during all phases of payment with 2 
   await test.step('Validate payment-page in between 2 approvals', async () => {
     await paymentPage.validateBadgeIsPresentByLabel({
       badgeName: '1 of 2 approved',
-      isVisible: true,
       count: 1,
     });
     await paymentPage.validateBadgeIsPresentByLabel({
       badgeName: pendingApprovalTransactionLabel,
-      isVisible: true,
       count: 8, // 1 per transaction
     });
 
@@ -265,12 +261,10 @@ test('Payment page should display correctly during all phases of payment with 2 
     // Validate 1 approved badge for payment and 8 successful badges for transactions
     await paymentPage.validateBadgeIsPresentByLabel({
       badgeName: approvedBadgeLabel,
-      isVisible: true,
       count: 1,
     });
     await paymentPage.validateBadgeIsPresentByLabel({
       badgeName: successfulBadgeLabel,
-      isVisible: true,
       count: registrationsCount,
     });
 

--- a/interfaces/portal/src/app/components/form-dialog/form-dialog.component.ts
+++ b/interfaces/portal/src/app/components/form-dialog/form-dialog.component.ts
@@ -44,7 +44,7 @@ export class FormDialogComponent<TMutationData = unknown> {
   readonly headerClass = input('');
   readonly headerIcon = input('pi pi-question');
 
-  // TODO: Why are these props called proceedX instead of submitX?
+  // Why are these props called proceedX instead of submitX?
   readonly proceedLabel = input($localize`:@@generic-proceed:Proceed`);
   readonly proceedIcon = input<string | undefined>(undefined);
 

--- a/services/121-service/src/registration/services/registrations-bulk.service.spec.ts
+++ b/services/121-service/src/registration/services/registrations-bulk.service.spec.ts
@@ -3,11 +3,13 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { MessageQueuesService } from '@121-service/src/notifications/message-queues/message-queues.service';
 import { MessageTemplateEntity } from '@121-service/src/notifications/message-template/message-template.entity';
+import { TransactionEntity } from '@121-service/src/payments/transactions/entities/transaction.entity';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { RegistrationViewScopedRepository } from '@121-service/src/registration/repositories/registration-view-scoped.repository';
 import { RegistrationsBulkService } from '@121-service/src/registration/services/registrations-bulk.service';
 import { RegistrationsPaginationService } from '@121-service/src/registration/services/registrations-pagination.service';
 import { RegistrationPreferredLanguage } from '@121-service/src/shared/enum/registration-preferred-language.enum';
+import { getScopedRepositoryProviderName } from '@121-service/src/utils/scope/createScopedRepositoryProvider.helper';
 import { generateMockCreateQueryBuilder } from '@121-service/src/utils/test-helpers/createQueryBuilderMock.helper';
 
 describe('RegistrationBulkService', () => {
@@ -113,6 +115,10 @@ describe('RegistrationBulkService', () => {
     jest
       .spyOn(queueMessageService as any, 'addMessageToQueue')
       .mockImplementation();
+
+    transactionScopedRepository = unitRef.get(
+      getScopedRepositoryProviderName(TransactionEntity),
+    );
   });
 
   it('should be defined', () => {

--- a/services/121-service/src/registration/services/registrations-bulk.service.spec.ts
+++ b/services/121-service/src/registration/services/registrations-bulk.service.spec.ts
@@ -3,13 +3,11 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { MessageQueuesService } from '@121-service/src/notifications/message-queues/message-queues.service';
 import { MessageTemplateEntity } from '@121-service/src/notifications/message-template/message-template.entity';
-import { TransactionEntity } from '@121-service/src/payments/transactions/entities/transaction.entity';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { RegistrationViewScopedRepository } from '@121-service/src/registration/repositories/registration-view-scoped.repository';
 import { RegistrationsBulkService } from '@121-service/src/registration/services/registrations-bulk.service';
 import { RegistrationsPaginationService } from '@121-service/src/registration/services/registrations-pagination.service';
 import { RegistrationPreferredLanguage } from '@121-service/src/shared/enum/registration-preferred-language.enum';
-import { getScopedRepositoryProviderName } from '@121-service/src/utils/scope/createScopedRepositoryProvider.helper';
 import { generateMockCreateQueryBuilder } from '@121-service/src/utils/test-helpers/createQueryBuilderMock.helper';
 
 describe('RegistrationBulkService', () => {
@@ -115,10 +113,6 @@ describe('RegistrationBulkService', () => {
     jest
       .spyOn(queueMessageService as any, 'addMessageToQueue')
       .mockImplementation();
-
-    transactionScopedRepository = unitRef.get(
-      getScopedRepositoryProviderName(TransactionEntity),
-    );
   });
 
   it('should be defined', () => {

--- a/services/121-service/src/registration/services/registrations-bulk.service.ts
+++ b/services/121-service/src/registration/services/registrations-bulk.service.ts
@@ -60,8 +60,6 @@ export class RegistrationsBulkService {
     private readonly registrationDataScopedRepository: RegistrationDataScopedRepository,
     @Inject(getScopedRepositoryProviderName(NoteEntity))
     private readonly noteScopedRepository: ScopedRepository<NoteEntity>,
-    @Inject(getScopedRepositoryProviderName(TransactionEntity))
-    private readonly transactionScopedRepository: ScopedRepository<TransactionEntity>,
   ) {}
 
   // Only these target statuses can affect registrations with a payment pending approval

--- a/services/121-service/src/registration/services/registrations-bulk.service.ts
+++ b/services/121-service/src/registration/services/registrations-bulk.service.ts
@@ -60,6 +60,8 @@ export class RegistrationsBulkService {
     private readonly registrationDataScopedRepository: RegistrationDataScopedRepository,
     @Inject(getScopedRepositoryProviderName(NoteEntity))
     private readonly noteScopedRepository: ScopedRepository<NoteEntity>,
+    @Inject(getScopedRepositoryProviderName(TransactionEntity))
+    private readonly transactionScopedRepository: ScopedRepository<TransactionEntity>,
   ) {}
 
   // Only these target statuses can affect registrations with a payment pending approval


### PR DESCRIPTION
[AB#43907](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/43907) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

E2E for registration pauze/decline warning modal

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] These are the tests for my changes
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not deviate from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8677.westeurope.3.azurestaticapps.net
