### PR TITLE
refactor: Use a stable sequence for the computed "RegistrationProgramId"s

### DIFF
--- a/services/121-service/src/migration/1788794699491-add-program-registration-program-id-counter.ts
+++ b/services/121-service/src/migration/1788794699491-add-program-registration-program-id-counter.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProgramRegistrationProgramIdCounter1788794699491 implements MigrationInterface {
+  name = 'AddProgramRegistrationProgramIdCounter1788794699491';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "121-service"."program_registration_program_id_counter" ("id" SERIAL NOT NULL, "created" TIMESTAMP NOT NULL DEFAULT now(), "updated" TIMESTAMP NOT NULL DEFAULT now(), "programId" integer NOT NULL, "lastRegistrationProgramId" integer NOT NULL DEFAULT 0, CONSTRAINT "REL_program_registration_program_id_counter_programId" UNIQUE ("programId"), CONSTRAINT "PK_program_registration_program_id_counter" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_program_registration_program_id_counter_created" ON "121-service"."program_registration_program_id_counter" ("created")`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_program_registration_program_id_counter_programId" ON "121-service"."program_registration_program_id_counter" ("programId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "121-service"."program_registration_program_id_counter" ADD CONSTRAINT "FK_program_registration_program_id_counter_programId" FOREIGN KEY ("programId") REFERENCES "121-service"."program"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "121-service"."program_registration_program_id_counter" ("programId", "lastRegistrationProgramId")
+       SELECT p.id, COALESCE(MAX(r."registrationProgramId"), 0)
+       FROM "121-service"."program" p
+       LEFT JOIN "121-service"."registration" r ON r."programId" = p.id
+       GROUP BY p.id
+       ON CONFLICT ("programId") DO NOTHING`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP TABLE IF EXISTS "121-service"."program_registration_program_id_counter"`,
+    );
+  }
+}

