### PR TITLE
cert path fix

### DIFF
--- a/services/121-service/src/ormconfig.ts
+++ b/services/121-service/src/ormconfig.ts
@@ -17,7 +17,7 @@ const createSSLConfig = (): boolean | TlsOptions => {
   // - Disable the NODE_ENV check above, or set the ENV-variable to 'production' in the `services/.env`-file
   const certsPath = '/etc/ssl/certs';
   const azureConnectionCACertificates = [
-    readFileSync(`${certsPath}/DigiCert_Global_Root_CA.pem`).toString(),
+    readFileSync(`${certsPath}/azl_DigiCert_Global_Root_CA.pem`).toString(),
     readFileSync(
       `${certsPath}/Microsoft_RSA_Root_Certificate_Authority_2017.pem`,
     ).toString(),

--- a/services/121-service/src/ormconfig.ts
+++ b/services/121-service/src/ormconfig.ts
@@ -12,12 +12,11 @@ const createSSLConfig = (): boolean | TlsOptions => {
   }
   // To make a secure connection to an "Azure Database for PostgreSQL flexible server" in local development:
   // - See: https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-networking-ssl-tls#configure-ssl-on-the-client
-  // - Download the 3 certificates mentioned (or extract them from an App Service instance) into the local `./cert`-folder,
+  // - Download the 2 certificates mentioned (or extract them from an App Service instance) into the local `./cert`-folder,
   // - Set: certsPath to: './cert'
   // - Disable the NODE_ENV check above, or set the ENV-variable to 'production' in the `services/.env`-file
   const certsPath = '/etc/ssl/certs';
   const azureConnectionCACertificates = [
-    readFileSync(`${certsPath}/azl_DigiCert_Global_Root_CA.pem`).toString(),
     readFileSync(
       `${certsPath}/Microsoft_RSA_Root_Certificate_Authority_2017.pem`,
     ).toString(),


### PR DESCRIPTION
[AB#44105](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44105) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Azure updated the App Service Node runtime image's root certificate bundle, which removed DigiCert_Global_Root_CA.pem (and renamed it to azl_DigiCert_Global_Root_CA.pem on Node 24 only) and caused the service to crash on boot with an ENOENT error. This PR removes the retired DigiCert Global Root CA from the SSL config since Azure Database for PostgreSQL no longer anchors on it, keeping only Microsoft_RSA_Root_Certificate_Authority_2017.pem and DigiCert_Global_Root_G2.pem, which are present and consistently named across both Node 22 and Node 24 runtime images.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
