### PR TITLE
Explainer tracking

### DIFF
--- a/interfaces/portal/src/app/components/explainer/explainer.component.ts
+++ b/interfaces/portal/src/app/components/explainer/explainer.component.ts
@@ -1,6 +1,8 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  effect,
+  inject,
   input,
   model,
 } from '@angular/core';
@@ -12,11 +14,16 @@ import {
   AccordionPanel,
 } from 'primeng/accordion';
 
+import {
+  TrackingAction,
+  TrackingCategory,
+  TrackingService,
+} from '~/services/tracking.service';
+
 export interface ExplainerItem {
   content: string;
   image?: { url: string; alt: string; maxWidth?: string };
 }
-
 @Component({
   selector: 'app-explainer',
   imports: [Accordion, AccordionPanel, AccordionHeader, AccordionContent],
@@ -26,5 +33,22 @@ export interface ExplainerItem {
 export class ExplainerComponent {
   readonly title = input.required<string>();
   readonly items = input.required<ExplainerItem[]>();
+  readonly trackingEventAction = input.required<string>();
+
   readonly expanded = model<boolean>(false);
+
+  readonly trackingService = inject(TrackingService);
+
+  constructor() {
+    effect(() => {
+      const isExpanded = this.expanded();
+      if (isExpanded) {
+        this.trackingService.trackEvent({
+          category: TrackingCategory.additionalInformationViewed,
+          action: TrackingAction.explainerOpened,
+          name: this.trackingEventAction(),
+        });
+      }
+    });
+  }
 }

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-configuration-dialog/kobo-configuration-dialog.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/kobo-configuration-dialog/kobo-configuration-dialog.component.html
@@ -47,6 +47,7 @@
       <app-explainer
         [title]="koboExplainers.formUrl.title"
         [items]="koboExplainers.formUrl.items"
+        [trackingEventAction]="'KoboToolbox form URL'"
         [expanded]="openExplainer() === 'formUrl'"
         (expandedChange)="
           onExplainerExpandedChange({ key: 'formUrl', expanded: $event })
@@ -70,6 +71,7 @@
     <app-explainer
       [title]="koboExplainers.apiKey.title"
       [items]="koboExplainers.apiKey.items"
+      [trackingEventAction]="'KoboToolbox API key'"
       [expanded]="openExplainer() === 'apiKey'"
       (expandedChange)="
         onExplainerExpandedChange({ key: 'apiKey', expanded: $event })

--- a/interfaces/portal/src/app/pages/program-settings-registration-data/components/required-attributes/required-attributes.component.html
+++ b/interfaces/portal/src/app/pages/program-settings-registration-data/components/required-attributes/required-attributes.component.html
@@ -82,6 +82,7 @@
         <app-explainer
           [title]="dataColumnNamesExplainers.title"
           [items]="dataColumnNamesExplainers.items"
+          [trackingEventAction]="'Data column names'"
         />
       </div>
     </p-accordion-content>

--- a/interfaces/portal/src/app/services/tracking.service.ts
+++ b/interfaces/portal/src/app/services/tracking.service.ts
@@ -71,8 +71,9 @@ export enum TrackingAction {
   createNewProgramStep3Error = 'errors: createNewProgram Step 3',
   createNewProgramStep3TotalTimeSpent = 'time: createNewProgram Step 3',
   createNewProgramTotalTimeSpent = 'time: createNewProgram Total Time',
-  formValidationError = 'errors: Form Validation',
+  explainerOpened = 'open: Explainer',
 
+  formValidationError = 'errors: Form Validation',
   hoverInformationIcon = 'hover: Information Icon',
 
   programSettingsBasicInfoSaveButtonClick = 'click: Program Settings info Save Button',


### PR DESCRIPTION
[AB#44385](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44385) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Adds tracker to app-explainer component on opening.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [ ] I have addressed all Copilot comments
- [x] The changes do not touch the UI/UX
- [x] Adding tests is unnecessary/irrelevant
- [ ] I have made sure that all automated checks pass before requesting a review
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

https://happy-rock-0411d2003-8812.westeurope.3.azurestaticapps.net
