### PR TITLE
Directly pass holder id to fix  flaky test

### DIFF
--- a/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.ts
+++ b/services/121-service/src/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.ts
@@ -83,6 +83,7 @@ export class IntersolveVisaService {
 
     const intersolveVisaChildWallets = await this.getChildWalletsOrCreateOne({
       intersolveVisaParentWallet,
+      holderId: intersolveVisaCustomer.holderId,
       brandCode,
     });
 
@@ -308,9 +309,11 @@ export class IntersolveVisaService {
 
   private async getChildWalletsOrCreateOne({
     intersolveVisaParentWallet,
+    holderId,
     brandCode,
   }: {
     intersolveVisaParentWallet: IntersolveVisaParentWalletEntity;
+    holderId: string;
     brandCode: string;
   }): Promise<IntersolveVisaChildWalletEntity[]> {
     // Check if at least one child wallet exists
@@ -322,10 +325,7 @@ export class IntersolveVisaService {
     const issueTokenResult = await this.intersolveVisaApiService.issueToken({
       brandCode,
       activate: false, // Child Wallets are always created deactivated
-      reference:
-        env.INTERSOLVE_MODE === FspMode.mock
-          ? intersolveVisaParentWallet.intersolveVisaCustomer.holderId
-          : undefined,
+      reference: env.INTERSOLVE_MODE === FspMode.mock ? holderId : undefined,
     });
 
     // Store child wallet


### PR DESCRIPTION
[AB#44430](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44430) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes


Fixes a flaky test failure in the **Test Service: Restart Service (ONLY)** workflow:
- **Failed Run:** https://github.com/global-121/121-platform/actions/runs/34214603503/job/102023286973

#### Error in Docker Logs

During the restart test, 31 out of 32 retried payment jobs completed, but one job failed with the following unhandled error:

```text
TypeError: Cannot read properties of undefined (reading 'holderId')
    at IntersolveVisaService.getChildWalletsOrCreateOne (/home/node/app/dist/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.js:221:131)
    at IntersolveVisaService.doTransferOrIssueCard (/home/node/app/dist/fsp-integrations/integrations/intersolve-visa/services/intersolve-visa.service.js:80:55)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async TransactionJobsIntersolveVisaService.processTransactionJob (/home/node/app/dist/fsp-integrations/transaction-jobs/services/transaction-jobs-intersolve-visa.service.js:97:60)
    at async TransactionJobProcessor.handleTransactionJob (/home/node/app/dist/fsp-integrations/transaction-jobs/processor/base-transaction-job.processor.js:36:13)
```

#### Why This Happened

When `kill121Service()` terminates the service during queue execution, an in-flight payment job may be interrupted after creating the parent wallet in the database, but before creating the child wallet.

On service restart, Bull retries `doTransferOrIssueCard`:
1. `getCustomerOrCreate` fetches the customer entity along with `intersolveVisaParentWallet` from the database.
2. In TypeORM, loading the forward relation `intersolveVisaParentWallet` does not populate the inverse relation on the child object (`parentWallet.intersolveVisaCustomer` remains `undefined`).
3. `getChildWalletsOrCreateOne` previously traversed `intersolveVisaParentWallet.intersolveVisaCustomer.holderId` when creating the mock token, throwing a `TypeError` and causing the retried job to permanently fail.

#### Solution

- Pass `holderId: intersolveVisaCustomer.holderId` directly to `getChildWalletsOrCreateOne` (aligning with the Interface Segregation Principle).
- Decouples child wallet token creation from parent-entity inverse relation loading in TypeORM.
- Added a regression unit test in `intersolve-visa.service.spec.ts`.
## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
