### PR TITLE
Improve registration save with regards to registrationProgramId

### DIFF
--- a/services/121-service/src/registration/entities/registration.entity.ts
+++ b/services/121-service/src/registration/entities/registration.entity.ts
@@ -37,7 +37,13 @@ import { RegistrationPreferredLanguage } from '@121-service/src/shared/enum/regi
 import { UserEntity } from '@121-service/src/user/entities/user.entity';
 import { WrapperType } from '@121-service/src/wrapper.type';
 
-@Unique('registrationProgramUnique', ['programId', 'registrationProgramId'])
+export const REGISTRATION_PROGRAM_UNIQUE_CONSTRAINT =
+  'registrationProgramUnique';
+
+@Unique(REGISTRATION_PROGRAM_UNIQUE_CONSTRAINT, [
+  'programId',
+  'registrationProgramId',
+])
 @Check(`"referenceId" NOT IN (${ReferenceIdConstraints})`)
 @Entity('registration')
 export class RegistrationEntity extends Base121Entity {

--- a/services/121-service/src/registration/modules/registration-utils/registration-utils.module.ts
+++ b/services/121-service/src/registration/modules/registration-utils/registration-utils.module.ts
@@ -4,11 +4,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { RegistrationDataModule } from '@121-service/src/registration/modules/registration-data/registration-data.module';
 import { RegistrationUtilsService } from '@121-service/src/registration/modules/registration-utils/registration-utils.service';
-import { RegistrationScopedRepository } from '@121-service/src/registration/repositories/registration-scoped.repository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([ProgramEntity]), RegistrationDataModule],
-  providers: [RegistrationScopedRepository, RegistrationUtilsService],
+  providers: [RegistrationUtilsService],
   exports: [RegistrationUtilsService],
 })
 export class RegistrationUtilsModule {}

