### PR TITLE
Fix flaky replace card on site

### DIFF
--- a/services/121-service/src/fsp-integrations/account-management/intersolve-visa/services/intersolve-visa-account-management.service.ts
+++ b/services/121-service/src/fsp-integrations/account-management/intersolve-visa/services/intersolve-visa-account-management.service.ts
@@ -172,8 +172,7 @@ export class IntersolveVisaAccountManagementService {
       );
     }
 
-    await this.throwIfCardDoesNotExistOrIsAlreadyLinked(tokenCode);
-
+    // Check this before validating the new card with Intersolve, to avoid an unnecessary external call.
     const isChildWalletLinkedToRegistration =
       await this.intersolveVisaChildWalletScopedRepository.hasLinkedChildWalletForRegistrationId(
         registration.id,
@@ -184,6 +183,8 @@ export class IntersolveVisaAccountManagementService {
         HttpStatus.BAD_REQUEST,
       );
     }
+
+    await this.throwIfCardDoesNotExistOrIsAlreadyLinked(tokenCode);
 
     await this.replaceCard({
       referenceId,
@@ -459,6 +460,8 @@ export class IntersolveVisaAccountManagementService {
             HttpStatus.BAD_REQUEST,
           );
         }
+      } else {
+        throw error;
       }
     }
 


### PR DESCRIPTION
[AB#44499](https://dev.azure.com/redcrossnl/7d17f2a9-3f18-40f1-8c29-98568fbca7e4/_workitems/edit/44499) <!--- Replace this with a reference to a DevOps/backlog-issue -->

## Describe your changes
Fixed 2 tiny bugs: 

- Wrong check order: throwIfCardDoesNotExistOrIsAlreadyLinked(tokenCode) (an external HTTP call to validate the new card) ran before checking whether the registration even has an existing linked card. For the "no card to replace" scenario, this meant an unnecessary, network-dependent call had to succeed with a specific outcome before the deterministic "no cards linked" error could be thrown — any transient hiccup on that external call surfaced a different error message and failed the test. Reordered so the local DB check (hasLinkedChildWalletForRegistrationId) runs first.
- Swallowed error bug: in throwIfCardDoesNotExistOrIsAlreadyLinked, the catch block only handled IntersolveVisaApiError and silently did nothing otherwise, leaving intersolveVisaChildWallet undefined and crashing on .holderId access instead of rethrowing. Added the missing else { throw error; }.

## Checklist before requesting a code review

- [x] I have performed a self-review of my code
- [x] I have addressed all Copilot comments
- [x] I have asked the design team to review these changes, or: The changes do not touch the UI/UX
- [x] I have added tests for my changes, or: Adding tests is unnecessary/irrelevant
- [x] I have made sure that all automated checks pass before requesting a review
- [x] I have updated all [documentation](https://github.com/rodekruis/dev-internal-documentation/blob/main/121/documentation.md) where necessary
- [x] I have checked [the list of integrations](https://github.com/global-121/121-platform/wiki/Integrations-with-external-systems#api-endpoints-used-by-external-systems) with the 121 API for [changed endpoints](https://github.com/global-121/121-platform/blob/main/services/121-service/README.md#api)
- [x] I do not need any deviation from [our PR guidelines](https://github.com/global-121/121-platform/blob/main/docs/CONTRIBUTING.md#pull-request-guidelines)

## Portal preview-deployment

<!--- Do not remove this block. It will be replaced automatically by a GitHub action if a deployment is made -->

<!-- start deployment url -->

This PR does not have any preview deployments yet.

<!-- end deployment url -->
