### PR TITLE
chore: harden alfouad redaction

### DIFF
--- a/services/121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.class.spec.ts
+++ b/services/121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.class.spec.ts
@@ -1,0 +1,31 @@
+import { AlfouadAuthIdentity } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.class';
+
+describe('AlfouadAuthIdentity', () => {
+  const authIdentity = new AlfouadAuthIdentity({
+    account: '161010004501',
+    branchId: '1',
+    username: 'Red Crescent',
+    password: 'secret',
+    publicKey: '<RSAParameters />',
+  });
+
+  it('should keep the credential fields readable for building the request', () => {
+    expect(authIdentity.account).toBe('161010004501');
+    expect(authIdentity.branchId).toBe('1');
+    expect(authIdentity.username).toBe('Red Crescent');
+    expect(authIdentity.password).toBe('secret');
+    expect(authIdentity.publicKey).toBe('<RSAParameters />');
+  });
+
+  it('should redact all credentials when serialized', () => {
+    expect(JSON.stringify(authIdentity)).toBe('"**REDACTED**"');
+  });
+
+  it('should redact the credentials when nested in a logged object', () => {
+    const logged = JSON.stringify({ authIdentity });
+
+    expect(logged).toBe('{"authIdentity":"**REDACTED**"}');
+    expect(logged).not.toContain('secret');
+    expect(logged).not.toContain('161010004501');
+  });
+});

--- a/services/121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.class.ts
+++ b/services/121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.class.ts
@@ -1,0 +1,32 @@
+export class AlfouadAuthIdentity {
+  public readonly account: string;
+  public readonly branchId: string;
+  public readonly username: string;
+  public readonly password: string;
+  public readonly publicKey: string;
+
+  public constructor({
+    account,
+    branchId,
+    username,
+    password,
+    publicKey,
+  }: {
+    account: string;
+    branchId: string;
+    username: string;
+    password: string;
+    publicKey: string;
+  }) {
+    this.account = account;
+    this.branchId = branchId;
+    this.username = username;
+    this.password = password;
+    this.publicKey = publicKey;
+  }
+
+  // Redacts all credentials if this object is ever serialized/logged (e.g. via JSON.stringify).
+  public toJSON(): string {
+    return '**REDACTED**';
+  }
+}

--- a/services/121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.interface.ts
+++ b/services/121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.interface.ts
@@ -1,7 +1,0 @@
-export interface AlfouadAuthIdentity {
-  readonly account: string;
-  readonly branchId: string;
-  readonly username: string;
-  readonly password: string;
-  readonly publicKey: string;
-}

