### PR TITLE
Flaky retry payment

### DIFF
--- a/services/121-service/test/payment/do-payment-retry.test.ts
+++ b/services/121-service/test/payment/do-payment-retry.test.ts
@@ -6,12 +6,14 @@ import { TransactionStatusEnum } from '@121-service/src/payments/transactions/en
 import { SeedScript } from '@121-service/src/scripts/enum/seed-script.enum';
 import { registrationAHWhatsapp } from '@121-service/src/seed-data/mock/registration-pv.data';
 import {
+  doPayment,
   getPaymentSummary,
   retryPayment,
   waitForPaymentAndTransactionsToComplete,
 } from '@121-service/test/helpers/program.helper';
 import { deleteProgramFspConfigurationProperty } from '@121-service/test/helpers/program-fsp-configuration.helper';
 import {
+  seedIncludedRegistrations,
   seedPaidRegistrations,
   updateRegistration,
 } from '@121-service/test/helpers/registration.helper';
@@ -130,20 +132,49 @@ describe('Do payment retry', () => {
   it('should retry all failed transactions if no filter is used', async () => {
     // Arrange
     const transferValue = 230;
-    const paymentId = await seedPaidRegistrations({
-      registrations: [
-        registrationSuccess,
-        registrationError1,
-        registrationWaiting,
-      ],
+    const registrations = [
+      registrationSuccess,
+      registrationError1,
+      registrationWaiting,
+    ];
+    await seedIncludedRegistrations(registrations, programId, accessToken);
+    const doPaymentResponse = await doPayment({
       programId,
       transferValue,
-      completeStatuses: [
-        TransactionStatusEnum.success,
-        TransactionStatusEnum.error,
-        TransactionStatusEnum.waiting,
-      ],
+      referenceIds: registrations.map(
+        (registration) => registration.referenceId,
+      ),
+      accessToken,
     });
+    const paymentId = doPaymentResponse.body.id;
+
+    // Waited for separately per expected end-status: a shared status list would let "waiting"
+    // count as complete for registrationSuccess too, while its transaction is still transitioning
+    // from waiting to success.
+    await Promise.all([
+      waitForPaymentAndTransactionsToComplete({
+        programId,
+        paymentReferenceIds: [
+          registrationSuccess.referenceId,
+          registrationError1.referenceId,
+        ],
+        paymentId,
+        accessToken,
+        maxWaitTimeMs: 30_000,
+        completeStatuses: [
+          TransactionStatusEnum.success,
+          TransactionStatusEnum.error,
+        ],
+      }),
+      waitForPaymentAndTransactionsToComplete({
+        programId,
+        paymentReferenceIds: [registrationWaiting.referenceId],
+        paymentId,
+        accessToken,
+        maxWaitTimeMs: 30_000,
+        completeStatuses: [TransactionStatusEnum.waiting],
+      }),
+    ]);
 
     // Act
     await updateRegistration(


### PR DESCRIPTION
[AB#44497](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44497) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes

Waiting for payments to complete was not working properly because transaction were considered "complete" while merely in a transient "waiting" state rather than its final "success" state. 

The test now waits for each registration group against its own expected end-status (success/error vs. waiting) concurrently via Promise.all, without changing any shared test-helper signatures

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
