### PR TITLE
refactor: Make all Toast-message-validators more specific and predictable

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -140,12 +140,16 @@ import { test } from '@121-e2e/portal/fixtures/fixture';
 Declare the fixtures you need as parameters in your test function. Playwright will automatically provide them:
 
 ```typescript
-test('Do successful payment for CBE FSP', async ({
+test('Do successful payment for FSP: CBE', async ({
   page,
   paymentPage,
   paymentsPage,
 }) => {
-  await paymentSetup.paymentsPage.createPayment({});
+  await paymentsPage.createPayment({});
+  await page.waitForURL((url) =>
+    url.pathname.endsWith(`/program/${programIdCbe}/payments/1`),
+  );
+  await paymentPage.approvePayment();
 });
 ```
 

--- a/e2e/portal/components/ExportData.ts
+++ b/e2e/portal/components/ExportData.ts
@@ -49,7 +49,7 @@ class ExportData extends BasePage {
       sortFunction,
     });
 
-    await this.dismissToastIfVisible('This might take a few minutes');
+    await this.validateToastMessageAndClose('This might take a few minutes');
   }
 }
 

--- a/e2e/portal/pages/BasePage.ts
+++ b/e2e/portal/pages/BasePage.ts
@@ -122,27 +122,23 @@ class BasePage {
     await this.page.getByRole('menuitem', { name: option }).click();
   }
 
-  // To speed tests up we can validate the toast message and close it
-  // without waiting for the toast to disappear by itself (this takes 5 seconds)
+  /**
+   * We validate the toast message and close it, to speed up the tests.
+   * We don't need to wait for the toast to disappear by itself (this takes 5 seconds)
+   */
   async validateToastMessageAndClose(message: string) {
-    await expect(this.toast.first()).toBeVisible({ timeout: 5_000 });
-    expect(await this.toast.first().textContent()).toContain(message);
-    await this.dismissToastIfVisible(message);
-  }
+    const toastLocator = this.toast.filter({
+      visible: true,
+      hasText: message,
+    });
 
-  async dismissToastIfVisible(message?: string) {
-    let toastLocator = this.toast;
-    if (message) {
-      toastLocator = this.toast.filter({ hasText: message });
-    }
-    // Handle multiple toasts, only dismiss the first visible one matching the filter
+    // Handle multiple toasts (if any)
     const visibleToasts = await toastLocator.all();
+
     for (const toast of visibleToasts) {
-      if (await toast.isVisible()) {
-        await toast.getByRole('button').click();
-        await expect(toast).toBeHidden();
-        break;
-      }
+      await expect(toast).toBeVisible();
+      await toast.getByRole('button').click();
+      await expect(toast).toBeHidden();
     }
   }
 