--- a/services/121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-create-transaction-params.interface.ts
+++ b/services/121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-create-transaction-params.interface.ts
@@ -1,4 +1,4 @@
-import { AlfouadAuthIdentity } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.interface';
+import { AlfouadAuthIdentity } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.class';
 import { AlfouadSenderInfo } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-sender-info.interface';
 
 export interface AlfouadCreateTransactionParams extends AlfouadSenderInfo {

--- a/services/121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.api.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.api.service.spec.ts
@@ -2,7 +2,7 @@ import { HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { AlfouadApiTransactionState } from '@121-service/src/fsp-integrations/integrations/alfouad/enums/alfouad-api-transaction-state.enum';
-import { AlfouadAuthIdentity } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.interface';
+import { AlfouadAuthIdentity } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.class';
 import { AlfouadCreateTransactionParams } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-create-transaction-params.interface';
 import { AlfouadApiHelperService } from '@121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.api.helper.service';
 import { AlfouadApiService } from '@121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.api.service';
@@ -16,13 +16,13 @@ jest.mock('@121-service/src/env', () => ({
 const baseUrl = new URL('https://alfouad.example.org/');
 const requestHeaders = new Headers({ Authorization: 'Bearer token' });
 
-const authIdentity: AlfouadAuthIdentity = {
+const authIdentity = new AlfouadAuthIdentity({
   account: '161010004501',
   branchId: '1',
   username: 'Red Crescent',
   password: 'secret',
   publicKey: '<RSAParameters />',
-};
+});
 
 const createTransactionInput: AlfouadCreateTransactionParams = {
   senderFullName: 'Test Sender',

--- a/services/121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.api.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.api.service.ts
@@ -9,7 +9,7 @@ import { AlfouadApiCreateTransactionResponseBodyDto } from '@121-service/src/fsp
 import { AlfouadApiGetTransactionResponseBodyDto } from '@121-service/src/fsp-integrations/integrations/alfouad/dtos/alfouad-api-get-transaction-response-body.dto';
 import { AlfouadApiTransactionState } from '@121-service/src/fsp-integrations/integrations/alfouad/enums/alfouad-api-transaction-state.enum';
 import { AlfouadApiError } from '@121-service/src/fsp-integrations/integrations/alfouad/errors/alfouad-api.error';
-import { AlfouadAuthIdentity } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.interface';
+import { AlfouadAuthIdentity } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.class';
 import { AlfouadCreateTransactionParams } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-create-transaction-params.interface';
 import { AlfouadCreateTransactionResult } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-create-transaction-result.interface';
 import { AlfouadApiHelperService } from '@121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.api.helper.service';

--- a/services/121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { AlfouadApiErrorCode } from '@121-service/src/fsp-integrations/integrations/alfouad/enums/alfouad-api-error-code.enum';
 import { AlfouadApiTransactionState } from '@121-service/src/fsp-integrations/integrations/alfouad/enums/alfouad-api-transaction-state.enum';
-import { AlfouadAuthIdentity } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.interface';
+import { AlfouadAuthIdentity } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.class';
 import { AlfouadCreateTransactionParams } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-create-transaction-params.interface';
 import { AlfouadApiService } from '@121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.api.service';
 import { AlfouadService } from '@121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.service';
@@ -10,13 +10,13 @@ import { TransactionStatusEnum } from '@121-service/src/payments/transactions/en
 import { TransactionEventsScopedRepository } from '@121-service/src/payments/transactions/transaction-events/repositories/transaction-events.scoped.repository';
 import { ProgramFspConfigurationRepository } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.repository';
 
-const authIdentity: AlfouadAuthIdentity = {
+const authIdentity = new AlfouadAuthIdentity({
   account: '161010004501',
   branchId: '1',
   username: 'Red Crescent',
   password: 'secret',
   publicKey: '<RSAParameters />',
-};
+});
 
 const createTransactionInput: AlfouadCreateTransactionParams = {
   senderFullName: 'Test Sender',

--- a/services/121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.service.ts
@@ -4,7 +4,7 @@ import { AlfouadApiErrorCode } from '@121-service/src/fsp-integrations/integrati
 import { AlfouadApiResponseState } from '@121-service/src/fsp-integrations/integrations/alfouad/enums/alfouad-api-response-state.enum';
 import { AlfouadApiTransactionState } from '@121-service/src/fsp-integrations/integrations/alfouad/enums/alfouad-api-transaction-state.enum';
 import { AlfouadApiError } from '@121-service/src/fsp-integrations/integrations/alfouad/errors/alfouad-api.error';
-import { AlfouadAuthIdentity } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.interface';
+import { AlfouadAuthIdentity } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.class';
 import { AlfouadCreateTransactionParams } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-create-transaction-params.interface';
 import { AlfouadSenderInfo } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-sender-info.interface';
 import { AlfouadApiService } from '@121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.api.service';
@@ -48,13 +48,13 @@ export class AlfouadService {
       properties.find((property) => property.name === name)?.value as string;
 
     return {
-      authIdentity: {
+      authIdentity: new AlfouadAuthIdentity({
         account: valueOf(FspConfigurationProperties.accountAlfouad),
         branchId: valueOf(FspConfigurationProperties.branchIdAlfouad),
         username: valueOf(FspConfigurationProperties.usernameAlfouad),
         password: valueOf(FspConfigurationProperties.passwordAlfouad),
         publicKey: valueOf(FspConfigurationProperties.publicKeyAlfouad),
-      },
+      }),
       senderInfo: {
         senderFullName: valueOf(
           FspConfigurationProperties.senderFullNameAlfouad,

--- a/services/121-service/src/fsp-integrations/reconciliation/alfouad/alfouad-reconciliation.service.ts
+++ b/services/121-service/src/fsp-integrations/reconciliation/alfouad/alfouad-reconciliation.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { AlfouadApiError } from '@121-service/src/fsp-integrations/integrations/alfouad/errors/alfouad-api.error';
-import { AlfouadAuthIdentity } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.interface';
+import { AlfouadAuthIdentity } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.class';
 import { AlfouadService } from '@121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.service';
 import { Fsps } from '@121-service/src/fsp-integrations/shared/enum/fsp-name.enum';
 import { TransactionStatusEnum } from '@121-service/src/payments/transactions/enums/transaction-status.enum';

--- a/services/121-service/src/fsp-integrations/transaction-jobs/services/transaction-jobs-alfouad.service.spec.ts
+++ b/services/121-service/src/fsp-integrations/transaction-jobs/services/transaction-jobs-alfouad.service.spec.ts
@@ -1,4 +1,4 @@
-import { AlfouadAuthIdentity } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.interface';
+import { AlfouadAuthIdentity } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-auth-identity.class';
 import { AlfouadSenderInfo } from '@121-service/src/fsp-integrations/integrations/alfouad/interfaces/alfouad-sender-info.interface';
 import { AlfouadService } from '@121-service/src/fsp-integrations/integrations/alfouad/services/alfouad.service';
 import { TransactionJobsAlfouadService } from '@121-service/src/fsp-integrations/transaction-jobs/services/transaction-jobs-alfouad.service';
@@ -6,13 +6,13 @@ import { TransactionJobsHelperService } from '@121-service/src/fsp-integrations/
 import { AlfouadTransactionJobDto } from '@121-service/src/fsp-integrations/transaction-queues/dto/alfouad-transaction-job.dto';
 import { TransactionsService } from '@121-service/src/payments/transactions/transactions.service';
 
-const authIdentity: AlfouadAuthIdentity = {
+const authIdentity = new AlfouadAuthIdentity({
   account: '161010004501',
   branchId: '1',
   username: 'Red Crescent',
   password: 'secret',
   publicKey: '<RSAParameters />',
-};
+});
 
 const senderInfo: AlfouadSenderInfo = {
   senderFullName: 'Red Crescent',

--- a/services/121-service/src/shared/services/custom-http.service.spec.ts
+++ b/services/121-service/src/shared/services/custom-http.service.spec.ts
@@ -275,6 +275,15 @@ describe('CustomHttpService', () => {
         response: { status: HttpStatus.OK, statusText: 'OK', data: {} },
       },
       {
+        caseName: 'Authorization header value',
+        sensitiveValue: 'Bearer super-secret-token-value',
+        request: {
+          url: 'http://example.com/api',
+          payload: { Authorization: 'Bearer super-secret-token-value' },
+        },
+        response: { status: HttpStatus.OK, statusText: 'OK', data: {} },
+      },
+      {
         caseName: 'access_token value',
         sensitiveValue: 'eyJhbGciOiJSUzI1NiJ9.sensitive-token-value',
         request: {

--- a/services/121-service/src/shared/services/custom-http.service.ts
+++ b/services/121-service/src/shared/services/custom-http.service.ts
@@ -426,6 +426,7 @@ export class CustomHttpService {
     }
 
     const sensitiveProperties = [
+      'authorization',
       'password',
       'access_token',
       CookieNames.general,
@@ -433,7 +434,8 @@ export class CustomHttpService {
     ];
 
     const isSensitiveProperty = (key: string | number | undefined): boolean =>
-      typeof key === 'string' && sensitiveProperties.includes(key);
+      typeof key === 'string' &&
+      sensitiveProperties.includes(key.toLowerCase());
 
     const isUsernameProperty = (key: string | number | undefined): boolean =>
       key === 'username';

--- a/services/121-service/src/shared/services/custom-http.service.ts
+++ b/services/121-service/src/shared/services/custom-http.service.ts
@@ -435,10 +435,11 @@ export class CustomHttpService {
 
     const isSensitiveProperty = (key: string | number | undefined): boolean =>
       typeof key === 'string' &&
-      sensitiveProperties.includes(key.toLowerCase());
+        sensitiveProperties.includes(key.toLowerCase());
 
     const isUsernameProperty = (key: string | number | undefined): boolean =>
-      key === 'username';
+      typeof key === 'string' &&
+        key.toLocaleLowerCase() === 'username';
 
     return cloneDeepWith(
       data,


### PR DESCRIPTION
[AB#44138](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44138) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

- Converted the auth identity interface to a class (`alfouad-auth-identity.class.ts`) whose `toJSON()` returns '**REDACTED**'. The credential fields stay fully readable for building the auth header, but any accidental serialization (`JSON.stringify`, an error message, another logger, or nested inside a logged payload) now yields **REDACTED**

- Added authorization to the redaction key-list in `custom-http.service.ts` and made the key matching case-insensitive. So if anyone ever adds header logging (or routes headers through `redactSensitiveDataProperties`), Authorization: `Bearer …` is redacted regardless of casing.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
