### PR TITLE
Improve performance of loading the Registrations-table

### DIFF
--- a/services/121-service/src/migration/1787662797814-add-registration-attribute-data-composite-index.ts
+++ b/services/121-service/src/migration/1787662797814-add-registration-attribute-data-composite-index.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRegistrationAttributeDataCompositeIndex1787662797814 implements MigrationInterface {
+  name = 'AddRegistrationAttributeDataCompositeIndex1787662797814';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // On production, build this index manually with CREATE INDEX CONCURRENTLY beforehand to
+    // avoid locking writes; IF NOT EXISTS then makes this migration a no-op there while still
+    // provisioning dev/test/CI environments.
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_registration_attribute_data_attributeId_value" ON "121-service"."registration_attribute_data" ("programRegistrationAttributeId", "value")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "121-service"."IDX_registration_attribute_data_attributeId_value"`,
+    );
+  }
+}

--- a/services/121-service/src/registration/entities/registration-attribute-data.entity.ts
+++ b/services/121-service/src/registration/entities/registration-attribute-data.entity.ts
@@ -18,6 +18,13 @@ import { RegistrationEntity } from '@121-service/src/registration/entities/regis
   'registrationId',
   'programRegistrationAttributeId',
 ])
+// Any time we filter or sort on registration attributes like phone number or name, we use both of these columns.
+// So we have a composite index on both of these columns to improve performance.
+// We still need the individual index on value because we have a few places where we filter across programs and programRegistrationAttributeId cannot be used
+@Index('IDX_registration_attribute_data_attributeId_value', [
+  'programRegistrationAttributeId',
+  'value',
+])
 @Entity('registration_attribute_data')
 export class RegistrationAttributeDataEntity extends Base121Entity {
   @ManyToOne(


### PR DESCRIPTION
[AB#44132](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44132) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Background

While investigating a CPU spike (up to ~96%, memory flat at ~40%) on the the postgres production server. I queried the performance of our queries:
```
AppDependencies
| where Type == "POSTGRES" or Target contains "postgres"
| where TimeGenerated between (datetime(2026-08-25T09:00:00Z) .. datetime(2026-08-25T11:30:00Z))
| summarize
    callCount = count(),
    avgDuration = avg(DurationMs),
    maxDuration = max(DurationMs),
    totalTime = sum(DurationMs)
    by AppRoleName, Name   // AppRoleName = which client instance (121-<clientName>)
| order by totalTime desc
```
Key findings:

The top offender by total time was the registrations list/search query pattern all queries that are fired using the nest-js-pagine package in the registration pagination server with the paginate method.

<img width="684" height="186" alt="image" src="https://github.com/user-attachments/assets/1d85bb17-7a37-4260-a0f4-4d17af0d2798" />



What this PR does

- Adds the composite index (programRegistrationAttributeId, value) in registration-attribute-data.entity.ts
- Adds the corresponding migration in 1787662797814-add-registration-attribute-data-composite-index.ts
- Performance validation
-

Tested locally against a program with ~60,000 registrations, comparing before/after via temporary perf logging on getPaginate():

before index	after index
paginate()	~1846–1892ms	~1169–1373ms
getPaginate() total	~1853–1892ms	~1173–1376ms
~25–35% reduction for this query path. 



## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
