### PR TITLE
chore: Prevent upgrading any PrimeNG/PrimeUI dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -148,13 +148,17 @@ updates:
       # Dependencies below are ordered alphabetically!
       - dependency-name: '@angular*'
         update-types: ['version-update:semver-major']
+      - dependency-name: '@primeuix/themes'
+        update-types: ['version-update:semver-major'] # Next major version has incompatible license; See: AB#43123
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
       - dependency-name: 'filesize'
         update-types: ['version-update:semver-major'] # See: https://www.npmjs.com/package/ngx-filesize
       - dependency-name: 'ngx-matomo-client'
         update-types: ['version-update:semver-major'] # Major versions tied to major-Angular-versions
-      - dependency-name: '*prime*'
+      - dependency-name: 'primeicons'
+        update-types: ['version-update:semver-major'] # Next major version has incompatible license; See: AB#43123
+      - dependency-name: 'primeng'
         update-types: ['version-update:semver-major'] # Next major version has incompatible license; See: AB#43123
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-major'] # Major versions tied to major-Angular-versions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -127,7 +127,6 @@ updates:
       angular:
         patterns:
           - '@angular*'
-          - 'primeng'
           - 'typescript'
           - 'zone.js'
           - '*eslint*'
@@ -140,7 +139,6 @@ updates:
           - '*'
         exclude-patterns: # Make sure to exclude all of the groups defined above
           - '@angular*'
-          - 'primeng'
           - 'typescript'
           - 'zone.js'
           - '@azure/msal*'
@@ -156,8 +154,8 @@ updates:
         update-types: ['version-update:semver-major'] # See: https://www.npmjs.com/package/ngx-filesize
       - dependency-name: 'ngx-matomo-client'
         update-types: ['version-update:semver-major'] # Major versions tied to major-Angular-versions
-      - dependency-name: 'primeng'
-        update-types: ['version-update:semver-major'] # Major versions tied to major-Angular-versions
+      - dependency-name: '*prime*'
+        update-types: ['version-update:semver-major'] # Next major version has incompatible license; See: AB#43123
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-major'] # Major versions tied to major-Angular-versions
 


### PR DESCRIPTION
[AB#44302](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44302)

## Describe your changes

We can't use the next version(s) of the PrimeNG/PrimeUI packages.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
