### PR TITLE
fox: don't sync data with enfuse for cards that don't exist

### DIFF
--- a/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.spec.ts
@@ -771,6 +771,7 @@ describe('IntersolveVisaService', () => {
       const newerChildWallet = new IntersolveVisaChildWalletEntity();
       newerChildWallet.tokenCode = 'newer-token';
       newerChildWallet.created = new Date('2024-06-01T00:00:00Z');
+      newerChildWallet.isDebitCardCreated = true;
 
       jest
         .spyOn(customerRepo, 'findOneWithWalletsByRegistrationId')
@@ -807,6 +808,35 @@ describe('IntersolveVisaService', () => {
         tokenCode: 'newer-token',
         contactInformation,
       });
+    });
+
+    it('should not update physical card information for cards that are not created', async () => {
+      // Arrange
+      const olderChildWallet = new IntersolveVisaChildWalletEntity();
+      olderChildWallet.tokenCode = 'older-token';
+      olderChildWallet.created = new Date('2023-01-01T00:00:00Z');
+
+      const newerChildWallet = new IntersolveVisaChildWalletEntity();
+      newerChildWallet.tokenCode = 'newer-token';
+      newerChildWallet.created = new Date('2024-06-01T00:00:00Z');
+      newerChildWallet.isDebitCardCreated = false;
+
+      jest
+        .spyOn(customerRepo, 'findOneWithWalletsByRegistrationId')
+        .mockResolvedValue(
+          buildCustomerWithChildWallets([olderChildWallet, newerChildWallet]),
+        );
+
+      // Act
+      await service.sendUpdatedCustomerInformation({
+        registrationId,
+        contactInformation,
+      });
+
+      // Assert
+      expect(
+        apiService.updatePhysicalCardContactInformation,
+      ).not.toHaveBeenCalledWith();
     });
 
     it('should not forward the address to a card when the customer has no child wallet', async () => {

--- a/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.ts
@@ -890,7 +890,7 @@ export class IntersolveVisaService {
     });
 
     const latestChildWallet = this.getLatestChildWallet(customer);
-    if (latestChildWallet) {
+    if (latestChildWallet && latestChildWallet.isDebitCardCreated) {
       await this.intersolveVisaApiService.updatePhysicalCardContactInformation({
         tokenCode: latestChildWallet.tokenCode,
         contactInformation,


### PR DESCRIPTION
[AB#44099](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44099) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

don't sync data with enfuse for cards that don't exist by check card is created

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
