### PR TITLE
Stop flaky Safaricom E2E

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -84,6 +84,16 @@ npm run test:find-flaky <substringMatchingFilename>
 
 This hunts for flaky tests by running each test 30 times, stops as soon as flakiness is detected, and keeps a trace of the failing run for debugging. It will also open the report after a failed run.
 
+Another great tip for finding difficult edge cases is [CPU throttling](https://charpeni.com/blog/how-to-easily-reproduce-a-flaky-test-in-playwright)
+
+```ts
+test.beforeEach(async ({page }) => {
+  const context = page.context();
+  const cdpSession = await context.newCDPSession(page);
+  await cdpSession.send('Emulation.setCPUThrottlingRate', { rate: 6 });
+)
+```
+
 ### Using the VS Code-extension
 
 Use the built-in runner of the VS Code-extension: [`#ms-playwright.playwright`](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright)

--- a/e2e/portal/pages/PaymentPage.ts
+++ b/e2e/portal/pages/PaymentPage.ts
@@ -25,7 +25,7 @@ class PaymentPage extends BasePage {
   readonly renamePaymentInput: Locator;
   readonly renamePaymentButton: Locator;
   readonly threeDotsMenuButton: Locator;
-  readonly succesfullyTransferredChip: Locator;
+  readonly succesfullyTransferredAmountChip: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -34,7 +34,7 @@ class PaymentPage extends BasePage {
     this.importReconciliationDataButton = this.page.getByRole('button', {
       name: 'Import reconciliation data',
     });
-    this.succesfullyTransferredChip = this.page
+    this.succesfullyTransferredAmountChip = this.page
       .locator('app-metric-tile', { hasText: 'Total amount' })
       .getByTestId('metric-tile-chip');
 
@@ -175,7 +175,8 @@ class PaymentPage extends BasePage {
     if (expectedAmount !== undefined) {
       await expect
         .poll(async () => {
-          const chipText = await this.succesfullyTransferredChip.textContent();
+          const chipText =
+            await this.succesfullyTransferredAmountChip.textContent();
           return chipText?.replace(/,/g, '');
         })
         .toContain(expectedAmount.toString());

--- a/e2e/portal/pages/PaymentPage.ts
+++ b/e2e/portal/pages/PaymentPage.ts
@@ -34,9 +34,8 @@ class PaymentPage extends BasePage {
     this.importReconciliationDataButton = this.page.getByRole('button', {
       name: 'Import reconciliation data',
     });
-    this.succesfullyTransferredAmountChip = this.page
-      .locator('app-metric-tile', { hasText: 'Total amount' })
-      .getByTestId('metric-tile-chip');
+    this.succesfullyTransferredAmountChip =
+      this.page.getByTestId('metric-tile-chip');
 
     this.chooseFileButton = this.page.getByRole('button', {
       name: 'Choose file',
@@ -164,7 +163,7 @@ class PaymentPage extends BasePage {
 
     /*
       The method utilized above isn't that robust.
-      Because there is a inbetween state where the approved chip is visible,
+      Because there is an inbetween state where the "Approved"-chip is visible,
       but the payment is still 'processing'. Since we can't use the <canvas />
       element to check the graph status, we need to check the amount that is
       displayed in the payment card on the payment page. When this chip shows the

--- a/e2e/portal/pages/PaymentPage.ts
+++ b/e2e/portal/pages/PaymentPage.ts
@@ -161,10 +161,14 @@ class PaymentPage extends BasePage {
     await inProgressChip.waitFor({ state: 'hidden' });
     await approvedChip.waitFor({ state: 'visible' });
 
-    // Okay, so the method above isn't that robust.
-    // Because there is a inbetween state where the approved chip is visible, but the payment is still 'processing'
-    // Since we can't use the <canvas /> element to check the graph status, we need to check the amount that is displayed in the payment card.
-    // When this thing shows the correct amount we can safely navigate away and assert the payment card in the overview
+    /*
+      The method utilized above isn't that robust.
+      Because there is a inbetween state where the approved chip is visible,
+      but the payment is still 'processing'. Since we can't use the <canvas />
+      element to check the graph status, we need to check the amount that is
+      displayed in the payment card. When this chip shows the correct amount
+      we can safely navigate away and assert the payment card in the overview
+    */
 
     if (expectedAmount) {
       await expect

--- a/e2e/portal/pages/PaymentPage.ts
+++ b/e2e/portal/pages/PaymentPage.ts
@@ -161,9 +161,10 @@ class PaymentPage extends BasePage {
     await inProgressChip.waitFor({ state: 'hidden' });
     await approvedChip.waitFor({ state: 'visible' });
 
-    // Okay, so the method above isn't that robust. Because there is a inbetween state where the approved
-    // chip is visible, but the amount isn't updated yet. So we need to poll until the amount is updated.
-    // Then we can continue with the rest of the test.
+    // Okay, so the method above isn't that robust.
+    // Because there is a inbetween state where the approved chip is visible, but the payment is still 'processing'
+    // Since we can't use the <canvas /> element to check the graph status, we need to check the amount that is displayed in the payment card.
+    // When this thing shows the correct amount we can safely navigate away and assert the payment card in the overview
 
     if (expectedAmount) {
       await expect

--- a/e2e/portal/pages/PaymentPage.ts
+++ b/e2e/portal/pages/PaymentPage.ts
@@ -34,9 +34,10 @@ class PaymentPage extends BasePage {
     this.importReconciliationDataButton = this.page.getByRole('button', {
       name: 'Import reconciliation data',
     });
-    this.succesfullyTransferredChip = this.page.getByTestId(
-      'metric-tile-chip-successfully-transferred',
-    );
+    this.succesfullyTransferredChip = this.page
+      .locator('app-metric-tile', { hasText: 'Total amount' })
+      .getByTestId('metric-tile-chip');
+
     this.chooseFileButton = this.page.getByRole('button', {
       name: 'Choose file',
     });
@@ -171,7 +172,7 @@ class PaymentPage extends BasePage {
       the overview.
     */
 
-    if (expectedAmount) {
+    if (expectedAmount !== undefined) {
       await expect
         .poll(async () => {
           const chipText = await this.succesfullyTransferredChip.textContent();

--- a/e2e/portal/pages/PaymentPage.ts
+++ b/e2e/portal/pages/PaymentPage.ts
@@ -25,6 +25,7 @@ class PaymentPage extends BasePage {
   readonly renamePaymentInput: Locator;
   readonly renamePaymentButton: Locator;
   readonly threeDotsMenuButton: Locator;
+  readonly succesfullyTransferredChip: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -33,6 +34,9 @@ class PaymentPage extends BasePage {
     this.importReconciliationDataButton = this.page.getByRole('button', {
       name: 'Import reconciliation data',
     });
+    this.succesfullyTransferredChip = this.page.getByTestId(
+      'metric-tile-chip-successfully-transferred',
+    );
     this.chooseFileButton = this.page.getByRole('button', {
       name: 'Choose file',
     });
@@ -142,7 +146,9 @@ class PaymentPage extends BasePage {
     }
   }
 
-  async waitForPaymentToComplete() {
+  async waitForPaymentToComplete({
+    expectedAmount,
+  }: { expectedAmount?: number } = {}) {
     await this.page.waitForTimeout(500); // TODO for now needed to bridge in-progress gap between actions & queue.
     const approvedChip = this.page
       .locator('app-colored-chip')
@@ -154,6 +160,19 @@ class PaymentPage extends BasePage {
 
     await inProgressChip.waitFor({ state: 'hidden' });
     await approvedChip.waitFor({ state: 'visible' });
+
+    // Okay, so the method above isn't that robust. Because there is a inbetween state where the approved
+    // chip is visible, but the amount isn't updated yet. So we need to poll until the amount is updated.
+    // Then we can continue with the rest of the test.
+
+    if (expectedAmount) {
+      await expect
+        .poll(async () => {
+          const chipText = await this.succesfullyTransferredChip.textContent();
+          return chipText?.replace(/,/g, '');
+        })
+        .toContain(expectedAmount.toString());
+    }
   }
 
   async validateBadgeIsPresentByLabel({

--- a/e2e/portal/pages/PaymentPage.ts
+++ b/e2e/portal/pages/PaymentPage.ts
@@ -166,8 +166,9 @@ class PaymentPage extends BasePage {
       Because there is a inbetween state where the approved chip is visible,
       but the payment is still 'processing'. Since we can't use the <canvas />
       element to check the graph status, we need to check the amount that is
-      displayed in the payment card. When this chip shows the correct amount
-      we can safely navigate away and assert the payment card in the overview
+      displayed in the payment card on the payment page. When this chip shows the
+      correct amount we can safely navigate away and assert the payment card in
+      the overview.
     */
 
     if (expectedAmount) {

--- a/e2e/portal/pages/PaymentsPage.ts
+++ b/e2e/portal/pages/PaymentsPage.ts
@@ -140,14 +140,8 @@ class PaymentsPage extends BasePage {
     expectedValue: number,
   ) {
     if (!elementText) throw new Error('Element text is null');
-    console.log('elementText:', elementText);
-
     const extractedValue = elementText.replace(/[^0-9.]/g, '');
     const actualNumber = parseFloat(extractedValue);
-
-    console.log('extractedValue:', extractedValue);
-    console.log('actualNumber:', actualNumber);
-
     expect(actualNumber).toBeCloseTo(expectedValue, 2);
   }
 

--- a/e2e/portal/pages/PaymentsPage.ts
+++ b/e2e/portal/pages/PaymentsPage.ts
@@ -140,8 +140,14 @@ class PaymentsPage extends BasePage {
     expectedValue: number,
   ) {
     if (!elementText) throw new Error('Element text is null');
+    console.log('elementText:', elementText);
+
     const extractedValue = elementText.replace(/[^0-9.]/g, '');
     const actualNumber = parseFloat(extractedValue);
+
+    console.log('extractedValue:', extractedValue);
+    console.log('actualNumber:', actualNumber);
+
     expect(actualNumber).toBeCloseTo(expectedValue, 2);
   }
 

--- a/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithCbe.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithCbe.spec.ts
@@ -59,7 +59,9 @@ test('Do successful payment for Cbe fsp', async ({
   });
 
   await test.step('Validate payment card', async () => {
-    await paymentPage.waitForPaymentToComplete();
+    await paymentPage.waitForPaymentToComplete({
+      expectedAmount: defaultMaxTransferValue,
+    });
     await paymentPage.navigateToProgramPage('Payments');
     await paymentsPage.validatePaymentCard({
       paymentAmount: defaultMaxTransferValue,

--- a/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithNedbank.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithNedbank.spec.ts
@@ -44,11 +44,10 @@ test('Do successful payment for Nedbank fsp', async ({
   });
 
   await test.step('Validate payment card', async () => {
-    // In case of Nedbank, we need to wait for the payment to be processed
-    // before we can validate the payment card
-    // This way we can avoid reloading the page
-    await page.waitForTimeout(1000);
-    await paymentPage.waitForPaymentToComplete();
+    await paymentPage.waitForPaymentToComplete({
+      expectedAmount: defaultMaxTransferValue,
+    });
+
     await paymentPage.navigateToProgramPage('Payments');
     await paymentsPage.validatePaymentCard({
       paymentAmount: defaultMaxTransferValue,

--- a/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithSafaricom.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithSafaricom.spec.ts
@@ -6,7 +6,13 @@ import {
 } from '@121-service/test/registrations/pagination/pagination-data';
 
 import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
-test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
+
+test.beforeEach(async ({ resetDBAndSeedRegistrations, page }) => {
+  const context = page.context();
+  const cdpSession = await context.newCDPSession(page);
+  // 4-6x CPU throttling is what worked well for my M1 Pro.
+  await cdpSession.send('Emulation.setCPUThrottlingRate', { rate: 6 });
+
   await resetDBAndSeedRegistrations({
     seedScript: SeedScript.safaricomProgram,
     registrations: registrationsSafaricom,
@@ -44,7 +50,10 @@ test('Do successful payment for Safaricom fsp', async ({
   });
 
   await test.step('Validate payment card', async () => {
-    await paymentPage.waitForPaymentToComplete();
+    await paymentPage.waitForPaymentToComplete({
+      expectedAmount: defaultMaxTransferValue,
+    });
+
     await paymentPage.navigateToProgramPage('Payments');
     await paymentsPage.validatePaymentCard({
       paymentAmount: defaultMaxTransferValue,

--- a/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithSafaricom.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithSafaricom.spec.ts
@@ -7,12 +7,7 @@ import {
 
 import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
 
-test.beforeEach(async ({ resetDBAndSeedRegistrations, page }) => {
-  const context = page.context();
-  const cdpSession = await context.newCDPSession(page);
-  // 4-6x CPU throttling is what worked well for my M1 Pro.
-  await cdpSession.send('Emulation.setCPUThrottlingRate', { rate: 6 });
-
+test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   await resetDBAndSeedRegistrations({
     seedScript: SeedScript.safaricomProgram,
     registrations: registrationsSafaricom,

--- a/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithVisa.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithVisa.spec.ts
@@ -39,7 +39,9 @@ test('Do successful payment for Visa fsp', async ({
   });
 
   await test.step('Validate payment card', async () => {
-    await paymentPage.waitForPaymentToComplete();
+    await paymentPage.waitForPaymentToComplete({
+      expectedAmount: defaultMaxTransferValue,
+    });
     await paymentPage.navigateToProgramPage('Payments');
     await paymentsPage.validatePaymentCard({
       paymentAmount: defaultMaxTransferValue,

--- a/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithVoucher.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithVoucher.spec.ts
@@ -43,8 +43,9 @@ test('Do successful payment for Voucher fsp', async ({
   });
 
   await test.step('Validate payment card', async () => {
-    await page.waitForTimeout(1000);
-    await paymentPage.waitForPaymentToComplete();
+    await paymentPage.waitForPaymentToComplete({
+      expectedAmount: defaultMaxTransferValue,
+    });
     await paymentPage.navigateToProgramPage('Payments');
     await paymentsPage.validatePaymentCard({
       paymentAmount: defaultMaxTransferValue,

--- a/interfaces/portal/src/app/components/metric-tile/metric-tile.component.html
+++ b/interfaces/portal/src/app/components/metric-tile/metric-tile.component.html
@@ -8,7 +8,7 @@
       [icon]="chipIcon()"
       [tooltip]="chipTooltip()"
       class="ms-auto"
-      data-testid="metric-tile-chip-successfully-transferred"
+      data-testid="metric-tile-chip"
     />
   }
   <dt class="text-grey-700 txt-body-m mbs-auto mbe-2 pbs-11">

--- a/interfaces/portal/src/app/components/metric-tile/metric-tile.component.html
+++ b/interfaces/portal/src/app/components/metric-tile/metric-tile.component.html
@@ -8,6 +8,7 @@
       [icon]="chipIcon()"
       [tooltip]="chipTooltip()"
       class="ms-auto"
+      data-testid="metric-tile-chip-successfully-transferred"
     />
   }
   <dt class="text-grey-700 txt-body-m mbs-auto mbe-2 pbs-11">


### PR DESCRIPTION
[AB#44134](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44134) 

## Describe your changes

Fixes flaky Safaricom - and possibly other payment related FSP tests - by making the waiting for payment completion more robust.  Also a minor update of README.MD with a fancy trick :)

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] I have edited tests for my changes
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8701.westeurope.3.azurestaticapps.net
