### PR TITLE
Fix nested reason on bulk update

### DIFF
--- a/services/121-service/src/registration/controllers/registrations.controller.ts
+++ b/services/121-service/src/registration/controllers/registrations.controller.ts
@@ -194,7 +194,7 @@ export class RegistrationsController {
   )
   public async patchRegistrations(
     @UploadedFile() csvFile: Express.Multer.File,
-    @AnyValidBody('reason') reason: string, // Registration can have dynamic attributes, so we cannot use whitelist
+    @Body('reason') reason: string,
     @Param('programId', ParseIntPipe) programId: number,
     @Req() req: ScopedUserRequest,
   ): Promise<void> {

--- a/services/121-service/test/registrations/bulk-update-registration.test.ts
+++ b/services/121-service/test/registrations/bulk-update-registration.test.ts
@@ -156,8 +156,7 @@ describe('Update attribute of multiple PAs via Bulk update', () => {
       referenceId: referenceId1,
     });
     const dataChangeEventsPa1 = eventsResponsePa1.body.data.filter(
-      (event: { type: string }) =>
-        event.type === RegistrationEventEnum.registrationDataChange,
+      (event) => event.type === RegistrationEventEnum.registrationDataChange,
     );
     expect(dataChangeEventsPa1.length).toBeGreaterThan(0);
     for (const event of dataChangeEventsPa1) {

--- a/services/121-service/test/registrations/bulk-update-registration.test.ts
+++ b/services/121-service/test/registrations/bulk-update-registration.test.ts
@@ -1,7 +1,9 @@
+import { RegistrationEventEnum } from '@121-service/src/registration-events/enum/registration-event.enum';
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { RegistrationPreferredLanguage } from '@121-service/src/shared/enum/registration-preferred-language.enum';
 import {
   bulkUpdateRegistrationsCSV,
+  getRegistrationEvents,
   importRegistrationsCSV,
   searchRegistrationByReferenceId,
   waitForBulkRegistrationChanges,
@@ -147,6 +149,20 @@ describe('Update attribute of multiple PAs via Bulk update', () => {
 
     expect(pa1AfterPatch).toMatchObject(dataThatStaysTheSamePa1);
     expect(pa2AfterPatch).toMatchObject(dataThatStaysTheSamePa2);
+
+    const eventsResponsePa1 = await getRegistrationEvents({
+      programId: programIdOcw,
+      accessToken,
+      referenceId: referenceId1,
+    });
+    const dataChangeEventsPa1 = eventsResponsePa1.body.data.filter(
+      (event: { type: string }) =>
+        event.type === RegistrationEventEnum.registrationDataChange,
+    );
+    expect(dataChangeEventsPa1.length).toBeGreaterThan(0);
+    for (const event of dataChangeEventsPa1) {
+      expect(event.reason).toBe('test-reason');
+    }
   });
 
   it('Should bulk update chosen FSP and validate changed records', async () => {


### PR DESCRIPTION
[AB#44181](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44181) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

I saw that change reasons look like this on production after a bulk upload
Change reason:
{"reason":"super good reason"} 

This should fix that. The reason was the AnyValidBdoy decorator which was accidently added in the wrong place

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