--- a/services/121-service/src/migration/1788794699491-add-program-registration-program-id-counter.ts
+++ b/services/121-service/src/migration/1788794699491-add-program-registration-program-id-counter.ts
@@ -8,13 +8,13 @@ export class AddProgramRegistrationProgramIdCounter1788794699491 implements Migr
       `CREATE TABLE "121-service"."program_registration_program_id_counter" ("id" SERIAL NOT NULL, "created" TIMESTAMP NOT NULL DEFAULT now(), "updated" TIMESTAMP NOT NULL DEFAULT now(), "programId" integer NOT NULL, "lastRegistrationProgramId" integer NOT NULL DEFAULT 0, CONSTRAINT "REL_program_registration_program_id_counter_programId" UNIQUE ("programId"), CONSTRAINT "PK_program_registration_program_id_counter" PRIMARY KEY ("id"))`,
     );
     await queryRunner.query(
-      `CREATE INDEX "IDX_program_registration_program_id_counter_created" ON "121-service"."program_registration_program_id_counter" ("created")`,
+      `CREATE INDEX "IDX_4c3f6cb29531b666ef1759fed5" ON "121-service"."program_registration_program_id_counter" ("created")`,
     );
     await queryRunner.query(
-      `CREATE UNIQUE INDEX "IDX_program_registration_program_id_counter_programId" ON "121-service"."program_registration_program_id_counter" ("programId")`,
+      `CREATE UNIQUE INDEX "IDX_017d12e48ecd706400d3bb4554" ON "121-service"."program_registration_program_id_counter" ("programId")`,
     );
     await queryRunner.query(
-      `ALTER TABLE "121-service"."program_registration_program_id_counter" ADD CONSTRAINT "FK_program_registration_program_id_counter_programId" FOREIGN KEY ("programId") REFERENCES "121-service"."program"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+      `ALTER TABLE "121-service"."program_registration_program_id_counter" ADD CONSTRAINT "FK_017d12e48ecd706400d3bb45544" FOREIGN KEY ("programId") REFERENCES "121-service"."program"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
       `INSERT INTO "121-service"."program_registration_program_id_counter" ("programId", "lastRegistrationProgramId")

--- a/services/121-service/src/programs/entities/program-registration-program-id-counter.entity.ts
+++ b/services/121-service/src/programs/entities/program-registration-program-id-counter.entity.ts
@@ -1,0 +1,24 @@
+import { Column, Entity, Index, JoinColumn, OneToOne, Relation } from 'typeorm';
+
+import { Base121Entity } from '@121-service/src/base.entity';
+import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
+
+@Entity('program_registration_program_id_counter')
+export class ProgramRegistrationProgramIdCounterEntity extends Base121Entity {
+  @OneToOne(
+    () => ProgramEntity,
+    (program) => program.registrationProgramIdCounter,
+    {
+      onDelete: 'CASCADE',
+    },
+  )
+  @JoinColumn({ name: 'programId' })
+  public program: Relation<ProgramEntity>;
+
+  @Index({ unique: true })
+  @Column({ type: 'int', nullable: false })
+  public programId: number;
+
+  @Column({ type: 'int', default: 0, nullable: false })
+  public lastRegistrationProgramId: number;
+}

--- a/services/121-service/src/programs/entities/program.entity.ts
+++ b/services/121-service/src/programs/entities/program.entity.ts
@@ -7,6 +7,7 @@ import { MessageTemplateEntity } from '@121-service/src/notifications/message-te
 import { PaymentEntity } from '@121-service/src/payments/entities/payment.entity';
 import { ProgramFspConfigurationEntity } from '@121-service/src/program-fsp-configurations/entities/program-fsp-configuration.entity';
 import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/entities/program-registration-attribute.entity';
+import { ProgramRegistrationProgramIdCounterEntity } from '@121-service/src/programs/entities/program-registration-program-id-counter.entity';
 import { ProgramAidworkerAssignmentEntity } from '@121-service/src/programs/program-aidworker-assignments/program-aidworker-assignment.entity';
 import { ProgramAttachmentEntity } from '@121-service/src/programs/program-attachments/program-attachment.entity';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
@@ -122,4 +123,11 @@ export class ProgramEntity extends Base121Entity {
 
   @OneToOne(() => KoboEntity, (kobo) => kobo.program, { onDelete: 'SET NULL' })
   public kobo: Relation<KoboEntity>;
+
+  @OneToOne(
+    () => ProgramRegistrationProgramIdCounterEntity,
+    (counter) => counter.program,
+    { cascade: true, onDelete: 'CASCADE' },
+  )
+  public registrationProgramIdCounter: Relation<ProgramRegistrationProgramIdCounterEntity>;
 }

--- a/services/121-service/src/programs/programs.module.ts
+++ b/services/121-service/src/programs/programs.module.ts
@@ -11,12 +11,14 @@ import { ProgramFspConfigurationsModule } from '@121-service/src/program-fsp-con
 import { ProgramRegistrationAttributesModule } from '@121-service/src/program-registration-attributes/program-registration-attributes.module';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/entities/program-registration-attribute.entity';
+import { ProgramRegistrationProgramIdCounterEntity } from '@121-service/src/programs/entities/program-registration-program-id-counter.entity';
 import { ProgramAidworkerAssignmentsModule } from '@121-service/src/programs/program-aidworker-assignments/program-aidworker-assignments.module';
 import { ProgramAttachmentsModule } from '@121-service/src/programs/program-attachments/program-attachments.module';
 import { ProgramController } from '@121-service/src/programs/programs.controller';
 import { ProgramService } from '@121-service/src/programs/programs.service';
 import { ProgramRepository } from '@121-service/src/programs/repositories/program.repository';
 import { ProgramRegistrationAttributeRepository } from '@121-service/src/programs/repositories/program-registration-attribute.repository';
+import { ProgramRegistrationProgramIdCounterRepository } from '@121-service/src/programs/repositories/program-registration-program-id-counter.repository';
 import { ProgramExistenceInterceptor } from '@121-service/src/shared/interceptors/program-existence.interceptor';
 import { UserModule } from '@121-service/src/user/user.module';
 
@@ -26,6 +28,7 @@ import { UserModule } from '@121-service/src/user/user.module';
       ProgramEntity,
       ProgramRegistrationAttributeEntity,
       ProgramFspConfigurationEntity,
+      ProgramRegistrationProgramIdCounterEntity,
     ]),
     UserModule,
     FspsModule,
@@ -44,12 +47,14 @@ import { UserModule } from '@121-service/src/user/user.module';
     ProgramRepository,
     ProgramExistenceInterceptor,
     ProgramRegistrationAttributeRepository,
+    ProgramRegistrationProgramIdCounterRepository,
   ],
   controllers: [ProgramController],
   exports: [
     ProgramService,
     ProgramRepository,
     ProgramRegistrationAttributeRepository,
+    ProgramRegistrationProgramIdCounterRepository,
   ],
 })
 export class ProgramModule {}

--- a/services/121-service/src/programs/programs.service.ts
+++ b/services/121-service/src/programs/programs.service.ts
@@ -17,6 +17,7 @@ import { ProgramReturnDto } from '@121-service/src/programs/dto/program-return.d
 import { UpdateProgramDto } from '@121-service/src/programs/dto/update-program.dto';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/entities/program-registration-attribute.entity';
+import { ProgramRegistrationProgramIdCounterEntity } from '@121-service/src/programs/entities/program-registration-program-id-counter.entity';
 import { ProgramRegistrationAttributeMapper } from '@121-service/src/programs/mappers/program-registration-attribute.mapper';
 import { ProgramAidworkerAssignmentEntity } from '@121-service/src/programs/program-aidworker-assignments/program-aidworker-assignment.entity';
 import { ProgramApprovalThresholdEntity } from '@121-service/src/programs/program-approval-thresholds/program-approval-threshold.entity';
@@ -194,6 +195,10 @@ export class ProgramService {
 
     let savedProgram: ProgramEntity;
     try {
+      const counter = new ProgramRegistrationProgramIdCounterEntity();
+      counter.lastRegistrationProgramId = 0;
+      program.registrationProgramIdCounter = counter;
+
       savedProgram = await programRepository.save(program);
 
       savedProgram.programRegistrationAttributes = [];

--- a/services/121-service/src/programs/repositories/program-registration-program-id-counter.repository.ts
+++ b/services/121-service/src/programs/repositories/program-registration-program-id-counter.repository.ts
@@ -1,0 +1,30 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { ProgramRegistrationProgramIdCounterEntity } from '@121-service/src/programs/entities/program-registration-program-id-counter.entity';
+
+export class ProgramRegistrationProgramIdCounterRepository extends Repository<ProgramRegistrationProgramIdCounterEntity> {
+  constructor(
+    @InjectRepository(ProgramRegistrationProgramIdCounterEntity)
+    baseRepository: Repository<ProgramRegistrationProgramIdCounterEntity>,
+  ) {
+    super(
+      baseRepository.target,
+      baseRepository.manager,
+      baseRepository.queryRunner,
+    );
+  }
+
+  public async createForProgram({
+    programId,
+  }: {
+    programId: number;
+  }): Promise<ProgramRegistrationProgramIdCounterEntity> {
+    const counter = this.create({
+      programId,
+      lastRegistrationProgramId: 0,
+    });
+
+    return await this.save(counter);
+  }
+}

--- a/services/121-service/src/registration/registrations.module.ts
+++ b/services/121-service/src/registration/registrations.module.ts
@@ -18,6 +18,7 @@ import { TransactionEntity } from '@121-service/src/payments/transactions/entiti
 import { ProgramFspConfigurationsModule } from '@121-service/src/program-fsp-configurations/program-fsp-configurations.module';
 import { ProgramEntity } from '@121-service/src/programs/entities/program.entity';
 import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/entities/program-registration-attribute.entity';
+import { ProgramRegistrationProgramIdCounterEntity } from '@121-service/src/programs/entities/program-registration-program-id-counter.entity';
 import { ProgramModule } from '@121-service/src/programs/programs.module';
 import { QueuesRegistryModule } from '@121-service/src/queues-registry/queues-registry.module';
 import { RegistrationsController } from '@121-service/src/registration/controllers/registrations.controller';
@@ -56,6 +57,7 @@ import { createScopedRepositoryProvider } from '@121-service/src/utils/scope/cre
       MessageTemplateEntity,
       ProgramRegistrationAttributeEntity,
       UniqueRegistrationPairEntity,
+      ProgramRegistrationProgramIdCounterEntity,
     ]),
     UserModule,
     HttpModule,

--- a/services/121-service/src/registration/repositories/registration-scoped.repository.ts
+++ b/services/121-service/src/registration/repositories/registration-scoped.repository.ts
@@ -1,7 +1,5 @@
 import { Inject, Injectable, Scope } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
-import { randomInt } from 'node:crypto';
-import { setTimeout } from 'node:timers/promises';
 import {
   DataSource,
   DeleteResult,
@@ -9,8 +7,8 @@ import {
   FindOptionsRelations,
   FindOptionsWhere,
   InsertResult,
-  QueryFailedError,
   RemoveOptions,
+  Repository,
   SaveOptions,
   UpdateResult,
 } from 'typeorm';
@@ -18,27 +16,27 @@ import { type QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialE
 
 import { ExportVisaCardDetailsRawData } from '@121-service/src/fsp-integrations/integrations/intersolve-visa/interfaces/export-visa-card-details-raw-data.interface';
 import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/entities/program-registration-attribute.entity';
-import {
-  REGISTRATION_PROGRAM_UNIQUE_CONSTRAINT,
-  RegistrationEntity,
-} from '@121-service/src/registration/entities/registration.entity';
+import { ProgramRegistrationProgramIdCounterEntity } from '@121-service/src/programs/entities/program-registration-program-id-counter.entity';
+import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { RegistrationAttributeDataEntity } from '@121-service/src/registration/entities/registration-attribute-data.entity';
 import { RegistrationStatusEnum } from '@121-service/src/registration/enum/registration-status.enum';
 import { GetDuplicatesResult } from '@121-service/src/registration/interfaces/get-duplicates-result.interface';
 import { RegistrationScopedBaseRepository } from '@121-service/src/registration/repositories/registration-scoped-base.repository';
-import { PostgresStatusCodes } from '@121-service/src/shared/enum/postgres-status-codes.enum';
 import { ScopedUserRequest } from '@121-service/src/shared/scoped-user-request';
-
-const MAX_REGISTRATION_PROGRAM_ID_SAVE_ATTEMPTS = 3;
 
 @Injectable({ scope: Scope.REQUEST, durable: true })
 export class RegistrationScopedRepository extends RegistrationScopedBaseRepository<RegistrationEntity> {
+  private readonly counterRepository: Repository<ProgramRegistrationProgramIdCounterEntity>;
+
   constructor(
     dataSource: DataSource,
     // TODO check if this can be set on ScopedRepository so it can be reused
     @Inject(REQUEST) public override request: ScopedUserRequest,
   ) {
     super(RegistrationEntity, dataSource);
+    this.counterRepository = dataSource.getRepository(
+      ProgramRegistrationProgramIdCounterEntity,
+    );
   }
 
   ///////////////////////////////////////////////////////////////
@@ -74,49 +72,12 @@ export class RegistrationScopedRepository extends RegistrationScopedBaseReposito
     registration: RegistrationEntity;
     options?: SaveOptions;
   }): Promise<RegistrationEntity> {
-    for (
-      let attempt = 1;
-      attempt <= MAX_REGISTRATION_PROGRAM_ID_SAVE_ATTEMPTS;
-      attempt++
-    ) {
-      registration.registrationProgramId =
-        await this.getNextRegistrationProgramId({
-          programId: registration.program?.id ?? registration.programId,
-        });
+    registration.registrationProgramId =
+      await this.getNextRegistrationProgramId({
+        programId: registration.program?.id ?? registration.programId,
+      });
 
-      try {
-        return await this.repository.save(registration, options);
-      } catch (error) {
-        const isLastAttempt =
-          attempt === MAX_REGISTRATION_PROGRAM_ID_SAVE_ATTEMPTS;
-
-        // Only retry the constraint that recalculating registrationProgramId can resolve, not any unrelated violation
-        if (
-          !this.isRegistrationProgramIdUniqueViolation(error) ||
-          isLastAttempt
-        ) {
-          throw error;
-        } else {
-          await setTimeout(randomInt(1, 21)); // Some jitter to reduce the chance of retries colliding on registrationProgramId
-        }
-      }
-    }
-
-    throw new Error(
-      `Failed to save a registration with a unique registrationProgramId after ${MAX_REGISTRATION_PROGRAM_ID_SAVE_ATTEMPTS} attempts.`,
-    );
-  }
-
-  private isRegistrationProgramIdUniqueViolation(
-    error: unknown,
-  ): error is QueryFailedError & { code: string; constraint: string } {
-    return (
-      error instanceof QueryFailedError &&
-      'code' in error &&
-      error.code === PostgresStatusCodes.UNIQUE_VIOLATION &&
-      'constraint' in error &&
-      error.constraint === REGISTRATION_PROGRAM_UNIQUE_CONSTRAINT
-    );
+    return this.repository.save(registration, options);
   }
 
   private async getNextRegistrationProgramId({
@@ -124,14 +85,23 @@ export class RegistrationScopedRepository extends RegistrationScopedBaseReposito
   }: {
     programId: number;
   }): Promise<number> {
-    // Deliberately unscoped: registrationProgramId must be unique across all scopes within a program
-    const result = await this.repository
-      .createQueryBuilder('r')
-      .select('MAX(r."registrationProgramId")', 'max')
-      .andWhere('r.programId = :programId', { programId })
-      .getRawOne<{ max: number | null }>();
+    const updateResult = await this.counterRepository
+      .createQueryBuilder()
+      .update(ProgramRegistrationProgramIdCounterEntity)
+      .set({
+        lastRegistrationProgramId: () => '"lastRegistrationProgramId" + 1',
+      })
+      .where('"programId" = :programId', { programId })
+      .returning('lastRegistrationProgramId')
+      .execute();
 
-    return (result?.max ?? 0) + 1;
+    if (updateResult.raw && updateResult.raw.length > 0) {
+      return Number(updateResult.raw[0].lastRegistrationProgramId);
+    }
+
+    throw new Error(
+      `No registrationProgramId counter found for program ${programId}`,
+    );
   }
 
   public async insert(

--- a/services/121-service/src/scripts/factories/registration-seed-factory.ts
+++ b/services/121-service/src/scripts/factories/registration-seed-factory.ts
@@ -4,6 +4,7 @@ import { DataSource, DeepPartial, Equal, In, Not } from 'typeorm';
 
 import { FspAttributes } from '@121-service/src/fsp-integrations/shared/enum/fsp-attributes.enum';
 import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/entities/program-registration-attribute.entity';
+import { ProgramRegistrationProgramIdCounterEntity } from '@121-service/src/programs/entities/program-registration-program-id-counter.entity';
 import { RegistrationEntity } from '@121-service/src/registration/entities/registration.entity';
 import { RegistrationAttributeDataEntity } from '@121-service/src/registration/entities/registration-attribute-data.entity';
 import { DefaultRegistrationDataAttributeNames } from '@121-service/src/registration/enum/registration-attribute.enum';
@@ -75,6 +76,18 @@ export class RegistrationSeedFactory extends BaseSeedFactory<RegistrationEntity>
 
     const newRegistrationIds =
       await this.insertEntitiesBatch(newRegistrationsData);
+
+    await this.dataSource
+      .getRepository(ProgramRegistrationProgramIdCounterEntity)
+      .createQueryBuilder()
+      .insert()
+      .into(ProgramRegistrationProgramIdCounterEntity)
+      .values({
+        programId,
+        lastRegistrationProgramId: currentMax,
+      })
+      .orUpdate(['lastRegistrationProgramId'], ['programId'])
+      .execute();
 
     await this.attributeDataFactory.duplicateAttributeDataForRegistrations(
       newRegistrationIds,

--- a/services/121-service/src/scripts/services/seed-helper.service.ts
+++ b/services/121-service/src/scripts/services/seed-helper.service.ts
@@ -25,6 +25,7 @@ import { ProgramRegistrationAttributeEntity } from '@121-service/src/programs/en
 import { ProgramAidworkerAssignmentEntity } from '@121-service/src/programs/program-aidworker-assignments/program-aidworker-assignment.entity';
 import { CreateProgramApprovalThresholdDto } from '@121-service/src/programs/program-approval-thresholds/dtos/create-program-approval-threshold.dto';
 import { ProgramApprovalThresholdsService } from '@121-service/src/programs/program-approval-thresholds/program-approval-thresholds.service';
+import { ProgramRegistrationProgramIdCounterRepository } from '@121-service/src/programs/repositories/program-registration-program-id-counter.repository';
 import { RegistrationAttributeTypes } from '@121-service/src/registration/enum/registration-attribute.enum';
 import { ApproverSeedMode } from '@121-service/src/scripts/enum/approval-seed-mode.enum';
 import { DebugScope } from '@121-service/src/scripts/enum/debug-scope.enum';
@@ -47,6 +48,7 @@ export class SeedHelperService {
     private readonly httpService: CustomHttpService,
     private readonly axiosCallsService: AxiosCallsService,
     private readonly programApprovalThresholdsService: ProgramApprovalThresholdsService,
+    private readonly programRegistrationProgramIdCounterRepository: ProgramRegistrationProgramIdCounterRepository,
   ) {}
 
   public async seedData({
@@ -374,6 +376,10 @@ export class SeedHelperService {
     const programExampleDump = JSON.stringify(programExample);
     const programFromJSON = JSON.parse(programExampleDump);
     const programReturn = await programRepository.save(programFromJSON);
+
+    await this.programRegistrationProgramIdCounterRepository.createForProgram({
+      programId: programReturn.id,
+    });
 
     // Remove original program registration attributes and add it to a separate variable
     const programRegistrationAttributes =

--- a/services/121-service/test/registrations/assign-registration-program-id.test.ts
+++ b/services/121-service/test/registrations/assign-registration-program-id.test.ts
@@ -1,8 +1,15 @@
 import { HttpStatus } from '@nestjs/common';
 
+import { CurrencyCode } from '@121-service/src/exchange-rates/enums/currency-code.enum';
+import { FspConfigurationProperties } from '@121-service/src/fsp-integrations/shared/enum/fsp-configuration-properties.enum';
+import { Fsps } from '@121-service/src/fsp-integrations/shared/enum/fsp-name.enum';
+import { CreateProgramFspConfigurationDto } from '@121-service/src/program-fsp-configurations/dtos/create-program-fsp-configuration.dto';
+import { CreateProgramDto } from '@121-service/src/programs/dto/create-program.dto';
 import { DebugScope } from '@121-service/src/scripts/enum/debug-scope.enum';
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { registrationScopedKisumuEastPv } from '@121-service/test/fixtures/scoped-registrations';
+import { postProgram } from '@121-service/test/helpers/program.helper';
+import { postProgramFspConfiguration } from '@121-service/test/helpers/program-fsp-configuration.helper';
 import {
   getRegistrations,
   importRegistrations,
@@ -40,10 +47,26 @@ const createRegistrations = ({
 const createSequenceUpTo = (count: number) =>
   Array.from({ length: count }, (_, index) => index + 1);
 
+const minimalProgram: CreateProgramDto = {
+  titlePortal: { en: 'Program for registrationProgramId counter test' },
+  currency: CurrencyCode.EUR,
+};
+
+// Name matches registrationScopedKisumuEastPv.programFspConfigurationName, so imported registrations resolve to this configuration
+const newProgramFspConfiguration: CreateProgramFspConfigurationDto = {
+  name: Fsps.intersolveVoucherPaper,
+  label: { en: 'Intersolve Voucher Paper' },
+  fspName: Fsps.intersolveVoucherPaper,
+  properties: [
+    { name: FspConfigurationProperties.username, value: 'username' },
+    { name: FspConfigurationProperties.password, value: 'password' },
+  ],
+};
+
 describe('Assign registrationProgramId', () => {
   let accessToken: string;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     await resetDB({ seedScript: SeedScript.nlrcMultiple });
     accessToken = await getAccessToken();
   });
@@ -133,5 +156,40 @@ describe('Assign registrationProgramId', () => {
         numberOfOutOfScopeRegistrations + numberOfInScopeRegistrations,
       ),
     );
+  });
+
+  it('should assign sequential registrationProgramIds starting at 1 for a newly created program', async () => {
+    // Arrange
+    const createProgramResponse = await postProgram(
+      minimalProgram,
+      accessToken,
+    );
+    expect(createProgramResponse.statusCode).toBe(HttpStatus.CREATED);
+    const newProgramId = createProgramResponse.body.id;
+
+    await postProgramFspConfiguration({
+      programId: newProgramId,
+      body: newProgramFspConfiguration,
+      accessToken,
+    });
+
+    // Act
+    const importResponse = await importRegistrations(
+      newProgramId,
+      [registrationScopedKisumuEastPv],
+      accessToken,
+    );
+
+    // Assert
+    expect(importResponse.statusCode).toBe(HttpStatus.CREATED);
+
+    // A first import receiving registrationProgramId 1 confirms the counter row was
+    // created via the program cascade with lastRegistrationProgramId starting at 0
+    const registrations = await waitForRegistrationCount({
+      programId: newProgramId,
+      expectedCount: 1,
+      accessToken,
+    });
+    expect(registrations[0].registrationProgramId).toBe(1);
   });
 });

--- a/services/121-service/test/registrations/assign-registration-program-id.test.ts
+++ b/services/121-service/test/registrations/assign-registration-program-id.test.ts
@@ -48,7 +48,7 @@ const createSequenceUpTo = (count: number) =>
   Array.from({ length: count }, (_, index) => index + 1);
 
 const minimalProgram: CreateProgramDto = {
-  titlePortal: { en: 'Program for registrationProgramId counter test' },
+  titlePortal: { en: 'Program for registrationProgramId tests' },
   currency: CurrencyCode.EUR,
 };
 
@@ -63,6 +63,25 @@ const newProgramFspConfiguration: CreateProgramFspConfigurationDto = {
   ],
 };
 
+// Each test creates its own program so registrationProgramId counters never leak between tests
+const createProgram = async ({
+  accessToken,
+}: {
+  accessToken: string;
+}): Promise<number> => {
+  const createProgramResponse = await postProgram(minimalProgram, accessToken);
+  expect(createProgramResponse.statusCode).toBe(HttpStatus.CREATED);
+  const programId = createProgramResponse.body.id;
+
+  await postProgramFspConfiguration({
+    programId,
+    body: newProgramFspConfiguration,
+    accessToken,
+  });
+
+  return programId;
+};
+
 describe('Assign registrationProgramId', () => {
   let accessToken: string;
 
@@ -73,6 +92,7 @@ describe('Assign registrationProgramId', () => {
 
   it('should assign a unique sequential registrationProgramId to concurrently imported registrations', async () => {
     // Arrange
+    const programId = await createProgram({ accessToken });
     const registrationBatches = Array.from(
       { length: numberOfConcurrentBatches },
       (_, batchIndex) =>
@@ -86,7 +106,7 @@ describe('Assign registrationProgramId', () => {
     // Act
     const responses = await Promise.all(
       registrationBatches.map((registrations) =>
-        importRegistrations(programIdPV, registrations, accessToken),
+        importRegistrations(programId, registrations, accessToken),
       ),
     );
 
@@ -96,7 +116,7 @@ describe('Assign registrationProgramId', () => {
     }
 
     const registrations = await waitForRegistrationCount({
-      programId: programIdPV,
+      programId,
       expectedCount: numberOfConcurrentRegistrations,
       accessToken,
       sort: { field: 'registrationProgramId', direction: 'ASC' },
@@ -156,40 +176,5 @@ describe('Assign registrationProgramId', () => {
         numberOfOutOfScopeRegistrations + numberOfInScopeRegistrations,
       ),
     );
-  });
-
-  it('should assign sequential registrationProgramIds starting at 1 for a newly created program', async () => {
-    // Arrange
-    const createProgramResponse = await postProgram(
-      minimalProgram,
-      accessToken,
-    );
-    expect(createProgramResponse.statusCode).toBe(HttpStatus.CREATED);
-    const newProgramId = createProgramResponse.body.id;
-
-    await postProgramFspConfiguration({
-      programId: newProgramId,
-      body: newProgramFspConfiguration,
-      accessToken,
-    });
-
-    // Act
-    const importResponse = await importRegistrations(
-      newProgramId,
-      [registrationScopedKisumuEastPv],
-      accessToken,
-    );
-
-    // Assert
-    expect(importResponse.statusCode).toBe(HttpStatus.CREATED);
-
-    // A first import receiving registrationProgramId 1 confirms the counter row was
-    // created via the program cascade with lastRegistrationProgramId starting at 0
-    const registrations = await waitForRegistrationCount({
-      programId: newProgramId,
-      expectedCount: 1,
-      accessToken,
-    });
-    expect(registrations[0].registrationProgramId).toBe(1);
   });
 });


### PR DESCRIPTION
[AB#44393](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44393) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Okay in the end I went the more robust but more code route. This guarantees parallel processes can never be assigned the same registrationProgramId.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