--- a/e2e/portal/pages/BasePage.ts
+++ b/e2e/portal/pages/BasePage.ts
@@ -128,16 +128,13 @@ class BasePage {
    */
   async validateToastMessageAndClose(message: string) {
     const toastLocator = this.toast.filter({
+      visible: true,
       hasText: message,
     });
 
     // Handle multiple toasts (if any)
-    const visibleToasts = await toastLocator.all();
-
-    for (const toast of visibleToasts) {
-      await expect(toast).toBeVisible();
+    for (const toast of await toastLocator.all()) {
       await toast.getByRole('button').click();
-      await expect(toast).toBeHidden();
     }
   }
 

--- a/e2e/portal/pages/BasePage.ts
+++ b/e2e/portal/pages/BasePage.ts
@@ -128,7 +128,6 @@ class BasePage {
    */
   async validateToastMessageAndClose(message: string) {
     const toastLocator = this.toast.filter({
-      visible: true,
       hasText: message,
     });
 

--- a/e2e/portal/pages/BasePage.ts
+++ b/e2e/portal/pages/BasePage.ts
@@ -122,16 +122,8 @@ class BasePage {
     await this.page.getByRole('menuitem', { name: option }).click();
   }
 
-  async validateToastMessage(message: string) {
-    await expect(this.toast).toBeVisible();
-    expect(await this.toast.textContent()).toContain(message);
-    await expect(this.toast).toBeHidden({
-      timeout: 6_000, // by default, toasts are visible for 5s, adding some buffer time to account for the fade out animation
-    });
-  }
-
   // To speed tests up we can validate the toast message and close it
-  // without waiting for the toast to disappear after 6 seconds
+  // without waiting for the toast to disappear by itself (this takes 5 seconds)
   async validateToastMessageAndClose(message: string) {
     await expect(this.toast.first()).toBeVisible({ timeout: 5_000 });
     expect(await this.toast.first().textContent()).toContain(message);

--- a/e2e/portal/pages/BasePage.ts
+++ b/e2e/portal/pages/BasePage.ts
@@ -142,6 +142,18 @@ class BasePage {
     }
   }
 
+  /**
+   * Validate a message is visible without dismissing, for when dismissing the toast is not possible because of some other modal/popup/overlay.
+   * @see validateToastMessageAndClose for the _*preferred*_ way to validate toast messages
+   */
+  async validateToastMessageIsVisibleOnly(message: string) {
+    const toastLocator = this.toast.filter({
+      visible: true,
+      hasText: message,
+    });
+    await expect(toastLocator).toBeVisible();
+  }
+
   async waitForPageLoad() {
     await this.page.waitForLoadState('networkidle');
     await this.page.waitForLoadState('domcontentloaded');

--- a/e2e/portal/pages/BasePage.ts
+++ b/e2e/portal/pages/BasePage.ts
@@ -146,11 +146,6 @@ class BasePage {
     }
   }
 
-  async dismissToast() {
-    await this.toast.getByRole('button').click();
-    await expect(this.toast).toBeHidden();
-  }
-
   async waitForPageLoad() {
     await this.page.waitForLoadState('networkidle');
     await this.page.waitForLoadState('domcontentloaded');

--- a/e2e/portal/pages/BasePage.ts
+++ b/e2e/portal/pages/BasePage.ts
@@ -104,9 +104,21 @@ class BasePage {
     await this.accountDropdown.click();
   }
 
-  async performActionWithRightClick(action: string, row = 0) {
-    await this.table.tableRows.nth(row).click({ button: 'right' });
-    await this.page.getByLabel(action).click();
+  async performActionWithRightClick(action: string, row: number | Locator = 0) {
+    let rowLocator: Locator;
+
+    if (typeof row === 'number') {
+      rowLocator = this.table.tableRows.nth(row);
+    } else {
+      rowLocator = row;
+    }
+
+    await expect(rowLocator).toHaveCount(1);
+    await rowLocator.click({ button: 'right' });
+
+    const actionMenuItem = this.page.getByLabel(action);
+    await expect(actionMenuItem).toBeVisible();
+    await actionMenuItem.click();
 
     if (
       action !== 'Message' &&

--- a/e2e/portal/pages/ChangePasswordPage.ts
+++ b/e2e/portal/pages/ChangePasswordPage.ts
@@ -39,7 +39,9 @@ class ChangePasswordPage extends BasePage {
   }
 
   async assertChangePasswordSuccessPopUp() {
-    await this.validateToastMessage('Your password was successfully changed.');
+    await this.validateToastMessageAndClose(
+      'Your password was successfully changed.',
+    );
   }
 }
 

--- a/e2e/portal/pages/PaymentPage.ts
+++ b/e2e/portal/pages/PaymentPage.ts
@@ -199,9 +199,9 @@ class PaymentPage extends BasePage {
     }
   }
 
-  async validatePaymentDetailsPageTitle(title?: string) {
-    const viewPaymentTitle = await this.viewPaymentTitle.textContent();
-    expect(viewPaymentTitle).toContain(title ?? 'Payment');
+  async validatePaymentDetailsPageTitle(title = 'Payment') {
+    await expect(this.viewPaymentTitle).toBeVisible();
+    await expect(this.viewPaymentTitle).toContainText(title);
   }
 
   async selectPaymentExportOption({ option }: { option: string }) {

--- a/e2e/portal/pages/PaymentPage.ts
+++ b/e2e/portal/pages/PaymentPage.ts
@@ -47,7 +47,7 @@ class PaymentPage extends BasePage {
       'form-dialog-submit-button',
     );
     this.viewPaymentTitle = this.page.getByRole('heading', {
-      name: /Payment/,
+      level: 1,
     });
     this.paymentAmount = this.page.getByTestId('metric-tile-component');
     this.retryFailedTransactionsButton = this.page.getByRole('button', {
@@ -199,9 +199,9 @@ class PaymentPage extends BasePage {
     }
   }
 
-  async validatePaymentDetailsPageTitle() {
+  async validatePaymentDetailsPageTitle(title?: string) {
     const viewPaymentTitle = await this.viewPaymentTitle.textContent();
-    expect(viewPaymentTitle).toContain('Payment');
+    expect(viewPaymentTitle).toContain(title ?? 'Payment');
   }
 
   async selectPaymentExportOption({ option }: { option: string }) {

--- a/e2e/portal/pages/ProgramSettingsRegistrationDataPage.ts
+++ b/e2e/portal/pages/ProgramSettingsRegistrationDataPage.ts
@@ -38,7 +38,7 @@ class ProgramSettingsRegistrationDataPage extends BasePage {
     this.initiateImportButton = this.page.getByRole('button', {
       name: 'Import registrations',
     });
-    this.closeImportDialog = this.page.getByRole('button', {
+    this.closeImportDialog = this.importDialog.getByRole('button', {
       name: 'Close',
     });
     this.languageTabs = this.page.getByTestId('language-tab');

--- a/e2e/portal/pages/RegistrationActivityLogPage.ts
+++ b/e2e/portal/pages/RegistrationActivityLogPage.ts
@@ -23,18 +23,25 @@ class RegistrationActivityLogPage extends RegistrationBasePage {
     this.saveButton = this.page.getByRole('button', { name: 'Save' });
   }
 
+  async resetTableStateStorage() {
+    await this.page.localStorage.removeItem('activity-log-table');
+  }
+
   async validateLastMessageSent(message: string) {
-    const dropdownButton = await this.table.getCell(0, 0);
-    const lastMessage = (await this.table.getCell(0, 1)).getByText('Message');
-    const lastMessageText = await lastMessage.innerText();
+    const lastMessageRow = this.table.tableRows
+      .filter({
+        has: this.page.getByText('Message', { exact: true }),
+      })
+      .first();
 
-    if (lastMessageText === 'Message') {
-      await dropdownButton.click();
-    }
+    await expect(lastMessageRow).toBeVisible();
 
-    const sentMessageText = await this.page.getByText(message).innerText();
-    expect(sentMessageText).toBe(message);
-    await dropdownButton.click();
+    await expect(this.page.getByText(message)).not.toBeVisible();
+
+    // The expanded state of this row is remembered in localStorage! So resetting the table-state is required for predictable test behavior.
+    await lastMessageRow.getByLabel('Toggle row').click();
+
+    await expect(this.page.getByText(message)).toBeVisible();
   }
 
   async navigateToPersonalInformation() {

--- a/e2e/portal/pages/RegistrationBasePage.ts
+++ b/e2e/portal/pages/RegistrationBasePage.ts
@@ -5,6 +5,7 @@ import DataListComponent from '../components/DataListComponent';
 import BasePage from './BasePage';
 
 abstract class RegistrationBasePage extends BasePage {
+  readonly registrationTitle: Locator;
   readonly duplicateChip: Locator;
   readonly duplicatesBanner: Locator;
 
@@ -12,12 +13,12 @@ abstract class RegistrationBasePage extends BasePage {
     super(page);
     this.duplicateChip = this.page.getByTestId('duplicate-chip');
     this.duplicatesBanner = this.page.getByTestId('duplicates-banner');
+    this.registrationTitle = this.page.getByTestId('registration-title');
   }
 
   async getRegistrationTitle(): Promise<string> {
-    const titleElement = this.page.getByTestId('registration-title');
-    await titleElement.waitFor();
-    return (await titleElement.textContent())?.trim() ?? '';
+    await this.registrationTitle.waitFor();
+    return (await this.registrationTitle.textContent())?.trim() ?? '';
   }
 
   async getRegistrationSummaryList(): Promise<Record<string, string>> {

--- a/e2e/portal/pages/RegistrationsPage.ts
+++ b/e2e/portal/pages/RegistrationsPage.ts
@@ -354,7 +354,7 @@ class RegistrationsPage extends BasePage {
     const filePath = await this.downloadFile(() =>
       this.exportCSVButton.click(),
     );
-    await this.validateToastMessageAndClose('Exporting');
+    await this.validateToastMessageIsVisibleOnly('Exporting');
     await this.validateExportedFile({
       filePath,
       expectedRowCount,
@@ -397,6 +397,8 @@ class RegistrationsPage extends BasePage {
       .check();
 
     await this.importFileButton.click();
+    // Wait for the upload to complete
+    await this.page.waitForLoadState('networkidle');
   }
 
   async assertImportTemplateForPvProgram() {

--- a/e2e/portal/pages/RegistrationsPage.ts
+++ b/e2e/portal/pages/RegistrationsPage.ts
@@ -65,7 +65,7 @@ class RegistrationsPage extends BasePage {
   }
 
   async typeCustomMessage(message: string) {
-    await this.page.fill('textarea', message);
+    await this.page.getByLabel('Message:').fill(message);
   }
 
   async selectTemplatedMessage(messageTemplate: string) {
@@ -79,14 +79,8 @@ class RegistrationsPage extends BasePage {
       .click();
   }
 
-  async validateMessagePresent(message: string) {
-    await this.page.waitForTimeout(200);
-    await expect(this.page.locator('textarea')).toHaveAttribute('readonly');
-    const textboxValue = await this.page.$eval(
-      'textarea',
-      (textarea) => textarea.value,
-    );
-    expect(textboxValue).toContain(message);
+  async validateMessagePreview(message: string) {
+    await expect(this.page.getByLabel('Message preview')).toHaveValue(message);
   }
 
   async sendMessage() {
@@ -104,7 +98,7 @@ class RegistrationsPage extends BasePage {
       expect(
         await this.manageTableSidebar.getByRole('checkbox').count(),
       ).toBeGreaterThan(0);
-    }).toPass({ timeout: 5000 });
+    }).toPass({ timeout: 5_000 });
   }
 
   async configureTableColumns({

--- a/e2e/portal/pages/RegistrationsPage.ts
+++ b/e2e/portal/pages/RegistrationsPage.ts
@@ -229,23 +229,15 @@ class RegistrationsPage extends BasePage {
   }: {
     registrationName: string;
   }) {
-    await this.page.waitForLoadState('domcontentloaded');
-    await this.page.waitForLoadState('networkidle');
-    const rowCount = await this.table.tableRows.count();
-    for (let i = 0; i <= rowCount; i++) {
-      const fullName = await this.table.getCell(i, 2);
-      const fullNameText = (await fullName.textContent())?.trim();
-      const isRequestedFullName = fullNameText?.includes(registrationName);
+    await this.table.waitForLoaded();
 
-      if (
-        (registrationName && isRequestedFullName) ||
-        (!registrationName && !isRequestedFullName)
-      ) {
-        await fullName.getByRole('link').click();
-        return;
-      }
-    }
-    throw new Error('Registration not found');
+    const registrationLink = this.table.table.getByRole('link', {
+      name: registrationName,
+      exact: true,
+    });
+
+    await expect(registrationLink).toHaveCount(1);
+    await registrationLink.click();
   }
 
   async performActionOnRegistrationByName({
@@ -255,23 +247,18 @@ class RegistrationsPage extends BasePage {
     registrationName: string;
     action: string;
   }) {
-    await this.page.waitForLoadState('domcontentloaded');
-    await this.page.waitForLoadState('networkidle');
-    const rowCount = await this.table.tableRows.count();
-    for (let i = 0; i <= rowCount; i++) {
-      const fullName = await this.table.getCell(i, 2);
-      const fullNameText = (await fullName.textContent())?.trim();
-      const isRequestedFullName = fullNameText?.includes(registrationName);
+    await this.table.waitForLoaded();
 
-      if (
-        (registrationName && isRequestedFullName) ||
-        (!registrationName && !isRequestedFullName)
-      ) {
-        await this.performActionWithRightClick(action, i);
-        return;
-      }
-    }
-    throw new Error('Registration not found');
+    const registrationRow = this.table.tableRows.filter({
+      has: this.page.getByRole('link', {
+        name: registrationName,
+        exact: true,
+      }),
+    });
+
+    await expect(registrationRow).toHaveCount(1);
+
+    await this.performActionWithRightClick(action, registrationRow);
   }
 
   async cancelSendMessageBulkAction() {

--- a/e2e/portal/pages/UsersPage.ts
+++ b/e2e/portal/pages/UsersPage.ts
@@ -84,7 +84,7 @@ class UsersPage extends BasePage {
     fullName: string;
     email: string;
   }) {
-    await this.validateToastMessage('User added');
+    await this.validateToastMessageAndClose('User added');
     await this.validateRowTextContent({
       email,
       textContent: `${fullName} ${email}`,

--- a/e2e/portal/tests/ChangeRegistrationStatus/ChangeRegistrationStatusOfRegistrationsIncludedInPendingPayments.spec.ts
+++ b/e2e/portal/tests/ChangeRegistrationStatus/ChangeRegistrationStatusOfRegistrationsIncludedInPendingPayments.spec.ts
@@ -74,7 +74,7 @@ test('Pause registrations included in pending payments', async ({
       submit: true,
     });
 
-    await registrationsPage.validateToastMessage(
+    await registrationsPage.validateToastMessageAndClose(
       `The status of 3 registration(s) is being changed to "Paused" successfully. The status change can take up to a minute to process.`,
     );
   });
@@ -144,7 +144,7 @@ test('Decline registrations included in pending payments', async ({
       submit: true,
     });
 
-    await registrationsPage.validateToastMessage(
+    await registrationsPage.validateToastMessageAndClose(
       `The status of 3 registration(s) is being changed to "Declined" successfully. The status change can take up to a minute to process.`,
     );
   });

--- a/e2e/portal/tests/CreateProgram/CreateProgramSuccessfully.spec.ts
+++ b/e2e/portal/tests/CreateProgram/CreateProgramSuccessfully.spec.ts
@@ -60,7 +60,7 @@ test('Create program successfully', async ({
       await page.waitForURL((url) =>
         url.pathname.startsWith(`/en-GB/program/${newProgramId}/settings`),
       );
-      await programOverviewPage.validateToastMessage(
+      await programOverviewPage.validateToastMessageAndClose(
         'Program successfully created.',
       );
     });
@@ -90,7 +90,7 @@ test('Duplicate program successfully', async ({
     await page.waitForURL((url) =>
       url.pathname.startsWith(`/en-GB/program/${newProgramId}/settings`),
     );
-    await programOverviewPage.validateToastMessage(
+    await programOverviewPage.validateToastMessageAndClose(
       'Program successfully duplicated.',
     );
   });
@@ -147,7 +147,7 @@ test('Create program validation checks on each step', async ({
 
   await test.step('Should successfully proceed without filling in step 3', async () => {
     await createProgramDialog.submitButton.click();
-    await programOverviewPage.validateToastMessage(
+    await programOverviewPage.validateToastMessageAndClose(
       'Program successfully created.',
     );
   });

--- a/e2e/portal/tests/DebitCards/LinkVisaCardToRegistration.spec.ts
+++ b/e2e/portal/tests/DebitCards/LinkVisaCardToRegistration.spec.ts
@@ -129,17 +129,20 @@ test.describe('Link Visa card to registration', () => {
         'Visa card linked successfully',
       );
 
-      // The behaviour of the page right now is that FE does not refresh immediately and the page should be refreshed to get new and old card numbers
-      // I think this should not work like that
-      // await page.reload();
-      const currentDebitCardDataList =
-        await registrationDebitCardPage.getCurrentDebitCardDataList();
-      const substituteDebitCardDataList =
-        await registrationDebitCardPage.getSubstituteDebitCardDataList();
-      expect(currentDebitCardDataList['Serial number']).toBe(newVisaCardNumber);
-      expect(substituteDebitCardDataList['Serial number']).toBe(
-        visaCardNumberDashed,
-      );
+      // The information in the page will update automatically, eventually
+      await expect(async () => {
+        const currentDebitCardDataList =
+          await registrationDebitCardPage.getCurrentDebitCardDataList();
+        const substituteDebitCardDataList =
+          await registrationDebitCardPage.getSubstituteDebitCardDataList();
+
+        expect(currentDebitCardDataList['Serial number']).toBe(
+          newVisaCardNumber,
+        );
+        expect(substituteDebitCardDataList['Serial number']).toBe(
+          visaCardNumberDashed,
+        );
+      }).toPass({ timeout: 3_000 });
     });
   });
 

--- a/e2e/portal/tests/DoPayment/DoPaymentWithCustomName.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoPaymentWithCustomName.spec.ts
@@ -23,8 +23,9 @@ test('Create payment with a custom name', async ({
   const customName = 'My custom payment';
 
   await paymentsPage.createPayment({ name: customName });
+  await paymentPage.validateToastMessageAndClose('Payment created.');
   await page.waitForURL((url) =>
     url.pathname.startsWith(`/en-GB/program/${programIdOCW}/payments/1`),
   );
-  await paymentPage.validateToastMessageAndClose('Payment created.');
+  await paymentPage.validatePaymentDetailsPageTitle(customName);
 });

--- a/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithCbe.spec.ts
+++ b/e2e/portal/tests/DoPayment/DoSuccessfulPaymentWithCbe.spec.ts
@@ -19,7 +19,7 @@ test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   });
 });
 
-test('Do successful payment for Cbe fsp', async ({
+test('Do successful payment for FSP: CBE', async ({
   page,
   paymentPage,
   paymentsPage,
@@ -32,13 +32,12 @@ test('Do successful payment for Cbe fsp', async ({
   }, 0);
 
   await test.step('Do payment', async () => {
-    await paymentsPage.createPayment({});
+    await paymentsPage.createPayment({ name: 'CBE Payment' });
     // Assert redirection to payment overview page
     await page.waitForURL((url) =>
       url.pathname.startsWith(`/en-GB/program/${programIdCbe}/payments/1`),
     );
-    // Assert payment overview page by payment date/ title
-    await paymentPage.validatePaymentDetailsPageTitle();
+    await paymentPage.validatePaymentDetailsPageTitle('CBE Payment');
     await paymentPage.approvePayment();
     await paymentPage.startPayment();
 
@@ -54,9 +53,7 @@ test('Do successful payment for Cbe fsp', async ({
     await page.waitForURL((url) =>
       url.pathname.startsWith(`/en-GB/program/${programIdCbe}/payments/1`),
     );
-    // Assert payment overview page by payment date/ title
-    // @TODO: Does this really validate anything? I don't think checking if a H1 renders validates anything tbh
-    await paymentPage.validatePaymentDetailsPageTitle();
+    await paymentPage.validatePaymentDetailsPageTitle('CBE Payment');
   });
 
   await test.step('Validate payment card', async () => {

--- a/e2e/portal/tests/ManageTeam/AssignSuccessfullyRolesToUser.spec.ts
+++ b/e2e/portal/tests/ManageTeam/AssignSuccessfullyRolesToUser.spec.ts
@@ -41,7 +41,7 @@ test('Assign successfully roles to a user ', async ({ programTeamPage }) => {
       userEmail: userFullEmail,
       role: userRole,
     });
-    await programTeamPage.validateToastMessage('User added');
+    await programTeamPage.validateToastMessageAndClose('User added');
     await programTeamPage.validateAssignedTeamMembers(expectedAssignedUsers);
   });
 });

--- a/e2e/portal/tests/ManageTeam/RemoveUserFromTeam.spec.ts
+++ b/e2e/portal/tests/ManageTeam/RemoveUserFromTeam.spec.ts
@@ -47,7 +47,7 @@ test('Users should be removable from "program team"', async ({
     await programTeamPage.removeUserFromTeam({
       userEmail: userToRemove,
     });
-    await programTeamPage.validateToastMessage('User removed');
+    await programTeamPage.validateToastMessageAndClose('User removed');
     await programTeamPage.validateAssignedTeamMembers(
       expectedFinalAssignedUsers,
     );

--- a/e2e/portal/tests/ProgramMonitoring/OrderDebitCards.spec.ts
+++ b/e2e/portal/tests/ProgramMonitoring/OrderDebitCards.spec.ts
@@ -79,7 +79,7 @@ test('Should be able to order debit cards when card distribution by mail is disa
     );
     await programMonitoringPage.selectTab({ tabName: 'Debit Cards' });
     await programMonitoringPage.orderCards(orderDebitCardOrder);
-    await programMonitoringPage.validateToastMessage(
+    await programMonitoringPage.validateToastMessageAndClose(
       'Order started. Check the table for progress.',
     );
 

--- a/e2e/portal/tests/ProgramSettings/FSP configuration/DuplicateAndDeleteExcelFsp.spec.ts
+++ b/e2e/portal/tests/ProgramSettings/FSP configuration/DuplicateAndDeleteExcelFsp.spec.ts
@@ -39,7 +39,7 @@ test('Duplicate and delete Excel FSP', async ({
     });
     await fspSettingsPage.configureExcelFsp({});
     await fspSettingsPage.saveReconfigurationButton.click();
-    await fspSettingsPage.validateToastMessage(
+    await fspSettingsPage.validateToastMessageAndClose(
       'Success FSP "Excel Payment Instructions" integrated successfully.',
     );
   });
@@ -53,7 +53,7 @@ test('Duplicate and delete Excel FSP', async ({
       withName: 'Excel Payment Instructions 2',
     });
     await fspSettingsPage.integrateFspButton.click();
-    await fspSettingsPage.validateToastMessage(
+    await fspSettingsPage.validateToastMessageAndClose(
       'Success FSP "Excel Payment Instructions 2" integrated successfully.',
     );
     await fspSettingsPage.validateProgramFspCards({

--- a/e2e/portal/tests/ProgramSettings/RegistrationData/RefreshKoboIntegration.spec.ts
+++ b/e2e/portal/tests/ProgramSettings/RegistrationData/RefreshKoboIntegration.spec.ts
@@ -140,7 +140,7 @@ test('Refresh Kobo integration - unsuccessful with error payload', async ({
   });
 
   await test.step('Validate error dialog for Kobo integration failure', async () => {
-    await programSettingsRegistrationDataPage.validateToastMessage(
+    await programSettingsRegistrationDataPage.validateToastMessageAndClose(
       'Integration update unsuccessful. Please try again.',
     );
 

--- a/e2e/portal/tests/ProgramSettings/RegistrationData/RefreshKoboIntegration.spec.ts
+++ b/e2e/portal/tests/ProgramSettings/RegistrationData/RefreshKoboIntegration.spec.ts
@@ -140,7 +140,7 @@ test('Refresh Kobo integration - unsuccessful with error payload', async ({
   });
 
   await test.step('Validate error dialog for Kobo integration failure', async () => {
-    await programSettingsRegistrationDataPage.validateToastMessageAndClose(
+    await programSettingsRegistrationDataPage.validateToastMessageIsVisibleOnly(
       'Integration update unsuccessful. Please try again.',
     );
 

--- a/e2e/portal/tests/ProgramSettings/RegistrationData/ValidateKoboIntegrationErrorMessage.spec.ts
+++ b/e2e/portal/tests/ProgramSettings/RegistrationData/ValidateKoboIntegrationErrorMessage.spec.ts
@@ -39,7 +39,7 @@ test('Add Kobo integration with invalid details and validate error message', asy
   });
 
   await test.step('Validate error dialog for Kobo integration failure', async () => {
-    await programSettingsRegistrationDataPage.validateToastMessage(
+    await programSettingsRegistrationDataPage.validateToastMessageAndClose(
       'Error while integrating Kobo form',
     );
 

--- a/e2e/portal/tests/SendMessage/SendCustomMessage.spec.ts
+++ b/e2e/portal/tests/SendMessage/SendCustomMessage.spec.ts
@@ -1,3 +1,5 @@
+import { expect } from '@playwright/test';
+
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import {
   programIdPV,
@@ -6,46 +8,59 @@ import {
 
 import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
 
-test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
-  await resetDBAndSeedRegistrations({
-    seedScript: SeedScript.nlrcMultiple,
-    registrations: registrationsPV,
-    programId: programIdPV,
-    navigateToPage: `/program/${programIdPV}/registrations`,
+test.describe('Send custom message', () => {
+  test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
+    await resetDBAndSeedRegistrations({
+      seedScript: SeedScript.nlrcMultiple,
+      registrations: registrationsPV,
+      programId: programIdPV,
+      navigateToPage: `/program/${programIdPV}/registrations`,
+    });
   });
-});
 
-test('Send custom message', async ({
-  registrationsPage,
-  registrationActivityLogPage,
-}) => {
-  await test.step('Send custom message', async () => {
-    const registrationFullName =
-      await registrationsPage.getFirstRegistrationNameFromTable();
-    if (!registrationFullName) {
-      throw new Error('Registration full name is undefined');
-    }
-    const customMessageText =
-      'This is {{fullName}} custom message from the Red Cross.';
-    const customMessagePreview = `This is ${registrationFullName} custom message from the Red Cross.`;
-    const sendingMessageToast =
-      'Closing this notification will not cancel message sending.';
+  test('Send custom message', async ({
+    page,
+    registrationsPage,
+    registrationActivityLogPage,
+  }) => {
+    const registrationFullName = 'Jack Strong';
+    const customMessageContent =
+      'This is a custom message from the Red Cross for: {{fullName}}';
+    const customMessageResult = `This is a custom message from the Red Cross for: ${registrationFullName}`;
 
-    await registrationsPage.selectAllRegistrations();
-    await registrationsPage.selectBulkAction('Message');
-    await registrationsPage.selectCustomMessage();
-    await registrationsPage.typeCustomMessage(customMessageText);
-    await registrationsPage.clickContinueToPreview();
-    await registrationsPage.validateMessagePresent(customMessagePreview);
-    await registrationsPage.sendMessage();
-
-    await registrationsPage.validateToastMessageAndClose(sendingMessageToast);
-    await registrationsPage.goToRegistrationByName({
-      registrationName: registrationFullName,
+    await test.step('Select registration', async () => {
+      await registrationsPage.selectAllRegistrations();
+      await registrationsPage.selectBulkAction('Message');
     });
 
-    await registrationActivityLogPage.validateLastMessageSent(
-      customMessagePreview,
-    );
+    await test.step('Send message', async () => {
+      await registrationsPage.selectCustomMessage();
+      await registrationsPage.typeCustomMessage(customMessageContent);
+      await registrationsPage.clickContinueToPreview();
+      await registrationsPage.validateMessagePreview(customMessageResult);
+      await registrationsPage.sendMessage();
+      await registrationsPage.validateToastMessageAndClose(
+        'Closing this notification will not cancel message sending.',
+      );
+      await page.waitForTimeout(900); // Sending the message takes time
+    });
+
+    await test.step('Verify message', async () => {
+      // Prepare a clean slate from any previous tries/actions on the page
+      await registrationActivityLogPage.resetTableStateStorage();
+
+      await registrationsPage.goto(`/program/${programIdPV}/registrations`);
+
+      await registrationsPage.goToRegistrationByName({
+        registrationName: registrationFullName,
+      });
+      await expect(registrationActivityLogPage.registrationTitle).toContainText(
+        registrationFullName,
+      );
+
+      await registrationActivityLogPage.validateLastMessageSent(
+        customMessageResult,
+      );
+    });
   });
 });

--- a/e2e/portal/tests/SendMessage/SendCustomMessage.spec.ts
+++ b/e2e/portal/tests/SendMessage/SendCustomMessage.spec.ts
@@ -39,7 +39,7 @@ test('Send custom message', async ({
     await registrationsPage.validateMessagePresent(customMessagePreview);
     await registrationsPage.sendMessage();
 
-    await registrationsPage.validateToastMessage(sendingMessageToast);
+    await registrationsPage.validateToastMessageAndClose(sendingMessageToast);
     await registrationsPage.goToRegistrationByName({
       registrationName: registrationFullName,
     });

--- a/e2e/portal/tests/SendMessage/SendTemplatedMessage.spec.ts
+++ b/e2e/portal/tests/SendMessage/SendTemplatedMessage.spec.ts
@@ -36,7 +36,7 @@ test('Send templated message', async ({
     );
     await registrationsPage.sendMessage();
 
-    await registrationsPage.validateToastMessage(sendingMessageToast);
+    await registrationsPage.validateToastMessageAndClose(sendingMessageToast);
     // Validate English message
     await registrationsPage.goToRegistrationByName({
       registrationName: 'Jack Strong',

--- a/e2e/portal/tests/SendMessage/SendTemplatedMessage.spec.ts
+++ b/e2e/portal/tests/SendMessage/SendTemplatedMessage.spec.ts
@@ -1,3 +1,5 @@
+import { expect } from '@playwright/test';
+
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import {
   programIdPV,
@@ -6,51 +8,73 @@ import {
 
 import { customSharedFixture as test } from '@121-e2e/portal/fixtures/fixture';
 
-const sendingMessageToast =
-  'Closing this notification will not cancel message sending.';
-const englishMessageTemplate =
-  'This is a message from the Red Cross.\n\nThanks for registering. From now on you will receive an Albert Heijn voucher via WhatsApp every Tuesday. You will receive the vouchers as long as you are on the list of .\n\nThe Red Cross can also provide you with information about, for example, medical assistance, food or safety. Check out our website:\n\nhttps://helpfulinformation.redcross.nl/\n\nor ask your question via WhatsApp:\n\nhttps://wa.me/3197010286964';
-const dutchMessageTemplate =
-  'Dit is een bericht van het Rode Kruis.\n\nBedankt voor je inschrijving. Je ontvangt vanaf nu elke dinsdag een Albert Heijn waardebon via WhatsApp. Je ontvangt de waardebonnen zo lang je op de lijst staat van .\n\nHet Rode Kruis kan je ook informatie geven over bijvoorbeeld medische hulp, voedsel of veiligheid. Kijk op onze website:\n\nhttps://helpfulinformation.redcross.nl/\n\nof stel je vraag via WhatsApp:\n\nhttps://wa.me/3197010286964';
-
-test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
-  await resetDBAndSeedRegistrations({
-    seedScript: SeedScript.nlrcMultiple,
-    registrations: registrationsPV,
-    programId: programIdPV,
-    navigateToPage: `/program/${programIdPV}/registrations`,
+test.describe('Send templated message', () => {
+  test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
+    await resetDBAndSeedRegistrations({
+      seedScript: SeedScript.nlrcMultiple,
+      registrations: registrationsPV,
+      programId: programIdPV,
+      navigateToPage: `/program/${programIdPV}/registrations`,
+    });
   });
-});
 
-test('Send templated message', async ({
-  registrationsPage,
-  registrationActivityLogPage,
-}) => {
-  await test.step('Send templated message', async () => {
-    await registrationsPage.selectAllRegistrations();
-    await registrationsPage.selectBulkAction('Message');
-    await registrationsPage.selectTemplatedMessage('Include');
-    await registrationsPage.clickContinueToPreview();
-    await registrationsPage.validateMessagePresent(
-      'This is a message from the Red Cross.',
-    );
-    await registrationsPage.sendMessage();
+  test('Send templated message', async ({
+    page,
+    registrationsPage,
+    registrationActivityLogPage,
+  }) => {
+    const messageResult =
+      'This is a message from the Red Cross.\n\nThanks for registering. From now on you will receive an Albert Heijn voucher via WhatsApp every Tuesday. You will receive the vouchers as long as you are on the list of .\n\nThe Red Cross can also provide you with information about, for example, medical assistance, food or safety. Check out our website:\n\nhttps://helpfulinformation.redcross.nl/\n\nor ask your question via WhatsApp:\n\nhttps://wa.me/3197010286964';
 
-    await registrationsPage.validateToastMessageAndClose(sendingMessageToast);
-    // Validate English message
-    await registrationsPage.goToRegistrationByName({
-      registrationName: 'Jack Strong',
+    await test.step('Select registration', async () => {
+      await registrationsPage.selectAllRegistrations();
+      await registrationsPage.selectBulkAction('Message');
     });
-    await registrationActivityLogPage.validateLastMessageSent(
-      englishMessageTemplate,
-    );
-    // Validate Dutch message
-    await registrationsPage.goto(`/program/${programIdPV}/registrations`);
-    await registrationsPage.goToRegistrationByName({
-      registrationName: 'Gemma Houtenbos',
+
+    await test.step('Send message', async () => {
+      await registrationsPage.selectTemplatedMessage('Include');
+      await registrationsPage.clickContinueToPreview();
+      await registrationsPage.validateMessagePreview(messageResult);
+      await registrationsPage.sendMessage();
+      await registrationsPage.validateToastMessageAndClose(
+        'Closing this notification will not cancel message sending.',
+      );
+      await page.waitForTimeout(900); // Sending the message takes time;
     });
-    await registrationActivityLogPage.validateLastMessageSent(
-      dutchMessageTemplate,
-    );
+
+    await test.step('Verify message', async () => {
+      const registrationEnFullName = 'Jack Strong';
+      const registrationNlFullName = 'Gemma Houtenbos';
+
+      // Prepare a clean slate from any previous tries/actions on the page
+      await registrationActivityLogPage.resetTableStateStorage();
+
+      // Validate English message
+      await registrationsPage.goto(`/program/${programIdPV}/registrations`);
+      await registrationsPage.goToRegistrationByName({
+        registrationName: registrationEnFullName,
+      });
+      await expect(registrationActivityLogPage.registrationTitle).toContainText(
+        registrationEnFullName,
+      );
+
+      await registrationActivityLogPage.validateLastMessageSent(messageResult);
+
+      // Prepare a clean slate from any previous tries/actions on ANY activity-log-page page
+      await registrationActivityLogPage.resetTableStateStorage();
+
+      // Validate Dutch message
+      await registrationsPage.goto(`/program/${programIdPV}/registrations`);
+      await registrationsPage.goToRegistrationByName({
+        registrationName: registrationNlFullName,
+      });
+      await expect(registrationActivityLogPage.registrationTitle).toContainText(
+        registrationNlFullName,
+      );
+
+      await registrationActivityLogPage.validateLastMessageSent(
+        'Dit is een bericht van het Rode Kruis.\n\nBedankt voor je inschrijving. Je ontvangt vanaf nu elke dinsdag een Albert Heijn waardebon via WhatsApp. Je ontvangt de waardebonnen zo lang je op de lijst staat van .\n\nHet Rode Kruis kan je ook informatie geven over bijvoorbeeld medische hulp, voedsel of veiligheid. Kijk op onze website:\n\nhttps://helpfulinformation.redcross.nl/\n\nof stel je vraag via WhatsApp:\n\nhttps://wa.me/3197010286964',
+      );
+    });
   });
 });

--- a/e2e/portal/tests/UpdateRegistrations/BulkUpdateVisibleInActivityLog.spec.ts
+++ b/e2e/portal/tests/UpdateRegistrations/BulkUpdateVisibleInActivityLog.spec.ts
@@ -32,7 +32,7 @@ test('Data should be updated according to selected columns and registrations', a
       status: 'Delete',
       sendMessage: false,
     });
-    await registrationsPage.dismissToast();
+    await registrationsPage.validateToastMessageAndClose('Changing statuses');
 
     await registrationsPage.selectAllRegistrations();
     await registrationsPage.clickAndSelectImportOption(

--- a/e2e/portal/tests/Users/ResetUsersPassword.spec.ts
+++ b/e2e/portal/tests/Users/ResetUsersPassword.spec.ts
@@ -17,6 +17,6 @@ test('[Admin] Reset users password', async ({ usersPage }) => {
       env.USERCONFIG_121_SERVICE_EMAIL_USER_VIEW ?? '',
     );
     // Assert
-    await usersPage.validateToastMessage('Password reset');
+    await usersPage.validateToastMessageAndClose('Password reset');
   });
 });

--- a/e2e/portal/tests/ViewPayment/DeletePayment.spec.ts
+++ b/e2e/portal/tests/ViewPayment/DeletePayment.spec.ts
@@ -17,26 +17,89 @@ test.beforeEach(async ({ resetDBAndSeedRegistrations }) => {
   });
 });
 
-test('Delete payment button is not visible when payment has started', async ({
+test('Payment can be deleted when payment is not approved', async ({
   page,
   paymentPage,
   paymentsPage,
 }) => {
-  await test.step('Create payment and process it to completion', async () => {
+  await test.step('Create payment', async () => {
+    await paymentsPage.createPayment({});
+    await paymentPage.validateToastMessageAndClose('Payment created');
+    await page.waitForURL((url) =>
+      url.pathname.startsWith(`/en-GB/program/${programIdOCW}/payments/1`),
+    );
+  });
+
+  await test.step('Verify delete payment button', async () => {
+    await paymentPage.isDeletePaymentButtonVisible({ isVisible: true });
+  });
+});
+
+test('Payment can be deleted when payment is not started', async ({
+  page,
+  paymentPage,
+  paymentsPage,
+}) => {
+  await test.step('Create payment and approve', async () => {
+    await paymentsPage.createPayment({});
+    await paymentPage.validateToastMessageAndClose('Payment created');
+    await page.waitForURL((url) =>
+      url.pathname.startsWith(`/en-GB/program/${programIdOCW}/payments/1`),
+    );
+  });
+
+  await test.step('Approve payment', async () => {
+    await paymentPage.approvePayment();
+    await paymentPage.validateToastMessageAndClose(
+      'Payment approved successfully',
+    );
+    await paymentPage.validateBadgeIsPresentByLabel({
+      badgeName: 'Approved',
+      count: 1,
+    });
+    await paymentPage.validateButtonVisibility({
+      isVisible: true,
+      button: 'start',
+    });
+  });
+
+  await test.step('Verify delete payment button', async () => {
+    await paymentPage.isDeletePaymentButtonVisible({ isVisible: true });
+  });
+});
+
+test('Payment cannot be deleted when payment has started', async ({
+  page,
+  paymentPage,
+  paymentsPage,
+}) => {
+  await test.step('Create payment', async () => {
     await paymentsPage.createPayment({});
     await page.waitForURL((url) =>
       url.pathname.startsWith(`/en-GB/program/${programIdOCW}/payments/1`),
     );
-    await paymentPage.approvePayment();
-    await paymentPage.startPayment();
   });
 
-  await test.step('Verify delete payment button is not visible', async () => {
+  await test.step('Approve payment', async () => {
+    await paymentPage.approvePayment();
+    await paymentPage.validateToastMessageAndClose(
+      'Payment approved successfully',
+    );
+  });
+
+  await test.step('Start payment', async () => {
+    await paymentPage.startPayment();
+    await paymentPage.validateToastMessageAndClose(
+      'Payment started successfully',
+    );
+  });
+
+  await test.step('Verify delete payment button', async () => {
     await paymentPage.isDeletePaymentButtonVisible({ isVisible: false });
   });
 });
 
-test('Delete payment navigates back to payments overview and shows empty state', async ({
+test('Deleting payment navigates back to payments overview and shows empty state', async ({
   page,
   paymentPage,
   paymentsPage,

--- a/e2e/portal/tests/ViewPayment/DeletePayment.spec.ts
+++ b/e2e/portal/tests/ViewPayment/DeletePayment.spec.ts
@@ -75,6 +75,7 @@ test('Payment cannot be deleted when payment has started', async ({
 }) => {
   await test.step('Create payment', async () => {
     await paymentsPage.createPayment({});
+    await paymentPage.validateToastMessageAndClose('Payment created');
     await page.waitForURL((url) =>
       url.pathname.startsWith(`/en-GB/program/${programIdOCW}/payments/1`),
     );
@@ -106,6 +107,7 @@ test('Deleting payment navigates back to payments overview and shows empty state
 }) => {
   await test.step('Create payment', async () => {
     await paymentsPage.createPayment({});
+    await paymentPage.validateToastMessageAndClose('Payment created');
     await page.waitForURL((url) =>
       url.pathname.startsWith(`/en-GB/program/${programIdOCW}/payments/1`),
     );

--- a/e2e/portal/tests/ViewPayment/ViewPaymentPageDuringPaymentPhases.spec.ts
+++ b/e2e/portal/tests/ViewPayment/ViewPaymentPageDuringPaymentPhases.spec.ts
@@ -98,12 +98,12 @@ test('Payment page should display correctly during all phases of payment with 2 
 }) => {
   await test.step('Create payment', async () => {
     await paymentsPage.createPayment({});
+    await paymentsPage.validateToastMessageAndClose('Payment created');
     await page.waitForURL((url) =>
       url.pathname.startsWith(
         `/en-GB/program/${programIdOCW}/payments/${paymentId}`,
       ),
     );
-    await paymentPage.dismissToast();
   });
 
   await test.step('Validate payment-page in "Pending approval" state', async () => {

--- a/e2e/portal/tests/ViewPayment/ViewPaymentPageDuringPaymentPhases.spec.ts
+++ b/e2e/portal/tests/ViewPayment/ViewPaymentPageDuringPaymentPhases.spec.ts
@@ -159,7 +159,9 @@ test('Payment page should display correctly during all phases of payment with 2 
 
   await test.step('1st Approve payment by admin', async () => {
     await paymentPage.approvePayment();
-    await paymentPage.validateToastMessage('Payment approved successfully.');
+    await paymentPage.validateToastMessageAndClose(
+      'Payment approved successfully.',
+    );
   });
 
   await test.step('Validate payment-page in between 2 approvals', async () => {
@@ -199,7 +201,9 @@ test('Payment page should display correctly during all phases of payment with 2 
     await paymentPage.waitForPageLoad();
 
     await paymentPage.approvePayment();
-    await paymentPage.validateToastMessage('Payment approved successfully.');
+    await paymentPage.validateToastMessageAndClose(
+      'Payment approved successfully.',
+    );
   });
 
   await test.step('Validate payment-page in "Approved" state', async () => {
@@ -242,7 +246,9 @@ test('Payment page should display correctly during all phases of payment with 2 
     await paymentPage.waitForPageLoad();
 
     await paymentPage.startPayment();
-    await paymentPage.validateToastMessage('Payment started successfully.');
+    await paymentPage.validateToastMessageAndClose(
+      'Payment started successfully.',
+    );
     await paymentPage.waitForPaymentToComplete();
   });
 

--- a/interfaces/portal/src/app/pages/program-registrations/components/custom-message-control/custom-message-control.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/custom-message-control/custom-message-control.component.html
@@ -5,7 +5,13 @@
   </p>
 
   <p>
-    <strong i18n> Message: </strong>
+    <label
+      i18n
+      for="customMessage"
+      class="font-semibold"
+    >
+      Message:
+    </label>
     <app-info-tooltip
       message="Note that if you go over 160 characters the Person affected may receive the message as multiple texts, if they have a feature-(non-smart-)phone."
       i18n-message
@@ -21,6 +27,7 @@
 
   <div>
     <textarea
+      id="customMessage"
       rows="5"
       pTextarea
       [(ngModel)]="customMessageInternalModel"

--- a/interfaces/portal/src/app/pages/program-registrations/components/custom-message-preview/custom-message-preview.component.html
+++ b/interfaces/portal/src/app/pages/program-registrations/components/custom-message-preview/custom-message-preview.component.html
@@ -1,13 +1,17 @@
-<p
-  i18n
-  class="mbe-2 font-semibold"
->
-  Message preview
+<p class="mbe-2">
+  <label
+    for="messagePreview"
+    i18n
+    class="font-semibold"
+  >
+    Message preview
+  </label>
 </p>
 <textarea
+  id="messagePreview"
   rows="5"
   pTextarea
   [value]="messageText()"
-  [attr.readonly]="true"
+  [readonly]="true"
   class="bg-grey-50 text-black inline-full"
 ></textarea>

--- a/interfaces/portal/src/locale/messages.xlf
+++ b/interfaces/portal/src/locale/messages.xlf
@@ -107,6 +107,9 @@
       <trans-unit id="1467442682545650796" datatype="html">
         <source>Reg. # <x equiv-text="event.registrationProgramId.toString()" id="PH"/></source>
       </trans-unit>
+      <trans-unit id="1478156471032913670" datatype="html">
+        <source>Message preview</source>
+      </trans-unit>
       <trans-unit id="1485624035618673724" datatype="html">
         <source>Import reconciliation data</source>
       </trans-unit>
@@ -518,9 +521,6 @@
       </trans-unit>
       <trans-unit id="3069764081921374374" datatype="html">
         <source>Kobo form successfully integrated.</source>
-      </trans-unit>
-      <trans-unit id="3082094200535618477" datatype="html">
-        <source>Message preview</source>
       </trans-unit>
       <trans-unit id="3086423071988594984" datatype="html">
         <source>Assign scope*</source>


### PR DESCRIPTION
[AB#44225](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44225)

## Describe your changes

<!--- Add a brief description of your changes - not in-depth because the bulk of the description should be in the task on DevOps. -->

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] I have improved tests with my changes
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8757.westeurope.3.azurestaticapps.net
