### PR TITLE
fix: Add more events to trigger CI (heavy) tests again

### DIFF
--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -11,10 +11,10 @@ on:
     types: [checks_requested]
   pull_request:
     types: # See: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request
-    - opened
-    - ready_for_review
-    - reopened
-    - synchronize
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_e2e_portal.yml
+++ b/.github/workflows/test_e2e_portal.yml
@@ -10,6 +10,11 @@ on:
   merge_group:
     types: [checks_requested]
   pull_request:
+    types: # See: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request
+    - opened
+    - ready_for_review
+    - reopened
+    - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_service_api.yml
+++ b/.github/workflows/test_service_api.yml
@@ -11,10 +11,10 @@ on:
     types: [checks_requested]
   pull_request:
     types: # See: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request
-    - opened
-    - ready_for_review
-    - reopened
-    - synchronize
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
   push:
     branches:
       - main

--- a/.github/workflows/test_service_api.yml
+++ b/.github/workflows/test_service_api.yml
@@ -10,6 +10,11 @@ on:
   merge_group:
     types: [checks_requested]
   pull_request:
+    types: # See: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request
+    - opened
+    - ready_for_review
+    - reopened
+    - synchronize
   push:
     branches:
       - main

--- a/.github/workflows/test_service_check_migrations.yml
+++ b/.github/workflows/test_service_check_migrations.yml
@@ -7,6 +7,11 @@ on:
   merge_group:
     types: [checks_requested]
   pull_request:
+    types: # See: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
     paths:
       - .github/workflows/test_service_check_migrations.yml
       - .github/actions/build-service/action.yml
@@ -33,6 +38,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/test_service_only_restart.yml
+++ b/.github/workflows/test_service_only_restart.yml
@@ -7,6 +7,11 @@ on:
   merge_group:
     types: [checks_requested]
   pull_request:
+    types: # See: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
     paths:
       - .github/workflows/test_service_only_restart.yml
       - .github/actions/build-service/action.yml
@@ -33,6 +38,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
     steps:
       - name: Check out repository code


### PR DESCRIPTION
[AB#44063](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44063)

Follow up on #8632

## Describe your changes

[Some PRs](https://github.com/global-121/121-platform/actions/runs/32355415167/job/96384392655?pr=8681) did NOT trigger the tests, when these PRs where "created as draft" and only _later_ "marked ready for review"...

Subscribing to more then the default event(-type)s should do the trick...


## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] The tests are my changes
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