--- a/services/121-service/src/registration/modules/registration-utils/registration-utils.service.ts
+++ b/services/121-service/src/registration/modules/registration-utils/registration-utils.service.ts
@@ -1,12 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { QueryFailedError, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { RegistrationDataService } from '@121-service/src/registration/modules/registration-data/registration-data.service';
-import { RegistrationScopedRepository } from '@121-service/src/registration/repositories/registration-scoped.repository';
-import { PostgresStatusCodes } from '@121-service/src/shared/enum/postgres-status-codes.enum';
 
 @Injectable()
 export class RegistrationUtilsService {
@@ -14,55 +12,8 @@ export class RegistrationUtilsService {
   private readonly programRepository: Repository<ProgramEntity>;
 
   constructor(
-    private registrationScopedRepository: RegistrationScopedRepository,
     private readonly registrationDataService: RegistrationDataService,
   ) {}
-
-  public async save(
-    registration: RegistrationEntity,
-    retryCount?: number,
-    recalculateRegistrationProgramId = false,
-  ): Promise<RegistrationEntity> {
-    let saveRetriesCount = retryCount ? retryCount : 0;
-    if (recalculateRegistrationProgramId) {
-      const programId = registration.program?.id ?? registration.programId;
-      const query = this.registrationScopedRepository
-        .createQueryBuilder('r')
-        .select('r."registrationProgramId"')
-        .andWhere('r.programId = :programId', { programId })
-        .andWhere('r.registrationProgramId is not null')
-        .orderBy('r."registrationProgramId"', 'DESC')
-        .limit(1);
-      const result = await query.getRawOne();
-      registration.registrationProgramId = result
-        ? result.registrationProgramId + 1
-        : 1;
-    }
-    try {
-      return await this.registrationScopedRepository.save(registration);
-    } catch (error) {
-      if (error instanceof QueryFailedError) {
-        const errorCodesThatShouldBeRetried: string[] = [
-          PostgresStatusCodes.NOT_NULL_VIOLATION,
-          PostgresStatusCodes.UNIQUE_VIOLATION,
-        ];
-        if (
-          'code' in error &&
-          errorCodesThatShouldBeRetried.includes(String(error.code)) &&
-          saveRetriesCount < 3
-        ) {
-          saveRetriesCount++;
-          return await this.save(registration, saveRetriesCount, true);
-        }
-        if (saveRetriesCount >= 3) {
-          saveRetriesCount = 0;
-          throw error;
-        }
-      }
-
-      throw error;
-    }
-  }
 
   public async getFullName(registration: RegistrationEntity): Promise<string> {
     let fullName = '';

--- a/services/121-service/src/registration/repositories/registration-scoped.repository.ts
+++ b/services/121-service/src/registration/repositories/registration-scoped.repository.ts
@@ -68,37 +68,39 @@ export class RegistrationScopedRepository extends RegistrationScopedBaseReposito
   private async saveNewRegistration({
     registration,
     options,
-    attempt = 1,
   }: {
     registration: RegistrationEntity;
     options?: SaveOptions;
-    attempt?: number;
   }): Promise<RegistrationEntity> {
-    if (attempt > MAX_REGISTRATION_PROGRAM_ID_SAVE_ATTEMPTS) {
-      throw new Error(
-        `Failed to save a registration with a unique registrationProgramId after ${MAX_REGISTRATION_PROGRAM_ID_SAVE_ATTEMPTS} attempts.`,
-      );
-    }
-
-    registration.registrationProgramId =
-      await this.getNextRegistrationProgramId({
-        programId: registration.program?.id ?? registration.programId,
-      });
-
-    try {
-      return await this.repository.save(registration, options);
-    } catch (error) {
-      // Only retry the constraint that recalculating registrationProgramId can resolve, not any unrelated violation
-      if (this.isRegistrationProgramIdUniqueViolation(error)) {
-        return await this.saveNewRegistration({
-          registration,
-          options,
-          attempt: attempt + 1,
+    for (
+      let attempt = 1;
+      attempt <= MAX_REGISTRATION_PROGRAM_ID_SAVE_ATTEMPTS;
+      attempt++
+    ) {
+      registration.registrationProgramId =
+        await this.getNextRegistrationProgramId({
+          programId: registration.program?.id ?? registration.programId,
         });
-      } else {
-        throw error;
+
+      try {
+        return await this.repository.save(registration, options);
+      } catch (error) {
+        const isLastAttempt =
+          attempt === MAX_REGISTRATION_PROGRAM_ID_SAVE_ATTEMPTS;
+
+        // Only retry the constraint that recalculating registrationProgramId can resolve, not any unrelated violation
+        if (
+          !this.isRegistrationProgramIdUniqueViolation(error) ||
+          isLastAttempt
+        ) {
+          throw error;
+        }
       }
     }
+
+    throw new Error(
+      `Failed to save a registration with a unique registrationProgramId after ${MAX_REGISTRATION_PROGRAM_ID_SAVE_ATTEMPTS} attempts.`,
+    );
   }
 
   private isRegistrationProgramIdUniqueViolation(

--- a/services/121-service/src/registration/repositories/registration-scoped.repository.ts
+++ b/services/121-service/src/registration/repositories/registration-scoped.repository.ts
@@ -7,6 +7,7 @@ import {
   FindOptionsWhere,
   InsertResult,
   ObjectId,
+  QueryFailedError,
   RemoveOptions,
   SaveOptions,
   UpdateResult,
@@ -15,12 +16,18 @@ import { type QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialE
 
 import { ExportVisaCardDetailsRawData } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/interfaces/export-visa-card-details-raw-data.interface';
 import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/entities/program-registration-attribute.entity';
-import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
+import {
+  REGISTRATION_PROGRAM_UNIQUE_CONSTRAINT,
+  RegistrationEntity,
+} from '@121-service/src/registration/entities/registration.entity';
 import { RegistrationAttributeDataEntity } from '@121-service/src/registration/entities/registration-attribute-data.entity';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { GetDuplicatesResult } from '@121-service/src/registration/interfaces/get-duplicates-result.interface';
 import { RegistrationScopedBaseRepository } from '@121-service/src/registration/repositories/registration-scoped-base.repository';
+import { PostgresStatusCodes } from '@121-service/src/shared/enum/postgres-status-codes.enum';
 import { ScopedUserRequest } from '@121-service/src/shared/scoped-user-request';
+
+const MAX_REGISTRATION_PROGRAM_ID_SAVE_ATTEMPTS = 3;
 
 @Injectable({ scope: Scope.REQUEST, durable: true })
 export class RegistrationScopedRepository extends RegistrationScopedBaseRepository<RegistrationEntity> {
@@ -35,6 +42,7 @@ export class RegistrationScopedRepository extends RegistrationScopedBaseReposito
   ///////////////////////////////////////////////////////////////
   // COPIED IMPLEMENTATION OF REPOSITORY METHODS ////////////////
   //////////////////////////////////////////////////////////////
+  // Arrays are intentionally not supported: registrationProgramId assignment relies on saving one registration at a time
   public async save(
     entity: RegistrationEntity,
     options: SaveOptions & { reload: false },
@@ -44,18 +52,80 @@ export class RegistrationScopedRepository extends RegistrationScopedBaseReposito
     options?: SaveOptions,
   ): Promise<RegistrationEntity>;
   public async save(
-    entities: RegistrationEntity[],
-    options: SaveOptions & { reload: false },
-  ): Promise<RegistrationEntity[]>;
-  public async save(
-    entities: RegistrationEntity[],
+    entity: RegistrationEntity,
     options?: SaveOptions,
-  ): Promise<RegistrationEntity[]>;
-  public async save(
-    entityOrEntities: RegistrationEntity | RegistrationEntity[],
-    options?: SaveOptions,
-  ): Promise<RegistrationEntity | RegistrationEntity[]> {
-    return this.repository.save(entityOrEntities as any, options);
+  ): Promise<RegistrationEntity> {
+    if (entity.id) {
+      return this.repository.save(entity, options);
+    }
+
+    return this.saveNewRegistration({
+      registration: entity,
+      options,
+    });
+  }
+
+  private async saveNewRegistration({
+    registration,
+    options,
+    attempt = 1,
+  }: {
+    registration: RegistrationEntity;
+    options?: SaveOptions;
+    attempt?: number;
+  }): Promise<RegistrationEntity> {
+    if (attempt > MAX_REGISTRATION_PROGRAM_ID_SAVE_ATTEMPTS) {
+      throw new Error(
+        `Failed to save a registration with a unique registrationProgramId after ${MAX_REGISTRATION_PROGRAM_ID_SAVE_ATTEMPTS} attempts.`,
+      );
+    }
+
+    registration.registrationProgramId =
+      await this.getNextRegistrationProgramId({
+        programId: registration.program?.id ?? registration.programId,
+      });
+
+    try {
+      return await this.repository.save(registration, options);
+    } catch (error) {
+      // Only retry the constraint that recalculating registrationProgramId can resolve, not any unrelated violation
+      if (this.isRegistrationProgramIdUniqueViolation(error)) {
+        return await this.saveNewRegistration({
+          registration,
+          options,
+          attempt: attempt + 1,
+        });
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  private isRegistrationProgramIdUniqueViolation(
+    error: unknown,
+  ): error is QueryFailedError & { code: string; constraint: string } {
+    return (
+      error instanceof QueryFailedError &&
+      'code' in error &&
+      error.code === PostgresStatusCodes.UNIQUE_VIOLATION &&
+      'constraint' in error &&
+      error.constraint === REGISTRATION_PROGRAM_UNIQUE_CONSTRAINT
+    );
+  }
+
+  private async getNextRegistrationProgramId({
+    programId,
+  }: {
+    programId: number;
+  }): Promise<number> {
+    // Deliberately unscoped: registrationProgramId must be unique across all scopes within a program
+    const result = await this.repository
+      .createQueryBuilder('r')
+      .select('MAX(r."registrationProgramId")', 'max')
+      .andWhere('r.programId = :programId', { programId })
+      .getRawOne<{ max: number | null }>();
+
+    return (result?.max ?? 0) + 1;
   }
 
   public async insert(

--- a/services/121-service/src/registration/services/inclusion-score.service.ts
+++ b/services/121-service/src/registration/services/inclusion-score.service.ts
@@ -7,7 +7,6 @@ import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/en
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { RegistrationAttributeTypes } from '@121-service/src/registration/enum/registration-attribute.enum';
 import { RegistrationDataService } from '@121-service/src/registration/modules/registration-data/registration-data.service';
-import { RegistrationUtilsService } from '@121-service/src/registration/modules/registration-utils/registration-utils.service';
 import { RegistrationScopedRepository } from '@121-service/src/registration/repositories/registration-scoped.repository';
 
 @Injectable()
@@ -17,7 +16,6 @@ export class InclusionScoreService {
 
   public constructor(
     private readonly registrationScopedRepository: RegistrationScopedRepository,
-    private readonly registrationUtilsService: RegistrationUtilsService,
     private readonly registrationDataService: RegistrationDataService,
   ) {}
 
@@ -50,7 +48,7 @@ export class InclusionScoreService {
         Number(factorElements[0]) * Number(factorValue);
     }
     registration.paymentAmountMultiplier = paymentAmountMultiplier;
-    return await this.registrationUtilsService.save(registration);
+    return await this.registrationScopedRepository.save(registration);
   }
 
   public async calculateInclusionScore(referenceId: string): Promise<void> {
@@ -72,7 +70,7 @@ export class InclusionScoreService {
 
     registration.inclusionScore = score;
 
-    await this.registrationUtilsService.save(registration);
+    await this.registrationScopedRepository.save(registration);
   }
 
   private async createQuestionAnswerListPrefilled(

--- a/services/121-service/src/registration/services/registrations-creation.service.ts
+++ b/services/121-service/src/registration/services/registrations-creation.service.ts
@@ -26,7 +26,7 @@ import { ValidationRegistrationConfig } from '@121-service/src/registration/inte
 import { ValidateRegistrationErrorObject } from '@121-service/src/registration/interfaces/validate-registration-error-object.interface';
 import { ValidatedRegistrationInput } from '@121-service/src/registration/interfaces/validated-registration-input.interface';
 import { RegistrationDataScopedRepository } from '@121-service/src/registration/modules/registration-data/repositories/registration-data.scoped.repository';
-import { RegistrationUtilsService } from '@121-service/src/registration/modules/registration-utils/registration-utils.service';
+import { RegistrationScopedRepository } from '@121-service/src/registration/repositories/registration-scoped.repository';
 import { InclusionScoreService } from '@121-service/src/registration/services/inclusion-score.service';
 import { QueueRegistrationUpdateService } from '@121-service/src/registration/services/queue-registrations-update.service';
 import { RegistrationsBulkService } from '@121-service/src/registration/services/registrations-bulk.service';
@@ -53,7 +53,7 @@ export class RegistrationsCreationService {
     private readonly programService: ProgramService,
     private readonly fileImportService: FileImportService,
     private readonly registrationDataScopedRepository: RegistrationDataScopedRepository,
-    private readonly registrationUtilsService: RegistrationUtilsService,
+    private readonly registrationScopedRepository: RegistrationScopedRepository,
     private readonly queueRegistrationUpdateService: QueueRegistrationUpdateService,
     private readonly registrationsInputValidator: RegistrationsInputValidator,
     private readonly programFspConfigurationRepository: ProgramFspConfigurationRepository,
@@ -237,11 +237,8 @@ export class RegistrationsCreationService {
     // Save registrations using .save to properly set registrationProgramId
     const savedRegistrations: RegistrationEntity[] = [];
     for await (const registration of registrations) {
-      const savedRegistration = await this.registrationUtilsService.save(
-        registration,
-        undefined,
-        true,
-      );
+      const savedRegistration =
+        await this.registrationScopedRepository.save(registration);
       savedRegistrations.push(savedRegistration);
     }
 

--- a/services/121-service/src/registration/services/registrations.service.spec.ts
+++ b/services/121-service/src/registration/services/registrations.service.spec.ts
@@ -13,7 +13,6 @@ import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/en
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { RegistrationDataService } from '@121-service/src/registration/modules/registration-data/registration-data.service';
 import { RegistrationDataScopedRepository } from '@121-service/src/registration/modules/registration-data/repositories/registration-data.scoped.repository';
-import { RegistrationUtilsService } from '@121-service/src/registration/modules/registration-utils/registration-utils.service';
 import { RegistrationScopedRepository } from '@121-service/src/registration/repositories/registration-scoped.repository';
 import { RegistrationViewScopedRepository } from '@121-service/src/registration/repositories/registration-view-scoped.repository';
 import { UniqueRegistrationPairRepository } from '@121-service/src/registration/repositories/unique-registration-pair.repository';
@@ -58,6 +57,7 @@ describe('RegistrationsService', () => {
               return Promise.resolve({ id, registrationProgramId: 9999 });
             }),
             getWithRelationsByReferenceIdAndProgramId: jest.fn(),
+            save: jest.fn(),
           },
         },
         {
@@ -136,12 +136,6 @@ describe('RegistrationsService', () => {
           provide: UserService,
           useValue: {
             getProgramScopeIdsUserHasPermission: jest.fn(),
-          },
-        },
-        {
-          provide: RegistrationUtilsService,
-          useValue: {
-            save: jest.fn(),
           },
         },
         {

--- a/services/121-service/src/registration/services/registrations.service.ts
+++ b/services/121-service/src/registration/services/registrations.service.ts
@@ -38,7 +38,6 @@ import { ValidationRegistrationConfig } from '@121-service/src/registration/inte
 import { ValidatedRegistrationInput } from '@121-service/src/registration/interfaces/validated-registration-input.interface';
 import { RegistrationDataService } from '@121-service/src/registration/modules/registration-data/registration-data.service';
 import { RegistrationDataScopedRepository } from '@121-service/src/registration/modules/registration-data/repositories/registration-data.scoped.repository';
-import { RegistrationUtilsService } from '@121-service/src/registration/modules/registration-utils/registration-utils.service';
 import { RegistrationScopedRepository } from '@121-service/src/registration/repositories/registration-scoped.repository';
 import { RegistrationViewScopedRepository } from '@121-service/src/registration/repositories/registration-view-scoped.repository';
 import { UniqueRegistrationPairRepository } from '@121-service/src/registration/repositories/unique-registration-pair.repository';
@@ -68,7 +67,6 @@ export class RegistrationsService {
     private readonly registrationDataService: RegistrationDataService,
     private readonly registrationsPaginationService: RegistrationsPaginationService,
     private readonly userService: UserService,
-    private readonly registrationUtilsService: RegistrationUtilsService,
     private readonly registrationScopedRepository: RegistrationScopedRepository,
     private readonly registrationEventsService: RegistrationEventsService,
     private readonly registrationViewScopedRepository: RegistrationViewScopedRepository,
@@ -245,7 +243,7 @@ export class RegistrationsService {
     registration.program = await this.programRepository.findOneByOrFail({
       id: programId,
     });
-    await this.registrationUtilsService.save(registration, undefined, true);
+    await this.registrationScopedRepository.save(registration);
     return this.setRegistrationStatus(
       postData.referenceId,
       RegistrationStatusEnum.new,
@@ -572,7 +570,7 @@ export class RegistrationsService {
         });
     }
     const savedRegistration: RegistrationEntity =
-      await this.registrationUtilsService.save(registration);
+      await this.registrationScopedRepository.save(registration);
     const calculatedRegistration =
       await this.inclusionScoreService.calculatePaymentAmountMultiplier(
         program,

--- a/services/121-service/src/shared/enum/postgres-status-codes.enum.ts
+++ b/services/121-service/src/shared/enum/postgres-status-codes.enum.ts
@@ -5,6 +5,5 @@
  */
 export const enum PostgresStatusCodes {
   FOREIGN_KEY_VIOLATION = '23503',
-  NOT_NULL_VIOLATION = '23502',
   UNIQUE_VIOLATION = '23505',
 }

--- a/services/121-service/test/helpers/registration.helper.ts
+++ b/services/121-service/test/helpers/registration.helper.ts
@@ -1188,3 +1188,48 @@ export async function waitForRegistrationToHaveUpdatedPaymentCount({
 
   return registration;
 }
+
+export async function waitForRegistrationCount({
+  programId,
+  expectedCount,
+  accessToken,
+  sort,
+  maxWaitTimeMs = 10_000,
+  pollIntervalMs = 500,
+}: {
+  programId: number;
+  expectedCount: number;
+  accessToken: string;
+  sort?: { field: string; direction: 'ASC' | 'DESC' };
+  maxWaitTimeMs?: number;
+  pollIntervalMs?: number;
+}): Promise<MappedPaginatedRegistrationDto[]> {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < maxWaitTimeMs) {
+    const getRegistrationsResponse = await getRegistrations({
+      programId,
+      accessToken,
+      sort,
+    });
+    const registrations: MappedPaginatedRegistrationDto[] =
+      getRegistrationsResponse.body.data;
+
+    if (registrations.length === expectedCount) {
+      return registrations;
+    }
+
+    // An unexpected extra registration will never resolve itself, so fail fast instead of waiting out the timeout
+    if (registrations.length > expectedCount) {
+      throw new Error(
+        `Expected ${expectedCount} registrations in program ${programId}, but found ${registrations.length}`,
+      );
+    }
+
+    await waitFor(pollIntervalMs);
+  }
+
+  throw new Error(
+    `Timed out waiting for ${expectedCount} registrations in program ${programId}`,
+  );
+}

--- a/services/121-service/test/registrations/assign-registration-program-id.test.ts
+++ b/services/121-service/test/registrations/assign-registration-program-id.test.ts
@@ -1,0 +1,133 @@
+import { HttpStatus } from '@nestjs/common';
+
+import { DebugScope } from '@121-service/src/scripts/enum/debug-scope.enum';
+import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
+import { registrationScopedKisumuEastPv } from '@121-service/test/fixtures/scoped-registrations';
+import {
+  getRegistrations,
+  importRegistrations,
+  waitForRegistrationCount,
+} from '@121-service/test/helpers/registration.helper';
+import {
+  getAccessToken,
+  getAccessTokenScoped,
+  resetDB,
+} from '@121-service/test/helpers/utility.helper';
+import { programIdPV } from '@121-service/test/registrations/pagination/pagination-data';
+
+const numberOfConcurrentBatches = 3;
+const registrationsPerBatch = 2;
+const numberOfConcurrentRegistrations =
+  numberOfConcurrentBatches * registrationsPerBatch;
+const numberOfOutOfScopeRegistrations = 4;
+const numberOfInScopeRegistrations = 2;
+
+const createRegistrations = ({
+  scope,
+  referenceIdPrefix,
+  count,
+}: {
+  scope: DebugScope;
+  referenceIdPrefix: string;
+  count: number;
+}) =>
+  Array.from({ length: count }, (_, index) => ({
+    ...registrationScopedKisumuEastPv,
+    referenceId: `${referenceIdPrefix}-${index}`,
+    scope,
+  }));
+
+const createSequenceUpTo = (count: number) =>
+  Array.from({ length: count }, (_, index) => index + 1);
+
+describe('Assign registrationProgramId', () => {
+  let accessToken: string;
+
+  beforeEach(async () => {
+    await resetDB({ seedScript: SeedScript.nlrcMultiple });
+    accessToken = await getAccessToken();
+  });
+
+  it('should assign a unique sequential registrationProgramId to concurrently imported registrations', async () => {
+    // Arrange
+    const registrationBatches = Array.from(
+      { length: numberOfConcurrentBatches },
+      (_, batchIndex) =>
+        createRegistrations({
+          scope: DebugScope.KisumuEast,
+          referenceIdPrefix: `concurrent-import-${batchIndex}`,
+          count: registrationsPerBatch,
+        }),
+    );
+
+    // Act
+    await Promise.all(
+      registrationBatches.map((registrations) =>
+        importRegistrations(programIdPV, registrations, accessToken),
+      ),
+    );
+
+    // Assert
+    const registrations = await waitForRegistrationCount({
+      programId: programIdPV,
+      expectedCount: numberOfConcurrentRegistrations,
+      accessToken,
+      sort: { field: 'registrationProgramId', direction: 'ASC' },
+    });
+
+    expect(
+      registrations.map((registration) => registration.registrationProgramId),
+    ).toEqual(createSequenceUpTo(numberOfConcurrentRegistrations));
+  });
+
+  it('should continue the registrationProgramId sequence of registrations outside the scope of the importing user', async () => {
+    // Arrange
+    await importRegistrations(
+      programIdPV,
+      createRegistrations({
+        scope: DebugScope.TurkanaNorth,
+        referenceIdPrefix: 'out-of-scope-import',
+        count: numberOfOutOfScopeRegistrations,
+      }),
+      accessToken,
+    );
+    const scopedAccessToken = await getAccessTokenScoped(DebugScope.Kisumu);
+
+    // Act
+    const importResponse = await importRegistrations(
+      programIdPV,
+      createRegistrations({
+        scope: DebugScope.KisumuEast,
+        referenceIdPrefix: 'in-scope-import',
+        count: numberOfInScopeRegistrations,
+      }),
+      scopedAccessToken,
+    );
+
+    // Assert
+    expect(importResponse.statusCode).toBe(HttpStatus.CREATED);
+
+    const scopedRegistrationsResponse = await getRegistrations({
+      programId: programIdPV,
+      accessToken: scopedAccessToken,
+    });
+    expect(scopedRegistrationsResponse.body.data).toHaveLength(
+      numberOfInScopeRegistrations,
+    );
+
+    const registrations = await waitForRegistrationCount({
+      programId: programIdPV,
+      expectedCount:
+        numberOfOutOfScopeRegistrations + numberOfInScopeRegistrations,
+      accessToken,
+      sort: { field: 'registrationProgramId', direction: 'ASC' },
+    });
+    expect(
+      registrations.map((registration) => registration.registrationProgramId),
+    ).toEqual(
+      createSequenceUpTo(
+        numberOfOutOfScopeRegistrations + numberOfInScopeRegistrations,
+      ),
+    );
+  });
+});


### PR DESCRIPTION
[AB#44188](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44188) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

It does these things:

1. Move registration save to the repository service
2. Fixes a scope related bug: RegistrationScopedRepository's query builder silently filters results to the current user's program-scope (adding a scope LIKE :scope clause), so when computing "the highest existing registrationProgramId" for a new registration, it only looked at rows within that user's scope instead of the whole program. That means two users creating registrations in different scopes of the same program could both compute the same "next" registrationProgramId, causing a unique-constraint collision — and worse, the retry logic would recompute the exact same (wrong) scoped max every time, so it could never actually resolve the collision. 
3. Make it a bit more readable using early return
4. Use registration.id as an indicator whether we want to calculate a registrationProgramId.If registration.id exists it means that the registration already exists and it's an UPDATE rather than an INSERT which means the whole registrationProgramId calculation is not needed
5. Always calculate the registrationProgramId when create a new registration
6. Make the catch more specific

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
