### PR TITLE
Fix flaky visa test by waiting for messages

### DIFF
--- a/services/121-service/test/payment/fsp-integrations/do-payment-fsp-visa-debit/do-payment-fsp-visa-debit.success.test.ts
+++ b/services/121-service/test/payment/fsp-integrations/do-payment-fsp-visa-debit/do-payment-fsp-visa-debit.success.test.ts
@@ -247,7 +247,6 @@ describe('Do successful payment with FSP Visa Debit', () => {
       registrationOCW4.referenceId,
       accessToken,
     );
-    await waitFor(2_000);
 
     const paymentResponse2 = await doPayment({
       programId: programIdVisa,

--- a/services/121-service/test/visa-card/replace-card-by-mail.test.ts
+++ b/services/121-service/test/visa-card/replace-card-by-mail.test.ts
@@ -13,6 +13,7 @@ import {
   registrationVisa,
 } from '@121-service/src/seed-data/mock/visa-card.data';
 import { waitFor } from '@121-service/src/utils/waitFor.helper';
+import { waitForMessagesToComplete } from '@121-service/test/helpers/program.helper';
 import {
   patchProgramFspConfigurationProperty,
   updateProgramCardDistributionByMail,
@@ -73,13 +74,21 @@ describe('Replace Visa debit card by mail', () => {
       registrationVisa.referenceId,
       accessToken,
     );
-    await waitFor(3_000);
     const visaWalletResponse = await getVisaWalletsAndDetails(
       programIdVisa,
       registrationVisa.referenceId,
       accessToken,
     );
 
+    await waitForMessagesToComplete({
+      programId: programIdVisa,
+      referenceIds: [registrationVisa.referenceId],
+      accessToken,
+      expectedMessageAttribute: {
+        key: 'body',
+        values: [messageTemplateNlrcOcw?.replaceVisaCard?.message?.en],
+      },
+    });
     const messageReponse = await getMessageHistory(
       programIdVisa,
       registrationVisa.referenceId,
@@ -133,7 +142,6 @@ describe('Replace Visa debit card by mail', () => {
       registrationVisa.referenceId,
       accessToken,
     );
-    await waitFor(2_000);
     const visaWalletResponseAttempt1 = await getVisaWalletsAndDetails(
       programIdPv,
       registrationVisa.referenceId,
@@ -158,12 +166,21 @@ describe('Replace Visa debit card by mail', () => {
       registrationVisa.referenceId,
       accessToken,
     );
-    await waitFor(2_000);
     const visaWalletResponseAttempt2 = await getVisaWalletsAndDetails(
       programIdPv,
       registrationVisa.referenceId,
       accessToken,
     );
+
+    await waitForMessagesToComplete({
+      programId: programIdPv,
+      referenceIds: [registrationVisa.referenceId],
+      accessToken,
+      expectedMessageAttribute: {
+        key: 'body',
+        values: [messageTemplateNlrcPv?.replaceVisaCard?.message?.en],
+      },
+    });
     const messageReponseAttempt2 = await getMessageHistory(
       programIdPv,
       registrationVisa.referenceId,


### PR DESCRIPTION
[AB#44084](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44084) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Fix flaky test `replace-card-by-mail.test.ts` by replacing fixed `waitFor` sleeps with the existing `waitForMessagesToComplete` poll helper before asserting on the async replace-card message. Also removed a now-redundant fixed wait after `replaceVisaCardByMail` in `do-payment-fsp-visa-debit.success.test.ts`.

Example flaky run: https://github.com/global-121/121-platform/actions/runs/32009654331 

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
